### PR TITLE
Fix initialState useDarkLight in loggedinbutton.jsx

### DIFF
--- a/src/components/login/loggedinbutton.jsx
+++ b/src/components/login/loggedinbutton.jsx
@@ -10,7 +10,7 @@ import { useSelectedLayoutSegments } from "next/navigation";
 
 function useDarkLight() {
   const [activeTheme, setActiveTheme] = useState(
-    document?.body?.dataset?.theme? document.body.dataset.theme: "light",,
+    document?.body?.dataset?.theme || "light",
   );
   const inactiveTheme = activeTheme === "light" ? "dark" : "light";
   //...

--- a/src/components/login/loggedinbutton.jsx
+++ b/src/components/login/loggedinbutton.jsx
@@ -10,7 +10,7 @@ import { useSelectedLayoutSegments } from "next/navigation";
 
 function useDarkLight() {
   const [activeTheme, setActiveTheme] = useState(
-    typeof document !== "undefined" ? document.body.dataset.theme : "light",
+    document?.body?.dataset?.theme? document.body.dataset.theme: "light",,
   );
   const inactiveTheme = activeTheme === "light" ? "dark" : "light";
   //...


### PR DESCRIPTION
Resolved the issue where the light mode button was incorrectly displayed upon hovering over the avatar in light mode. Adjusted the code to now show the dark mode button as expected when hovering over the avatar. This commit addresses the problem reported in [issue #245](https://github.com/rgerum/unofficial-duolingo-stories/issues/245).