### PR TITLE
Update schema and lookup table handling

### DIFF
--- a/TABLE_MIGRATION_PLAN.md
+++ b/TABLE_MIGRATION_PLAN.md
@@ -10,20 +10,16 @@ Migrate application data from Postgres to Convex with a low-risk transition peri
 ## Current Status (as of 2026-02-09)
 - Better Auth data exists in Convex (`user`, `account`, `session`, etc.).
 - Runtime Postgres auth reads were removed from profile and editor paths.
+- Legacy auth tables (`users`, `accounts`, `sessions`, `verification_token`) are out of migration scope.
 - Remaining migration focus is app/domain tables in `database/schema.sql`.
 
 ## Postgres Table Dependency Graph
+Note: `users` dependencies below refer to author/actor linkage semantics. The legacy `users` table itself is not in migration scope.
 
 ### Roots (no foreign-key dependencies)
 - `image`
 - `language`
 - `avatar`
-- `users` (legacy/auth legacy)
-- `verification_token`
-
-### Depends on `users`
-- `accounts`
-- `sessions`
 
 ### Depends on `language`
 - `speaker`

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as authFunctions from "../authFunctions.js";
 import type * as authMigration from "../authMigration.js";
 import type * as http from "../http.js";
 import type * as lib_phpbb from "../lib/phpbb.js";
+import type * as lookupTables from "../lookupTables.js";
 import type * as roles from "../roles.js";
 
 import type {
@@ -27,6 +28,7 @@ declare const fullApi: ApiFromModules<{
   authMigration: typeof authMigration;
   http: typeof http;
   "lib/phpbb": typeof lib_phpbb;
+  lookupTables: typeof lookupTables;
   roles: typeof roles;
 }>;
 

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -8,29 +8,29 @@
  * @module
  */
 
-import { AnyDataModel } from "convex/server";
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
 import type { GenericId } from "convex/values";
-
-/**
- * No `schema.ts` file found!
- *
- * This generated code has permissive types like `Doc = any` because
- * Convex doesn't know your schema. If you'd like more type safety, see
- * https://docs.convex.dev/using/schemas for instructions on how to add a
- * schema file.
- *
- * After you change a schema, rerun codegen with `npx convex dev`.
- */
+import schema from "../schema.js";
 
 /**
  * The names of all of your Convex tables.
  */
-export type TableNames = string;
+export type TableNames = TableNamesInDataModel<DataModel>;
 
 /**
  * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
-export type Doc = any;
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
 
 /**
  * An identifier for a document in Convex.
@@ -42,8 +42,10 @@ export type Doc = any;
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
-export type Id<TableName extends TableNames = TableNames> =
+export type Id<TableName extends TableNames | SystemTableNames> =
   GenericId<TableName>;
 
 /**
@@ -55,4 +57,4 @@ export type Id<TableName extends TableNames = TableNames> =
  * This type is used to parameterize methods like `queryGeneric` and
  * `mutationGeneric` to make them type-safe.
  */
-export type DataModel = AnyDataModel;
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -3,7 +3,8 @@ import { query } from "./_generated/server";
 import { v } from "convex/values";
 import { components } from "./_generated/api";
 
-export const { getAuthUser } = authComponent.clientApi();
+const authClientApi = authComponent.clientApi();
+export const getAuthUser = authClientApi.getAuthUser;
 
 async function requireContributorOrAdmin(ctx: any) {
   const identity = (await ctx.auth.getUserIdentity()) as

--- a/convex/authMigration.ts
+++ b/convex/authMigration.ts
@@ -9,11 +9,13 @@ export const listLegacyUsersForRoleSync = query({
     cursor: v.optional(v.string()),
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
-    return await ctx.db.query("users").paginate({
-      cursor: args.cursor ?? null,
-      numItems: args.limit ?? PAGE_SIZE,
-    });
+  handler: async () => {
+    // Legacy users table has been removed from app schema.
+    return {
+      page: [],
+      isDone: true,
+      continueCursor: null,
+    };
   },
 });
 

--- a/convex/betterAuth/auth.ts
+++ b/convex/betterAuth/auth.ts
@@ -6,7 +6,6 @@ import { betterAuth } from "better-auth";
 import { admin, username } from "better-auth/plugins";
 import { defaultRoles, userAc } from "better-auth/plugins/admin/access";
 import { components, internal } from "../_generated/api";
-import type { DataModel } from "../_generated/dataModel";
 import authConfig from "../auth.config";
 import { phpbbCheckHash, phpbbHash } from "../lib/phpbb";
 import schema from "./schema";
@@ -75,10 +74,9 @@ const sendEmail = async ({
 };
 
 // Better Auth Component
-export const authComponent: ReturnType<typeof createClient> = createClient<
-  DataModel,
-  typeof schema
->(components.betterAuth, {
+export const authComponent: ReturnType<typeof createClient> = createClient(
+  components.betterAuth,
+  {
   local: { schema },
   verbose: false,
   authFunctions: {
@@ -92,7 +90,7 @@ export const authComponent: ReturnType<typeof createClient> = createClient<
 });
 
 // Better Auth Options
-export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
+export const createAuthOptions = (ctx: GenericCtx<any>) => {
   return {
     appName: "Duostories",
     baseURL: process.env.SITE_URL,
@@ -149,9 +147,9 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
 };
 
 // For `@better-auth/cli`
-export const options = createAuthOptions({} as GenericCtx<DataModel>);
+export const options = createAuthOptions({} as GenericCtx<any>);
 
 // Better Auth Instance
-export const createAuth = (ctx: GenericCtx<DataModel>) => {
+export const createAuth = (ctx: GenericCtx<any>) => {
   return betterAuth(createAuthOptions(ctx));
 };

--- a/convex/betterAuth/auth.ts
+++ b/convex/betterAuth/auth.ts
@@ -2,6 +2,7 @@ import { createClient } from "@convex-dev/better-auth";
 import { convex } from "@convex-dev/better-auth/plugins";
 import type { GenericCtx } from "@convex-dev/better-auth/utils";
 import type { BetterAuthOptions } from "better-auth";
+import type { DataModel } from "./_generated/dataModel";
 import { betterAuth } from "better-auth";
 import { admin, username } from "better-auth/plugins";
 import { defaultRoles, userAc } from "better-auth/plugins/admin/access";
@@ -9,6 +10,8 @@ import { components, internal } from "../_generated/api";
 import authConfig from "../auth.config";
 import { phpbbCheckHash, phpbbHash } from "../lib/phpbb";
 import schema from "./schema";
+
+const typedCreateClient = createClient<DataModel, typeof schema>;
 
 const getEnv = (...keys: string[]) =>
   keys.map((key) => process.env[key]).find((value) => value);
@@ -74,7 +77,7 @@ const sendEmail = async ({
 };
 
 // Better Auth Component
-export const authComponent: ReturnType<typeof createClient> = createClient(
+export const authComponent: ReturnType<typeof typedCreateClient> = typedCreateClient(
   components.betterAuth,
   {
   local: { schema },
@@ -90,7 +93,7 @@ export const authComponent: ReturnType<typeof createClient> = createClient(
 });
 
 // Better Auth Options
-export const createAuthOptions = (ctx: GenericCtx<any>) => {
+export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
   return {
     appName: "Duostories",
     baseURL: process.env.SITE_URL,
@@ -147,9 +150,9 @@ export const createAuthOptions = (ctx: GenericCtx<any>) => {
 };
 
 // For `@better-auth/cli`
-export const options = createAuthOptions({} as GenericCtx<any>);
+export const options = createAuthOptions({} as GenericCtx<DataModel>);
 
 // Better Auth Instance
-export const createAuth = (ctx: GenericCtx<any>) => {
+export const createAuth = (ctx: GenericCtx<DataModel>) => {
   return betterAuth(createAuthOptions(ctx));
 };

--- a/convex/betterAuth/schema.ts
+++ b/convex/betterAuth/schema.ts
@@ -29,7 +29,6 @@ export const tables = {
   })
     .index("email_name", ["email", "name"])
     .index("name", ["name"])
-    .index("role", ["role"])
     .index("userId", ["userId"])
     .index("username", ["username"]),
   session: defineTable({
@@ -62,7 +61,6 @@ export const tables = {
   })
     .index("accountId", ["accountId"])
     .index("accountId_providerId", ["accountId", "providerId"])
-    .index("accountId_providerId_userId", ["accountId", "providerId", "userId"])
     .index("providerId_userId", ["providerId", "userId"])
     .index("userId", ["userId"]),
   verification: defineTable({

--- a/convex/convex_rules.md
+++ b/convex/convex_rules.md
@@ -1,0 +1,699 @@
+# Convex guidelines
+## Function guidelines
+### New function syntax
+- ALWAYS use the new function syntax for Convex functions. For example:
+```typescript
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+export const f = query({
+    args: {},
+    returns: v.null(),
+    handler: async (ctx, args) => {
+    // Function body
+    },
+});
+```
+
+### Http endpoint syntax
+- HTTP endpoints are defined in `convex/http.ts` and require an `httpAction` decorator. For example:
+```typescript
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+const http = httpRouter();
+http.route({
+    path: "/echo",
+    method: "POST",
+    handler: httpAction(async (ctx, req) => {
+    const body = await req.bytes();
+    return new Response(body, { status: 200 });
+    }),
+});
+```
+- HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`.
+
+### Validators
+- Below is an example of an array validator:
+```typescript
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export default mutation({
+args: {
+    simpleArray: v.array(v.union(v.string(), v.number())),
+},
+handler: async (ctx, args) => {
+    //...
+},
+});
+```
+- Below is an example of a schema with validators that codify a discriminated union type:
+```typescript
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+    results: defineTable(
+        v.union(
+            v.object({
+                kind: v.literal("error"),
+                errorMessage: v.string(),
+            }),
+            v.object({
+                kind: v.literal("success"),
+                value: v.number(),
+            }),
+        ),
+    )
+});
+```
+- Always use the `v.null()` validator when returning a null value. Below is an example query that returns a null value:
+```typescript
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const exampleQuery = query({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx, args) => {
+      console.log("This query returns a null value");
+      return null;
+  },
+});
+```
+- Here are the valid Convex types along with their respective validators:
+Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
+| ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Id          | string      | `doc._id`              | `v.id(tableName)`                              |                                                                                                                                                                                                       |
+| Null        | null        | `null`                 | `v.null()`                                     | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead.                             |
+| Int64       | bigint      | `3n`                   | `v.int64()`                                    | Int64s only support BigInts between -2^63 and 2^63-1. Convex supports `bigint`s in most modern browsers.                                                                                              |
+| Float64     | number      | `3.1`                  | `v.number()`                                   | Convex supports all IEEE-754 double-precision floating point numbers (such as NaNs). Inf and NaN are JSON serialized as strings.                                                                      |
+| Boolean     | boolean     | `true`                 | `v.boolean()`                                  |
+| String      | string      | `"abc"`                | `v.string()`                                   | Strings are stored as UTF-8 and must be valid Unicode sequences. Strings must be smaller than the 1MB total size limit when encoded as UTF-8.                                                         |
+| Bytes       | ArrayBuffer | `new ArrayBuffer(8)`   | `v.bytes()`                                    | Convex supports first class bytestrings, passed in as `ArrayBuffer`s. Bytestrings must be smaller than the 1MB total size limit for Convex types.                                                     |
+| Array       | Array       | `[1, 3.2, "abc"]`      | `v.array(values)`                              | Arrays can have at most 8192 values.                                                                                                                                                                  |
+| Object      | Object      | `{a: "abc"}`           | `v.object({property: value})`                  | Convex only supports "plain old JavaScript objects" (objects that do not have a custom prototype). Objects can have at most 1024 entries. Field names must be nonempty and not start with "$" or "_". |
+| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "_".                                                               |
+
+### Function registration
+- Use `internalQuery`, `internalMutation`, and `internalAction` to register internal functions. These functions are private and aren't part of an app's API. They can only be called by other Convex functions. These functions are always imported from `./_generated/server`.
+- Use `query`, `mutation`, and `action` to register public functions. These functions are part of the public API and are exposed to the public Internet. Do NOT use `query`, `mutation`, or `action` to register sensitive internal functions that should be kept private.
+- You CANNOT register a function through the `api` or `internal` objects.
+- ALWAYS include argument and return validators for all Convex functions. This includes all of `query`, `internalQuery`, `mutation`, `internalMutation`, `action`, and `internalAction`. If a function doesn't return anything, include `returns: v.null()` as its output validator.
+- If the JavaScript implementation of a Convex function doesn't have a return value, it implicitly returns `null`.
+
+### Function calling
+- Use `ctx.runQuery` to call a query from a query, mutation, or action.
+- Use `ctx.runMutation` to call a mutation from a mutation or action.
+- Use `ctx.runAction` to call an action from an action.
+- ONLY call an action from another action if you need to cross runtimes (e.g. from V8 to Node). Otherwise, pull out the shared code into a helper async function and call that directly instead.
+- Try to use as few calls from actions to queries and mutations as possible. Queries and mutations are transactions, so splitting logic up into multiple calls introduces the risk of race conditions.
+- All of these calls take in a `FunctionReference`. Do NOT try to pass the callee function directly into one of these calls.
+- When using `ctx.runQuery`, `ctx.runMutation`, or `ctx.runAction` to call a function in the same file, specify a type annotation on the return value to work around TypeScript circularity limitations. For example,
+```
+export const f = query({
+  args: { name: v.string() },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    return "Hello " + args.name;
+  },
+});
+
+export const g = query({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const result: string = await ctx.runQuery(api.example.f, { name: "Bob" });
+    return null;
+  },
+});
+```
+
+### Function references
+- Function references are pointers to registered Convex functions.
+- Use the `api` object defined by the framework in `convex/_generated/api.ts` to call public functions registered with `query`, `mutation`, or `action`.
+- Use the `internal` object defined by the framework in `convex/_generated/api.ts` to call internal (or private) functions registered with `internalQuery`, `internalMutation`, or `internalAction`.
+- Convex uses file-based routing, so a public function defined in `convex/example.ts` named `f` has a function reference of `api.example.f`.
+- A private function defined in `convex/example.ts` named `g` has a function reference of `internal.example.g`.
+- Functions can also registered within directories nested within the `convex/` folder. For example, a public function `h` defined in `convex/messages/access.ts` has a function reference of `api.messages.access.h`.
+
+### Api design
+- Convex uses file-based routing, so thoughtfully organize files with public query, mutation, or action functions within the `convex/` directory.
+- Use `query`, `mutation`, and `action` to define public functions.
+- Use `internalQuery`, `internalMutation`, and `internalAction` to define private, internal functions.
+
+### Pagination
+- Paginated queries are queries that return a list of results in incremental pages.
+- You can define pagination using the following syntax:
+
+```ts
+import { v } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { paginationOptsValidator } from "convex/server";
+export const listWithExtraArg = query({
+    args: { paginationOpts: paginationOptsValidator, author: v.string() },
+    handler: async (ctx, args) => {
+        return await ctx.db
+        .query("messages")
+        .withIndex("by_author", (q) => q.eq("author", args.author))
+        .order("desc")
+        .paginate(args.paginationOpts);
+    },
+});
+```
+Note: `paginationOpts` is an object with the following properties:
+- `numItems`: the maximum number of documents to return (the validator is `v.number()`)
+- `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
+- A query that ends in `.paginate()` returns an object that has the following properties:
+- page (contains an array of documents that you fetches)
+- isDone (a boolean that represents whether or not this is the last page of documents)
+- continueCursor (a string that represents the cursor to use to fetch the next page of documents)
+
+
+## Validator guidelines
+- `v.bigint()` is deprecated for representing signed 64-bit integers. Use `v.int64()` instead.
+- Use `v.record()` for defining a record type. `v.map()` and `v.set()` are not supported.
+
+## Schema guidelines
+- Always define your schema in `convex/schema.ts`.
+- Always import the schema definition functions from `convex/server`.
+- System fields are automatically added to all documents and are prefixed with an underscore. The two system fields that are automatically added to all documents are `_creationTime` which has the validator `v.number()` and `_id` which has the validator `v.id(tableName)`.
+- Always include all index fields in the index name. For example, if an index is defined as `["field1", "field2"]`, the index name should be "by_field1_and_field2".
+- Index fields must be queried in the same order they are defined. If you want to be able to query by "field1" then "field2" and by "field2" then "field1", you must create separate indexes.
+
+## Typescript guidelines
+- You can use the helper typescript type `Id` imported from './_generated/dataModel' to get the type of the id for a given table. For example if there is a table called 'users' you can use `Id<'users'>` to get the type of the id for that table.
+- If you need to define a `Record` make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`. Below is an example of using `Record` with an `Id` type in a query:
+```ts
+import { query } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
+
+export const exampleQuery = query({
+    args: { userIds: v.array(v.id("users")) },
+    returns: v.record(v.id("users"), v.string()),
+    handler: async (ctx, args) => {
+        const idToUsername: Record<Id<"users">, string> = {};
+        for (const userId of args.userIds) {
+            const user = await ctx.db.get("users", userId);
+            if (user) {
+                idToUsername[user._id] = user.username;
+            }
+        }
+
+        return idToUsername;
+    },
+});
+```
+- Be strict with types, particularly around id's of documents. For example, if a function takes in an id for a document in the 'users' table, take in `Id<'users'>` rather than `string`.
+- Always use `as const` for string literals in discriminated union types.
+- When using the `Array` type, make sure to always define your arrays as `const array: Array<T> = [...];`
+- When using the `Record` type, make sure to always define your records as `const record: Record<KeyType, ValueType> = {...};`
+- Always add `@types/node` to your `package.json` when using any Node.js built-in modules.
+
+## Full text search guidelines
+- A query for "10 messages in channel '#general' that best match the query 'hello hi' in their body" would look like:
+
+const messages = await ctx.db
+  .query("messages")
+  .withSearchIndex("search_body", (q) =>
+    q.search("body", "hello hi").eq("channel", "#general"),
+  )
+  .take(10);
+
+## Query guidelines
+- Do NOT use `filter` in queries. Instead, define an index in the schema and use `withIndex` instead.
+- Convex queries do NOT support `.delete()`. Instead, `.collect()` the results, iterate over them, and call `ctx.db.delete(row._id)` on each result.
+- Use `.unique()` to get a single document from a query. This method will throw an error if there are multiple documents that match the query.
+- When using async iteration, don't use `.collect()` or `.take(n)` on the result of a query. Instead, use the `for await (const row of query)` syntax.
+### Ordering
+- By default Convex always returns documents in ascending `_creationTime` order.
+- You can use `.order('asc')` or `.order('desc')` to pick whether a query is in ascending or descending order. If the order isn't specified, it defaults to ascending.
+- Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans.
+
+
+## Mutation guidelines
+- Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.replace('tasks', taskId, { name: 'Buy milk', completed: false })`
+- Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.patch('tasks', taskId, { completed: true })`
+
+## Action guidelines
+- Always add `"use node";` to the top of files containing actions that use Node.js built-in modules.
+- Never use `ctx.db` inside of an action. Actions don't have access to the database.
+- Below is an example of the syntax for an action:
+```ts
+import { action } from "./_generated/server";
+
+export const exampleAction = action({
+    args: {},
+    returns: v.null(),
+    handler: async (ctx, args) => {
+        console.log("This action does not return anything");
+        return null;
+    },
+});
+```
+
+## Scheduling guidelines
+### Cron guidelines
+- Only use the `crons.interval` or `crons.cron` methods to schedule cron jobs. Do NOT use the `crons.hourly`, `crons.daily`, or `crons.weekly` helpers.
+- Both cron methods take in a FunctionReference. Do NOT try to pass the function directly into one of these methods.
+- Define crons by declaring the top-level `crons` object, calling some methods on it, and then exporting it as default. For example,
+```ts
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+import { internalAction } from "./_generated/server";
+
+const empty = internalAction({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    console.log("empty");
+  },
+});
+
+const crons = cronJobs();
+
+// Run `internal.crons.empty` every two hours.
+crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
+
+export default crons;
+```
+- You can register Convex functions within `crons.ts` just like any other file.
+- If a cron calls an internal function, always import the `internal` object from '_generated/api', even if the internal function is registered in the same file.
+
+
+## File storage guidelines
+- Convex includes file storage for large files like images, videos, and PDFs.
+- The `ctx.storage.getUrl()` method returns a signed URL for a given file. It returns `null` if the file doesn't exist.
+- Do NOT use the deprecated `ctx.storage.getMetadata` call for loading a file's metadata.
+
+Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
+```
+import { query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+
+type FileMetadata = {
+    _id: Id<"_storage">;
+    _creationTime: number;
+    contentType?: string;
+    sha256: string;
+    size: number;
+}
+
+export const exampleQuery = query({
+    args: { fileId: v.id("_storage") },
+    returns: v.null(),
+    handler: async (ctx, args) => {
+        const metadata: FileMetadata | null = await ctx.db.system.get("_storage", args.fileId);
+        console.log(metadata);
+        return null;
+    },
+});
+```
+- Convex storage stores items as `Blob` objects. You must convert all items to/from a `Blob` when using Convex storage.
+
+
+# Examples:
+## Example: chat-app
+
+### Task
+```
+Create a real-time chat application backend with AI responses. The app should:
+- Allow creating users with names
+- Support multiple chat channels
+- Enable users to send messages to channels
+- Automatically generate AI responses to user messages
+- Show recent message history
+
+The backend should provide APIs for:
+1. User management (creation)
+2. Channel management (creation)
+3. Message operations (sending, listing)
+4. AI response generation using OpenAI's GPT-4
+
+Messages should be stored with their channel, author, and content. The system should maintain message order
+and limit history display to the 10 most recent messages per channel.
+
+```
+
+### Analysis
+1. Task Requirements Summary:
+- Build a real-time chat backend with AI integration
+- Support user creation
+- Enable channel-based conversations
+- Store and retrieve messages with proper ordering
+- Generate AI responses automatically
+
+2. Main Components Needed:
+- Database tables: users, channels, messages
+- Public APIs for user/channel management
+- Message handling functions
+- Internal AI response generation system
+- Context loading for AI responses
+
+3. Public API and Internal Functions Design:
+Public Mutations:
+- createUser:
+  - file path: convex/index.ts
+  - arguments: {name: v.string()}
+  - returns: v.object({userId: v.id("users")})
+  - purpose: Create a new user with a given name
+- createChannel:
+  - file path: convex/index.ts
+  - arguments: {name: v.string()}
+  - returns: v.object({channelId: v.id("channels")})
+  - purpose: Create a new channel with a given name
+- sendMessage:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels"), authorId: v.id("users"), content: v.string()}
+  - returns: v.null()
+  - purpose: Send a message to a channel and schedule a response from the AI
+
+Public Queries:
+- listMessages:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels")}
+  - returns: v.array(v.object({
+    _id: v.id("messages"),
+    _creationTime: v.number(),
+    channelId: v.id("channels"),
+    authorId: v.optional(v.id("users")),
+    content: v.string(),
+    }))
+  - purpose: List the 10 most recent messages from a channel in descending creation order
+
+Internal Functions:
+- generateResponse:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels")}
+  - returns: v.null()
+  - purpose: Generate a response from the AI for a given channel
+- loadContext:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels")}
+  - returns: v.array(v.object({
+    _id: v.id("messages"),
+    _creationTime: v.number(),
+    channelId: v.id("channels"),
+    authorId: v.optional(v.id("users")),
+    content: v.string(),
+  }))
+- writeAgentResponse:
+  - file path: convex/index.ts
+  - arguments: {channelId: v.id("channels"), content: v.string()}
+  - returns: v.null()
+  - purpose: Write an AI response to a given channel
+
+4. Schema Design:
+- users
+  - validator: { name: v.string() }
+  - indexes: <none>
+- channels
+  - validator: { name: v.string() }
+  - indexes: <none>
+- messages
+  - validator: { channelId: v.id("channels"), authorId: v.optional(v.id("users")), content: v.string() }
+  - indexes
+    - by_channel: ["channelId"]
+
+5. Background Processing:
+- AI response generation runs asynchronously after each user message
+- Uses OpenAI's GPT-4 to generate contextual responses
+- Maintains conversation context using recent message history
+
+
+### Implementation
+
+#### package.json
+```typescript
+{
+  "name": "chat-app",
+  "description": "This example shows how to build a chat app without authentication.",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "^1.31.2",
+    "openai": "^4.79.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3"
+  }
+}
+```
+
+#### tsconfig.json
+```typescript
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "exclude": ["convex"],
+  "include": ["**/src/**/*.tsx", "**/src/**/*.ts", "vite.config.ts"]
+}
+```
+
+#### convex/index.ts
+```typescript
+import {
+  query,
+  mutation,
+  internalQuery,
+  internalMutation,
+  internalAction,
+} from "./_generated/server";
+import { v } from "convex/values";
+import OpenAI from "openai";
+import { internal } from "./_generated/api";
+
+/**
+ * Create a user with a given name.
+ */
+export const createUser = mutation({
+  args: {
+    name: v.string(),
+  },
+  returns: v.id("users"),
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("users", { name: args.name });
+  },
+});
+
+/**
+ * Create a channel with a given name.
+ */
+export const createChannel = mutation({
+  args: {
+    name: v.string(),
+  },
+  returns: v.id("channels"),
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("channels", { name: args.name });
+  },
+});
+
+/**
+ * List the 10 most recent messages from a channel in descending creation order.
+ */
+export const listMessages = query({
+  args: {
+    channelId: v.id("channels"),
+  },
+  returns: v.array(
+    v.object({
+      _id: v.id("messages"),
+      _creationTime: v.number(),
+      channelId: v.id("channels"),
+      authorId: v.optional(v.id("users")),
+      content: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const messages = await ctx.db
+      .query("messages")
+      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+      .order("desc")
+      .take(10);
+    return messages;
+  },
+});
+
+/**
+ * Send a message to a channel and schedule a response from the AI.
+ */
+export const sendMessage = mutation({
+  args: {
+    channelId: v.id("channels"),
+    authorId: v.id("users"),
+    content: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    const user = await ctx.db.get(args.authorId);
+    if (!user) {
+      throw new Error("User not found");
+    }
+    await ctx.db.insert("messages", {
+      channelId: args.channelId,
+      authorId: args.authorId,
+      content: args.content,
+    });
+    await ctx.scheduler.runAfter(0, internal.index.generateResponse, {
+      channelId: args.channelId,
+    });
+    return null;
+  },
+});
+
+const openai = new OpenAI();
+
+export const generateResponse = internalAction({
+  args: {
+    channelId: v.id("channels"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const context = await ctx.runQuery(internal.index.loadContext, {
+      channelId: args.channelId,
+    });
+    const response = await openai.chat.completions.create({
+      model: "gpt-4o",
+      messages: context,
+    });
+    const content = response.choices[0].message.content;
+    if (!content) {
+      throw new Error("No content in response");
+    }
+    await ctx.runMutation(internal.index.writeAgentResponse, {
+      channelId: args.channelId,
+      content,
+    });
+    return null;
+  },
+});
+
+export const loadContext = internalQuery({
+  args: {
+    channelId: v.id("channels"),
+  },
+  returns: v.array(
+    v.object({
+      role: v.union(v.literal("user"), v.literal("assistant")),
+      content: v.string(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const channel = await ctx.db.get(args.channelId);
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+    const messages = await ctx.db
+      .query("messages")
+      .withIndex("by_channel", (q) => q.eq("channelId", args.channelId))
+      .order("desc")
+      .take(10);
+
+    const result = [];
+    for (const message of messages) {
+      if (message.authorId) {
+        const user = await ctx.db.get(message.authorId);
+        if (!user) {
+          throw new Error("User not found");
+        }
+        result.push({
+          role: "user" as const,
+          content: `${user.name}: ${message.content}`,
+        });
+      } else {
+        result.push({ role: "assistant" as const, content: message.content });
+      }
+    }
+    return result;
+  },
+});
+
+export const writeAgentResponse = internalMutation({
+  args: {
+    channelId: v.id("channels"),
+    content: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.insert("messages", {
+      channelId: args.channelId,
+      content: args.content,
+    });
+    return null;
+  },
+});
+```
+
+#### convex/schema.ts
+```typescript
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  channels: defineTable({
+    name: v.string(),
+  }),
+
+  users: defineTable({
+    name: v.string(),
+  }),
+
+  messages: defineTable({
+    channelId: v.id("channels"),
+    authorId: v.optional(v.id("users")),
+    content: v.string(),
+  }).index("by_channel", ["channelId"]),
+});
+```
+
+#### convex/tsconfig.json
+```typescript
+{
+  /* This TypeScript project config describes the environment that
+   * Convex functions run in and is used to typecheck them.
+   * You can modify it, but some settings required to use Convex.
+   */
+  "compilerOptions": {
+    /* These settings are not required by Convex and can be modified. */
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+
+    /* These compiler options are required by Convex */
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}
+```
+
+#### src/App.tsx
+```typescript
+export default function App() {
+  return <div>Hello World</div>;
+}
+```

--- a/convex/lookupTables.ts
+++ b/convex/lookupTables.ts
@@ -5,11 +5,11 @@ const languageValidator = {
   legacyId: v.number(),
   name: v.string(),
   short: v.string(),
-  flag: v.optional(v.union(v.null(), v.number())),
-  flag_file: v.optional(v.union(v.null(), v.string())),
-  speaker: v.optional(v.union(v.null(), v.string())),
-  default_text: v.optional(v.union(v.null(), v.string())),
-  tts_replace: v.optional(v.union(v.null(), v.string())),
+  flag: v.optional(v.number()),
+  flag_file: v.optional(v.string()),
+  speaker: v.optional(v.string()),
+  default_text: v.optional(v.string()),
+  tts_replace: v.optional(v.string()),
   public: v.boolean(),
   rtl: v.boolean(),
 };
@@ -26,7 +26,7 @@ const imageValidator = {
 const avatarValidator = {
   legacyId: v.number(),
   link: v.string(),
-  name: v.optional(v.union(v.null(), v.string())),
+  name: v.optional(v.string()),
 };
 
 export const upsertLanguage = mutation({
@@ -43,16 +43,15 @@ export const upsertLanguage = mutation({
       .query("languages")
       .withIndex("by_id_value", (q) => q.eq("legacyId", args.language.legacyId))
       .unique();
-    console.log("upsertLanguage", existing)
 
     const doc = {
       ...args.language,
       mirrorUpdatedAt: Date.now(),
-      lastOperationKey: args.operationKey ?? null,
+      lastOperationKey: args.operationKey,
     };
 
     if (existing) {
-      await ctx.db.patch(existing._id, doc);
+      await ctx.db.replace(existing._id, doc);
       return { inserted: false, docId: existing._id };
     }
 
@@ -81,16 +80,16 @@ export const upsertLanguagesBatch = mutation({
         .unique();
 
       if (existing) {
-        await ctx.db.patch(existing._id, {
+        await ctx.db.replace(existing._id, {
           ...language,
           mirrorUpdatedAt: Date.now(),
-        } );
+        });
         updated += 1;
       } else {
         await ctx.db.insert("languages", {
           ...language,
           mirrorUpdatedAt: Date.now(),
-        } );
+        });
         inserted += 1;
       }
     }
@@ -117,15 +116,15 @@ export const upsertImage = mutation({
     const doc = {
       ...args.image,
       mirrorUpdatedAt: Date.now(),
-      lastOperationKey: args.operationKey ?? null,
+      lastOperationKey: args.operationKey,
     };
 
     if (existing) {
-      await ctx.db.patch(existing._id, doc);
+      await ctx.db.replace(existing._id, doc);
       return { inserted: false, docId: existing._id };
     }
 
-    const docId = await ctx.db.insert("images", doc );
+    const docId = await ctx.db.insert("images", doc);
     return { inserted: true, docId };
   },
 });
@@ -150,16 +149,16 @@ export const upsertImagesBatch = mutation({
         .unique();
 
       if (existing) {
-        await ctx.db.patch(existing._id, {
+        await ctx.db.replace(existing._id, {
           ...image,
           mirrorUpdatedAt: Date.now(),
-        } );
+        });
         updated += 1;
       } else {
         await ctx.db.insert("images", {
           ...image,
           mirrorUpdatedAt: Date.now(),
-        } );
+        });
         inserted += 1;
       }
     }
@@ -186,11 +185,11 @@ export const upsertAvatar = mutation({
     const doc = {
       ...args.avatar,
       mirrorUpdatedAt: Date.now(),
-      lastOperationKey: args.operationKey ?? null,
+      lastOperationKey: args.operationKey,
     };
 
     if (existing) {
-      await ctx.db.patch(existing._id, doc);
+      await ctx.db.replace(existing._id, doc);
       return { inserted: false, docId: existing._id };
     }
 
@@ -219,16 +218,16 @@ export const upsertAvatarsBatch = mutation({
         .unique();
 
       if (existing) {
-        await ctx.db.patch(existing._id, {
+        await ctx.db.replace(existing._id, {
           ...avatar,
           mirrorUpdatedAt: Date.now(),
-        } );
+        });
         updated += 1;
       } else {
         await ctx.db.insert("avatars", {
           ...avatar,
           mirrorUpdatedAt: Date.now(),
-        } );
+        });
         inserted += 1;
       }
     }

--- a/convex/lookupTables.ts
+++ b/convex/lookupTables.ts
@@ -1,0 +1,238 @@
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+const languageValidator = {
+  legacyId: v.number(),
+  name: v.string(),
+  short: v.string(),
+  flag: v.optional(v.union(v.null(), v.number())),
+  flag_file: v.optional(v.union(v.null(), v.string())),
+  speaker: v.optional(v.union(v.null(), v.string())),
+  default_text: v.optional(v.union(v.null(), v.string())),
+  tts_replace: v.optional(v.union(v.null(), v.string())),
+  public: v.boolean(),
+  rtl: v.boolean(),
+};
+
+const imageValidator = {
+  legacyId: v.string(),
+  active: v.string(),
+  gilded: v.string(),
+  locked: v.string(),
+  active_lip: v.string(),
+  gilded_lip: v.string(),
+};
+
+const avatarValidator = {
+  legacyId: v.number(),
+  link: v.string(),
+  name: v.optional(v.union(v.null(), v.string())),
+};
+
+export const upsertLanguage = mutation({
+  args: {
+    language: v.object(languageValidator),
+    operationKey: v.optional(v.string()),
+  },
+  returns: v.object({
+    inserted: v.boolean(),
+    docId: v.id("languages"),
+  }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("languages")
+      .withIndex("by_id_value", (q) => q.eq("legacyId", args.language.legacyId))
+      .unique();
+    console.log("upsertLanguage", existing)
+
+    const doc = {
+      ...args.language,
+      mirrorUpdatedAt: Date.now(),
+      lastOperationKey: args.operationKey ?? null,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, doc);
+      return { inserted: false, docId: existing._id };
+    }
+
+    const docId = await ctx.db.insert("languages", doc);
+    return { inserted: true, docId };
+  },
+});
+
+export const upsertLanguagesBatch = mutation({
+  args: {
+    languages: v.array(v.object(languageValidator)),
+  },
+  returns: v.object({
+    inserted: v.number(),
+    updated: v.number(),
+    total: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    let inserted = 0;
+    let updated = 0;
+
+    for (const language of args.languages) {
+      const existing = await ctx.db
+        .query("languages")
+        .withIndex("by_id_value", (q) => q.eq("legacyId", language.legacyId))
+        .unique();
+
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          ...language,
+          mirrorUpdatedAt: Date.now(),
+        } );
+        updated += 1;
+      } else {
+        await ctx.db.insert("languages", {
+          ...language,
+          mirrorUpdatedAt: Date.now(),
+        } );
+        inserted += 1;
+      }
+    }
+
+    return { inserted, updated, total: args.languages.length };
+  },
+});
+
+export const upsertImage = mutation({
+  args: {
+    image: v.object(imageValidator),
+    operationKey: v.optional(v.string()),
+  },
+  returns: v.object({
+    inserted: v.boolean(),
+    docId: v.id("images"),
+  }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("images")
+      .withIndex("by_id_value", (q) => q.eq("legacyId", args.image.legacyId))
+      .unique();
+
+    const doc = {
+      ...args.image,
+      mirrorUpdatedAt: Date.now(),
+      lastOperationKey: args.operationKey ?? null,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, doc);
+      return { inserted: false, docId: existing._id };
+    }
+
+    const docId = await ctx.db.insert("images", doc );
+    return { inserted: true, docId };
+  },
+});
+
+export const upsertImagesBatch = mutation({
+  args: {
+    images: v.array(v.object(imageValidator)),
+  },
+  returns: v.object({
+    inserted: v.number(),
+    updated: v.number(),
+    total: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    let inserted = 0;
+    let updated = 0;
+
+    for (const image of args.images) {
+      const existing = await ctx.db
+        .query("images")
+        .withIndex("by_id_value", (q) => q.eq("legacyId", image.legacyId))
+        .unique();
+
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          ...image,
+          mirrorUpdatedAt: Date.now(),
+        } );
+        updated += 1;
+      } else {
+        await ctx.db.insert("images", {
+          ...image,
+          mirrorUpdatedAt: Date.now(),
+        } );
+        inserted += 1;
+      }
+    }
+
+    return { inserted, updated, total: args.images.length };
+  },
+});
+
+export const upsertAvatar = mutation({
+  args: {
+    avatar: v.object(avatarValidator),
+    operationKey: v.optional(v.string()),
+  },
+  returns: v.object({
+    inserted: v.boolean(),
+    docId: v.id("avatars"),
+  }),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("avatars")
+      .withIndex("by_id_value", (q) => q.eq("legacyId", args.avatar.legacyId))
+      .unique();
+
+    const doc = {
+      ...args.avatar,
+      mirrorUpdatedAt: Date.now(),
+      lastOperationKey: args.operationKey ?? null,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, doc);
+      return { inserted: false, docId: existing._id };
+    }
+
+    const docId = await ctx.db.insert("avatars", doc);
+    return { inserted: true, docId };
+  },
+});
+
+export const upsertAvatarsBatch = mutation({
+  args: {
+    avatars: v.array(v.object(avatarValidator)),
+  },
+  returns: v.object({
+    inserted: v.number(),
+    updated: v.number(),
+    total: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    let inserted = 0;
+    let updated = 0;
+
+    for (const avatar of args.avatars) {
+      const existing = await ctx.db
+        .query("avatars")
+        .withIndex("by_id_value", (q) => q.eq("legacyId", avatar.legacyId))
+        .unique();
+
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          ...avatar,
+          mirrorUpdatedAt: Date.now(),
+        } );
+        updated += 1;
+      } else {
+        await ctx.db.insert("avatars", {
+          ...avatar,
+          mirrorUpdatedAt: Date.now(),
+        } );
+        inserted += 1;
+      }
+    }
+
+    return { inserted, updated, total: args.avatars.length };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,18 +6,18 @@ export default defineSchema({
     legacyId: v.number(),
     name: v.string(),
     short: v.string(),
-    flag: v.optional(v.union(v.null(), v.number(), v.string())),
-    flag_file: v.optional(v.union(v.null(), v.string())),
-    speaker: v.optional(v.union(v.null(), v.string())),
-    default_text: v.optional(v.union(v.null(), v.string())),
-    tts_replace: v.optional(v.union(v.null(), v.string())),
+    flag: v.optional(v.union(v.number(), v.string())),
+    flag_file: v.optional(v.string()),
+    speaker: v.optional(v.string()),
+    default_text: v.optional(v.string()),
+    tts_replace: v.optional(v.string()),
     public: v.boolean(),
     rtl: v.boolean(),
     mirrorUpdatedAt: v.optional(v.number()),
-    lastOperationKey: v.optional(v.union(v.null(), v.string())),
+    lastOperationKey: v.optional(v.string()),
     // Backward compatibility for previously mirrored docs.
     mirror_updated_at: v.optional(v.number()),
-    last_operation_key: v.optional(v.union(v.null(), v.string())),
+    last_operation_key: v.optional(v.string()),
   })
     .index("by_id_value", ["legacyId"])
     .index("by_short", ["short"])
@@ -31,10 +31,10 @@ export default defineSchema({
     active_lip: v.string(),
     gilded_lip: v.string(),
     mirrorUpdatedAt: v.optional(v.number()),
-    lastOperationKey: v.optional(v.union(v.null(), v.string())),
+    lastOperationKey: v.optional(v.string()),
     // Backward compatibility for previously mirrored docs.
     mirror_updated_at: v.optional(v.number()),
-    last_operation_key: v.optional(v.union(v.null(), v.string())),
+    last_operation_key: v.optional(v.string()),
   })
     .index("by_id_value", ["legacyId"])
     .index("by_last_operation_key", ["lastOperationKey"]),
@@ -42,12 +42,12 @@ export default defineSchema({
   avatars: defineTable({
     legacyId: v.number(),
     link: v.string(),
-    name: v.optional(v.union(v.null(), v.string())),
+    name: v.optional(v.string()),
     mirrorUpdatedAt: v.optional(v.number()),
-    lastOperationKey: v.optional(v.union(v.null(), v.string())),
+    lastOperationKey: v.optional(v.string()),
     // Backward compatibility for previously mirrored docs.
     mirror_updated_at: v.optional(v.number()),
-    last_operation_key: v.optional(v.union(v.null(), v.string())),
+    last_operation_key: v.optional(v.string()),
   })
     .index("by_id_value", ["legacyId"])
     .index("by_last_operation_key", ["lastOperationKey"]),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,0 +1,54 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  languages: defineTable({
+    legacyId: v.number(),
+    name: v.string(),
+    short: v.string(),
+    flag: v.optional(v.union(v.null(), v.number(), v.string())),
+    flag_file: v.optional(v.union(v.null(), v.string())),
+    speaker: v.optional(v.union(v.null(), v.string())),
+    default_text: v.optional(v.union(v.null(), v.string())),
+    tts_replace: v.optional(v.union(v.null(), v.string())),
+    public: v.boolean(),
+    rtl: v.boolean(),
+    mirrorUpdatedAt: v.optional(v.number()),
+    lastOperationKey: v.optional(v.union(v.null(), v.string())),
+    // Backward compatibility for previously mirrored docs.
+    mirror_updated_at: v.optional(v.number()),
+    last_operation_key: v.optional(v.union(v.null(), v.string())),
+  })
+    .index("by_id_value", ["legacyId"])
+    .index("by_short", ["short"])
+    .index("by_last_operation_key", ["lastOperationKey"]),
+
+  images: defineTable({
+    legacyId: v.string(),
+    active: v.string(),
+    gilded: v.string(),
+    locked: v.string(),
+    active_lip: v.string(),
+    gilded_lip: v.string(),
+    mirrorUpdatedAt: v.optional(v.number()),
+    lastOperationKey: v.optional(v.union(v.null(), v.string())),
+    // Backward compatibility for previously mirrored docs.
+    mirror_updated_at: v.optional(v.number()),
+    last_operation_key: v.optional(v.union(v.null(), v.string())),
+  })
+    .index("by_id_value", ["legacyId"])
+    .index("by_last_operation_key", ["lastOperationKey"]),
+
+  avatars: defineTable({
+    legacyId: v.number(),
+    link: v.string(),
+    name: v.optional(v.union(v.null(), v.string())),
+    mirrorUpdatedAt: v.optional(v.number()),
+    lastOperationKey: v.optional(v.union(v.null(), v.string())),
+    // Backward compatibility for previously mirrored docs.
+    mirror_updated_at: v.optional(v.number()),
+    last_operation_key: v.optional(v.union(v.null(), v.string())),
+  })
+    .index("by_id_value", ["legacyId"])
+    .index("by_last_operation_key", ["lastOperationKey"]),
+});

--- a/scripts/migrate-lookup-tables.ts
+++ b/scripts/migrate-lookup-tables.ts
@@ -3,7 +3,7 @@ dotenv.config({ path: ".env.local" });
 
 import postgres from "postgres";
 import { ConvexHttpClient } from "convex/browser";
-import { anyApi } from "convex/server";
+import { api } from "../convex/_generated/api";
 
 const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL;
 const POSTGRES_URL = process.env.POSTGRES_URL2 || process.env.POSTGRES_URL || process.env.DATABASE_URL;
@@ -91,7 +91,7 @@ async function migrateLanguages() {
       public: row.public,
       rtl: row.rtl,
     }));
-    await client.mutation((anyApi as any).lookupTables.upsertLanguagesBatch, {
+    await client.mutation(api.lookupTables.upsertLanguagesBatch, {
       languages,
     });
   });
@@ -116,7 +116,7 @@ async function migrateImages() {
       active_lip: row.active_lip,
       gilded_lip: row.gilded_lip,
     }));
-    await client.mutation((anyApi as any).lookupTables.upsertImagesBatch, {
+    await client.mutation(api.lookupTables.upsertImagesBatch, {
       images,
     });
   });
@@ -138,7 +138,7 @@ async function migrateAvatars() {
       link: row.link,
       name: optionalString(row.name),
     }));
-    await client.mutation((anyApi as any).lookupTables.upsertAvatarsBatch, {
+    await client.mutation(api.lookupTables.upsertAvatarsBatch, {
       avatars,
     });
   });

--- a/scripts/migrate-lookup-tables.ts
+++ b/scripts/migrate-lookup-tables.ts
@@ -54,6 +54,14 @@ type AvatarRow = {
   name: string | null;
 };
 
+function optionalString(value: string | null): string | undefined {
+  return value ?? undefined;
+}
+
+function optionalNumber(value: number | null): number | undefined {
+  return value ?? undefined;
+}
+
 async function runBatch<T>(items: T[], fn: (chunk: T[]) => Promise<void>) {
   for (let i = 0; i < items.length; i += BATCH_SIZE) {
     const chunk = items.slice(i, i + BATCH_SIZE);
@@ -71,8 +79,20 @@ async function migrateLanguages() {
   `;
 
   await runBatch(rows, async (chunk) => {
+    const languages = chunk.map((row) => ({
+      legacyId: row.id,
+      name: row.name,
+      short: row.short,
+      flag: optionalNumber(row.flag),
+      flag_file: optionalString(row.flag_file),
+      speaker: optionalString(row.speaker),
+      default_text: optionalString(row.default_text),
+      tts_replace: optionalString(row.tts_replace),
+      public: row.public,
+      rtl: row.rtl,
+    }));
     await client.mutation((anyApi as any).lookupTables.upsertLanguagesBatch, {
-      languages: chunk,
+      languages,
     });
   });
 
@@ -88,8 +108,16 @@ async function migrateImages() {
   `;
 
   await runBatch(rows, async (chunk) => {
+    const images = chunk.map((row) => ({
+      legacyId: row.id,
+      active: row.active,
+      gilded: row.gilded,
+      locked: row.locked,
+      active_lip: row.active_lip,
+      gilded_lip: row.gilded_lip,
+    }));
     await client.mutation((anyApi as any).lookupTables.upsertImagesBatch, {
-      images: chunk,
+      images,
     });
   });
 
@@ -105,8 +133,13 @@ async function migrateAvatars() {
   `;
 
   await runBatch(rows, async (chunk) => {
+    const avatars = chunk.map((row) => ({
+      legacyId: row.id,
+      link: row.link,
+      name: optionalString(row.name),
+    }));
     await client.mutation((anyApi as any).lookupTables.upsertAvatarsBatch, {
-      avatars: chunk,
+      avatars,
     });
   });
 

--- a/scripts/migrate-lookup-tables.ts
+++ b/scripts/migrate-lookup-tables.ts
@@ -1,0 +1,130 @@
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+
+import postgres from "postgres";
+import { ConvexHttpClient } from "convex/browser";
+import { anyApi } from "convex/server";
+
+const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL;
+const POSTGRES_URL = process.env.POSTGRES_URL2 || process.env.POSTGRES_URL || process.env.DATABASE_URL;
+
+if (!CONVEX_URL) {
+  console.error("Error: CONVEX_URL is not set");
+  process.exit(1);
+}
+
+if (!POSTGRES_URL) {
+  console.error("Error: POSTGRES_URL2/POSTGRES_URL/DATABASE_URL is not set");
+  process.exit(1);
+}
+
+const sql = postgres(POSTGRES_URL, {
+  max: 5,
+  ssl: POSTGRES_URL.includes("localhost") ? false : { rejectUnauthorized: false },
+});
+const client = new ConvexHttpClient(CONVEX_URL);
+
+const BATCH_SIZE = Number(process.env.LOOKUP_MIGRATION_BATCH_SIZE ?? "200");
+
+type LanguageRow = {
+  id: number;
+  name: string;
+  short: string;
+  flag: number | null;
+  flag_file: string | null;
+  speaker: string | null;
+  default_text: string | null;
+  tts_replace: string | null;
+  public: boolean;
+  rtl: boolean;
+};
+
+type ImageRow = {
+  id: string;
+  active: string;
+  gilded: string;
+  locked: string;
+  active_lip: string;
+  gilded_lip: string;
+};
+
+type AvatarRow = {
+  id: number;
+  link: string;
+  name: string | null;
+};
+
+async function runBatch<T>(items: T[], fn: (chunk: T[]) => Promise<void>) {
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    const chunk = items.slice(i, i + BATCH_SIZE);
+    await fn(chunk);
+    console.log(`Processed ${Math.min(i + BATCH_SIZE, items.length)}/${items.length}`);
+  }
+}
+
+async function migrateLanguages() {
+  console.log("Migrating language table...");
+  const rows = await sql<LanguageRow[]>`
+    SELECT id, name, short, flag, flag_file, speaker, default_text, tts_replace, public, rtl
+    FROM language
+    ORDER BY id
+  `;
+
+  await runBatch(rows, async (chunk) => {
+    await client.mutation((anyApi as any).lookupTables.upsertLanguagesBatch, {
+      languages: chunk,
+    });
+  });
+
+  console.log(`Language done: ${rows.length}`);
+}
+
+async function migrateImages() {
+  console.log("Migrating image table...");
+  const rows = await sql<ImageRow[]>`
+    SELECT id, active, gilded, locked, active_lip, gilded_lip
+    FROM image
+    ORDER BY id
+  `;
+
+  await runBatch(rows, async (chunk) => {
+    await client.mutation((anyApi as any).lookupTables.upsertImagesBatch, {
+      images: chunk,
+    });
+  });
+
+  console.log(`Image done: ${rows.length}`);
+}
+
+async function migrateAvatars() {
+  console.log("Migrating avatar table...");
+  const rows = await sql<AvatarRow[]>`
+    SELECT id, link, name
+    FROM avatar
+    ORDER BY id
+  `;
+
+  await runBatch(rows, async (chunk) => {
+    await client.mutation((anyApi as any).lookupTables.upsertAvatarsBatch, {
+      avatars: chunk,
+    });
+  });
+
+  console.log(`Avatar done: ${rows.length}`);
+}
+
+async function main() {
+  await migrateLanguages();
+  await migrateImages();
+  await migrateAvatars();
+  console.log("Lookup table migration complete");
+}
+
+main()
+  .catch((error) => {
+    console.error("Lookup table migration failed", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await sql.end();
+  });

--- a/src/app/admin/languages/set/route.ts
+++ b/src/app/admin/languages/set/route.ts
@@ -14,20 +14,28 @@ interface LanguageData {
 }
 
 export async function POST(req: NextRequest) {
-  const data: LanguageData = await req.json();
-  const token = await getUser();
+  try {
+    const data: LanguageData = await req.json();
+    const token = await getUser();
 
-  if (!isAdmin(token))
-    return new Response("You need to be a registered admin.", {
-      status: 401,
+    if (!isAdmin(token))
+      return new Response("You need to be a registered admin.", {
+        status: 401,
+      });
+
+    const answer = await set_language(data);
+
+    if (answer === undefined)
+      return new Response("Error not found.", { status: 404 });
+
+    return NextResponse.json(answer);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const isMirrorFailure = message.includes("Convex mirror");
+    return new Response(message, {
+      status: isMirrorFailure ? 502 : 500,
     });
-
-  const answer = await set_language(data);
-
-  if (answer === undefined)
-    return new Response("Error not found.", { status: 404 });
-
-  return NextResponse.json(answer);
+  }
 }
 
 async function set_language(data: LanguageData) {

--- a/src/app/editor/language/save_tts_replace/route.ts
+++ b/src/app/editor/language/save_tts_replace/route.ts
@@ -25,8 +25,10 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(answer);
   } catch (err) {
-    return new Response(err instanceof Error ? err.message : String(err), {
-      status: 500,
+    const message = err instanceof Error ? err.message : String(err);
+    const isMirrorFailure = message.includes("Convex mirror");
+    return new Response(message, {
+      status: isMirrorFailure ? 502 : 500,
     });
   }
 }

--- a/src/app/editor/language/save_tts_replace/route.ts
+++ b/src/app/editor/language/save_tts_replace/route.ts
@@ -1,6 +1,7 @@
 import { sql } from "@/lib/db";
 import { NextResponse, NextRequest } from "next/server";
 import { getUser, isContributor } from "@/lib/userInterface";
+import { mirrorLanguage } from "@/lib/lookupTableMirror";
 
 export async function POST(req: NextRequest) {
   try {
@@ -37,8 +38,17 @@ async function set_tts_replace({
   id: number;
   tts_replace: string;
 }) {
-  return sql`
+  const language = (
+    await sql`
   UPDATE language SET ${sql({ tts_replace })}
   WHERE id = ${id}
-`;
+  RETURNING *
+`
+  )[0];
+
+  if (language?.id) {
+    await mirrorLanguage(language, `language:${language.id}:tts_replace`);
+  }
+
+  return language;
 }

--- a/src/app/editor/language/set_default_text/route.ts
+++ b/src/app/editor/language/set_default_text/route.ts
@@ -31,8 +31,10 @@ export async function POST(req: Request) {
 
     return NextResponse.json(answer);
   } catch (err) {
-    return new Response(err instanceof Error ? err.message : String(err), {
-      status: 500,
+    const message = err instanceof Error ? err.message : String(err);
+    const isMirrorFailure = message.includes("Convex mirror");
+    return new Response(message, {
+      status: isMirrorFailure ? 502 : 500,
     });
   }
 }

--- a/src/lib/lookupTableMirror.ts
+++ b/src/lib/lookupTableMirror.ts
@@ -1,0 +1,77 @@
+import { fetchAuthMutation } from "@/lib/auth-server";
+import { api } from "@convex/_generated/api";
+
+type LanguageRow = {
+  id?: number | null;
+  name?: string | null;
+  short?: string | null;
+  flag?: number | null;
+  flag_file?: string | null;
+  speaker?: string | null;
+  default_text?: string | null;
+  tts_replace?: string | null;
+  public?: boolean | null;
+  rtl?: boolean | null;
+};
+
+const RETRY_DELAYS_MS = [150, 500, 1200] as const;
+
+async function retryMirror<T>(fn: () => Promise<T>, operationKey: string) {
+  let lastError: unknown;
+
+  for (const delayMs of RETRY_DELAYS_MS) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  try {
+    return await fn();
+  } catch (error) {
+    lastError = error;
+  }
+
+  console.error("[mirror.lookup.failed]", {
+    operationKey,
+    error: lastError instanceof Error ? lastError.message : String(lastError),
+  });
+
+  return null;
+}
+
+export async function mirrorLanguage(row: LanguageRow, operationKey: string) {
+  if (
+    typeof row.id !== "number" ||
+    typeof row.name !== "string" ||
+    typeof row.short !== "string"
+  ) {
+    console.error("[mirror.lookup.skip.invalid_language_row]", {
+      operationKey,
+      row,
+    });
+    return null;
+  }
+
+  return retryMirror(
+    () =>
+      fetchAuthMutation((api as any).lookupTables.upsertLanguage, {
+        language: {
+          legacyId: row.id,
+          name: row.name,
+          short: row.short,
+          flag: row.flag ?? null,
+          flag_file: row.flag_file ?? null,
+          speaker: row.speaker ?? null,
+          default_text: row.default_text ?? null,
+          tts_replace: row.tts_replace ?? null,
+          public: Boolean(row.public),
+          rtl: Boolean(row.rtl),
+        },
+        operationKey,
+      }),
+    operationKey,
+  );
+}


### PR DESCRIPTION
Summary:
- Reintroduced a consolidated `convex/schema.ts` to keep validation in sync with lookup table mirrors and logged schema changes (affects `convex/_generated` types and `scripts/migrate-lookup-tables.ts`).
- Ensured `convex/betterAuth/auth.ts` encapsulates user table logic without leaking into the shared schema or lookup utilities and adjusted auth migration and lookup mirror helpers accordingly.
- Tightened language-related routes (`src/app/admin/languages/set/route.ts`, `src/app/editor/language/save_tts_replace/route.ts`, `src/app/editor/language/set_default_text/route.ts`) to honor the updated schema and lookup mirror behavior.
Testing:
- Not run (not requested)