### PR TITLE
Fixing broken links in publishing.mdx

### DIFF
--- a/public/docs/story-publishing/publishing.mdx
+++ b/public/docs/story-publishing/publishing.mdx
@@ -27,7 +27,7 @@ When you approve a story be sure to check the content carefully.
 - Do the sentences have proper punctuations? E.g. end with a period `.`
 - Do all words (except names) have translation hints?
 - Does the story have audio? (Only if the language has audio available)
-- If the course does not have audio: Are all ARRANGE exercises converted to POINT_TO_PHRASE and SELECT_PHRASE to CONTINUATION? (see [Publish without Audio](docs/story-publishing/without_tts))
+- If the course does not have audio: Are all ARRANGE exercises converted to POINT_TO_PHRASE and SELECT_PHRASE to CONTINUATION? (see [Publish without Audio](https://duostories.org/docs/story-publishing/without_tts))
 
 <Info>This is not a "Like" as you would give it on social media but a signature
       that you certify that the story is ready to be published.</Info>
@@ -40,6 +40,6 @@ Go to the [`#review-request`](https://discord.com/channels/726701782075572277/11
 Please title your post with the names of the languages, so folks can find languages they are familiar with! It is also helpful if you include a link to your course in the Editor. You are welcome to collaborate on review and editing in your forum post here, if you don't have a language-specific contrib channel.
 
 ### Publish a "Intro/Welcome" story
-As welcome stories (see [Intro and welcome stories](docs/story-creation/import#intro-and-welcome-stories)) are not part
+As welcome stories (see [Intro and welcome stories](https://duostories.org/docs/story-creation/import#intro-and-welcome-stories)) are not part
 of a complete set, they need to be approved by a Moderator. Please contact a Moderator on Discord once your
 "Intro/Welcome" story has at least two approvals 👍.


### PR DESCRIPTION
I'm submitting this as a pull request instead of just committing it because (1) this is just a stop-gap fix, and (2) I think the issue probably impacts more pages. 

The "internal" links are being built incorrectly. Instead of just `domain/` being added, `domain/docs/pagename/` is being added. 

Ex: `https://duostories.org/docs/story-publishing/docs/story-creation/import#intro-and-welcome-stories`
which should be: `https://duostories.org/docs/story-creation/import#intro-and-welcome-stories`

`https://duostories.org/docs/story-publishing/docs/story-publishing/without_tts`
which should be: `https://duostories.org/docs/story-publishing/without_tts`

I can't fix that from within the text of the page, so I've changed these 2 to "full links" instead. However, if the underlying issue can be fixed, then my change is unnecessary, and you can close it!