### PR TITLE
Accept arbitrary length TLDs in email validation regex

### DIFF
--- a/src/app/(stories)/auth/register/register.jsx
+++ b/src/app/(stories)/auth/register/register.jsx
@@ -55,7 +55,7 @@ export default function Register() {
   const [emailInput, emailInputSetValue] = useInput("");
 
   async function register_button() {
-    const emailValidation = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+    const emailValidation = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w+)+$/;
     if (!emailValidation.test(emailInput)) {
       let msg = "Not a valid email, please try again.";
       setError(msg);

--- a/src/app/(stories)/auth/reset_pw/reset_pw.jsx
+++ b/src/app/(stories)/auth/reset_pw/reset_pw.jsx
@@ -52,7 +52,7 @@ export default function ResetPassword() {
   const [emailInput, emailInputSetValue] = useInput("");
 
   async function register_button() {
-    const emailValidation = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+    const emailValidation = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w+)+$/;
     if (!emailValidation.test(emailInput)) {
       let msg = "Not a valid email, please try again.";
       setError(msg);


### PR DESCRIPTION
TLDs are not necessarily 2-3 characters long. I personally failed to sign up because my own email address (other@ingrids.email) was flagged as invalid. Here one can find many examples that are longer:
https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains

Although there are currently no 1 character TLDs, the spec doesn't forbid them, so I don't see a reason why this regex should, as there may be ones accepted in the future.