### PR TITLE
Remove overflow in admin dropdown

### DIFF
--- a/next/next-all/components/layout/dropdown.module.css
+++ b/next/next-all/components/layout/dropdown.module.css
@@ -1,6 +1,7 @@
 
 .dropdown {
     position: relative;
+    right: calc(5vw);
 }
 
 .dropdown:hover > :last-child, .dropdown:hover .diamond_wrap {
@@ -20,7 +21,6 @@
     font-weight: bold;
     margin-top: 7px;
     text-transform: none;
-    overflow-y: scroll;
 }
 
 .dropdown > :last-child > {


### PR DESCRIPTION
This pull request addresses the issue **#198** of overflow in the admin dropdown. 

**Changes Made:**
Removed the overflow property in the admin dropdown.

**Testing:**
I have thoroughly tested the modified dropdown to ensure responsiveness in Microsoft Edge and Firefox. 
The dropdown renders correctly and adapts to different screen sizes without any overflow issues,
I used the calc() CSS method to get a little unit of the viewport width, so it matches all screens.

**Firefox screenshot:**
[![](https://i.imgur.com/fqJEwys.png)]()


_Thank you!_