### PR TITLE
store last selected language in local storage in editor

### DIFF
--- a/packages/admin-app/src/hooks.js
+++ b/packages/admin-app/src/hooks.js
@@ -79,3 +79,42 @@ export function useEventListener(eventName, handler, element = window) {
         }, [eventName, element] // Re-run if eventName or element changes
     );
 }
+
+export function useLocalStorage(key, initialValue) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = React.useState(() => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue];
+}

--- a/packages/editor-app/src/course-editor.jsx
+++ b/packages/editor-app/src/course-editor.jsx
@@ -5,6 +5,7 @@ import {Flag} from './react/flag'
 import {useUsername, LoginDialog} from './login'
 import {getCourses, getCourse, getImportList, setImport, setStatus, setApproval} from "./api_calls.mjs";
 import "./course-editor.css"
+import { useLocalStorage } from '../../admin-app/src/hooks';
 
 
 function CourseList(props) {
@@ -253,7 +254,16 @@ export function EditorOverview() {
 
     const courses = useDataFetcher(getCourses);
 
-    const [course_id, setCourseID] = React.useState(parseInt(urlParams.get("course")) || undefined);
+    const [courseIdSelected, setCourseIdSelected] = useLocalStorage("course_id_selected", urlParams.get("course"));
+
+    const [course_id, setCourseID] = React.useState(parseInt(courseIdSelected) || undefined);
+    
+    React.useEffect(() => {
+      if(!urlParams.get("course")) {
+        history.pushState({course: courseIdSelected}, "Language"+courseIdSelected, `?course=${courseIdSelected}`);
+      }
+    }, [courseIdSelected])
+
     const [course, ] = useDataFetcher2(getCourse, [course_id]);
 
     const [showImport, do_setShowImport] = React.useState(false);
@@ -267,6 +277,7 @@ export function EditorOverview() {
 
         history.pushState({course: course_new}, "Language"+course_new, `?course=${course_new}`);
         setCourseID(course_new);
+        setCourseIdSelected(course_new);
     }
 
     useEventListener("popstate", (event) => {


### PR DESCRIPTION
Implemented new feature as ptoro suggested me but used local storage instead of cookie, we can use cookies though

Ptoro suggestion: 
Users usually only use the editor for a single language. To reduce friction, it'd be great to save the last-opened editor language in the user's cookies and open that by default when they log into the editor. This would help on desktop but even more so on mobile. 
