### PR TITLE
Allow searching for users with spaces in their names

### DIFF
--- a/src/app/admin/users/[user_id]/page.jsx
+++ b/src/app/admin/users/[user_id]/page.jsx
@@ -7,7 +7,7 @@ async function user_properties(id) {
     value.length !== 0 && [...value].every((c) => c >= "0" && c <= "9");
   if (isNumeric(id))
     return (await sql`SELECT * FROM "users" WHERE id = ${id} LIMIT 1;`)[0];
-  else return (await sql`SELECT * FROM "users" WHERE name = ${id} LIMIT 1;`)[0];
+  else return (await sql`SELECT * FROM "users" WHERE REPLACE(name, ' ', '') = ${id.replace("%20", "")} LIMIT 1;`)[0];
 }
 
 export default async function Page({ params }) {


### PR DESCRIPTION
## Issue

Currently, we are unable to search for users with spaces in their names (e.g. "user name") in the admin user search page.

## Solution

I removed the spaces when making the query. I was then able to find users with spaces in their names in my local database.