### PR TITLE
Allow selection of DL's flags by using flag index

### DIFF
--- a/src/components/layout/flag.jsx
+++ b/src/components/layout/flag.jsx
@@ -62,7 +62,8 @@ export default function Flag(props) {
     if (order[i] === (props.iso || "world")) flag = i;
   }
   if (flag === 0 && !props.flag_file && props.iso !== "en") {
-    flag = 37; // "world"
+    // Check if there's a valid flag index, fall back to "world" flag if not
+    flag = (props.flag > 0 && props.flag < 48) ? props.flag : 37; // "world"
   }
 
   let style = {


### PR DESCRIPTION
(I just realized i branched off of `master` instead of `dev`, let me know if you'd like me to branch off of `dev` instead.)

## Description

This was mainly for the Afrikaans course, but this could be useful for other courses as well for countries with multiple official languages with existing flags in Duolingo's [flag collection](https://d35aaqx5ub95lt.cloudfront.net/vendor/87938207afff1598611ba626a8c4827c.svg).

This lets you use the flag's index to display that flag. In Afrikaans's case, Duolingo has a course for Zulu, which has the South African flag, so we can re-use the flag by typing its index in the flag value.

## Potential Issues

It looks like this doesn't affect any existing flags. Many of the flags have negative values, i'm not sure what those are for, but i made sure to filter out flag values other than those between 1 and 47 inclusive.

## Screenshots
![image](https://github.com/user-attachments/assets/aa7b68dd-95f5-4b7e-b063-ef596dd776d6)
![image](https://github.com/user-attachments/assets/b8a3361a-80bd-47a1-b777-575da1989295)
