### PR TITLE
Simple fix for broken search/null language names

### DIFF
--- a/src/app/admin/courses/set/route.js
+++ b/src/app/admin/courses/set/route.js
@@ -34,14 +34,11 @@ async function set_course(data) {
   }
   data["public"] =
     data["public"] == 1 || data["public"] === "true" ? "true" : "false";
-  data["short"] = (
-    await sql`SELECT CONCAT(l2.short, '-', l.short) as short
-FROM language l, language l2
-WHERE l.id = ${data["from_language"]}
-      AND l2.id = ${data["learning_language"]};`
-  )[0].short;
-  data["from_language_name"] = (await sql`SELECT name FROM language WHERE id = ${data["from_language"]};`)[0].name;
-  data["learning_language_name"] = (await sql`SELECT name FROM language WHERE id = ${data["learning_language"]};`)[0].name;
+  const from_language = (await sql`SELECT name, short FROM language WHERE id = ${data["from_language"]};`)[0];
+  const learning_language = (await sql`SELECT name, short FROM language WHERE id = ${data["learning_language"]};`)[0];
+  data["short"] = `${learning_language.short}-${from_language.short}`;
+  data["from_language_name"] = from_language.name;
+  data["learning_language_name"] = learning_language.name;
   if (data.id === undefined) {
     id = (await sql`INSERT INTO course ${sql(data)} RETURNING id`)[0].id;
   } else {

--- a/src/app/admin/courses/set/route.js
+++ b/src/app/admin/courses/set/route.js
@@ -40,13 +40,16 @@ FROM language l, language l2
 WHERE l.id = ${data["from_language"]}
       AND l2.id = ${data["learning_language"]};`
   )[0].short;
-
+  data["from_language_name"] = (await sql`SELECT name FROM language WHERE id = ${data["from_language"]};`)[0].name;
+  data["learning_language_name"] = (await sql`SELECT name FROM language WHERE id = ${data["learning_language"]};`)[0].name;
   if (data.id === undefined) {
     id = (await sql`INSERT INTO course ${sql(data)} RETURNING id`)[0].id;
   } else {
     await sql`UPDATE course SET ${sql(data, [
       "learning_language",
+      "learning_language_name",
       "from_language",
+      "from_language_name",
       "public",
       "name",
       "official",


### PR DESCRIPTION
It looks like the language names weren't getting set when creating the course object in the database.

I don't know if there's a more efficient way to do this, but this is at least *a* solution.