### PR TITLE
Mirror story writes into Convex tables

### DIFF
--- a/MIGRATION_WRITE_MATRIX.md
+++ b/MIGRATION_WRITE_MATRIX.md
@@ -10,6 +10,8 @@ Scope:
 - `localization`
 - `course`
 - `avatar_mapping`
+- `story`
+- `story_content`
 
 Status values:
 - `Yes`: Runtime write path includes Convex mirror call.
@@ -32,6 +34,13 @@ Status values:
 | `course` | `src/app/editor/story/set_story/route.ts` | `UPDATE course todo_count` | Story save recalculates aggregate TODO count for the course. | `mirrorCourse(...)` | Yes |
 | `course` | `src/app/editor/(course)/approve/[story_id]/route.ts` | `UPDATE course count/contributors/contributors_past` | Approval flow updates publication totals and active/past contributor lists for the affected course. | `mirrorCourse(...)` | Yes |
 | `course` | `src/app/admin/story/[story_id]/actions.ts` | `UPDATE course count` | Admin publish toggle recalculates public story count for the story's course. | `mirrorCourse(...)` | Yes |
+| `story` | `src/app/editor/story/set_story/route.ts` | `UPDATE story` | Contributor saves story metadata and content (`text`, `json`) and updates status-related fields. | `mirrorStory(...)` | Yes |
+| `story` | `src/app/editor/story/delete_story/route.ts` | `UPDATE story deleted/public` | Contributor soft-deletes story and unpublishes it. | `mirrorStory(...)` | Yes |
+| `story` | `src/app/editor/(course)/course/[course_id]/import/send/[story_id]/route.ts` | `INSERT INTO story` | Contributor imports an existing story into another course. | `mirrorStory(...)` | Yes |
+| `story` | `src/app/editor/(course)/approve/[story_id]/route.ts` | `UPDATE story status/public/date_published` | Approval toggles update review status and auto-publish completed set stories. | `mirrorStory(...)` | Yes |
+| `story` | `src/app/admin/story/[story_id]/actions.ts` | `UPDATE story public` | Admin publish toggle directly flips visibility. | `mirrorStory(...)` | Yes |
+| `story_content` | `src/app/editor/story/set_story/route.ts` | _Not yet split in SQL_ | Mirrors heavy story payload (`text`, `json`) into Convex `story_content`. | `mirrorStory(..., { mirrorContent: true })` | Yes |
+| `story_content` | `src/app/editor/(course)/course/[course_id]/import/send/[story_id]/route.ts` | _Not yet split in SQL_ | Mirrors imported story payload into Convex `story_content`. | `mirrorStory(..., { mirrorContent: true })` | Yes |
 
 ## Backfill Paths
 
@@ -44,6 +53,8 @@ Status values:
 | `localization` | `scripts/migrate-lookup-tables.ts` | Backfill | Bulk copy from Postgres `localization` to Convex. | `api.lookupTables.upsertLocalization` | Backfill |
 | `course` | `scripts/migrate-lookup-tables.ts` | Backfill | Bulk copy from Postgres `course` to Convex. | `api.lookupTables.upsertCourse` | Backfill |
 | `avatar_mapping` | `scripts/migrate-lookup-tables.ts` | Backfill | Bulk copy from Postgres `avatar_mapping` to Convex. | `api.lookupTables.upsertAvatarMapping` | Backfill |
+| `story` | `scripts/migrate-story-tables.ts` | Backfill | Bulk copy story metadata from Postgres `story` to Convex `stories`. | `api.storyTables.upsertStory` | Backfill |
+| `story_content` | `scripts/migrate-story-tables.ts` | Backfill | Bulk copy heavy payload (`text`, `json`) from Postgres `story` to Convex `story_content`. | `api.storyTables.upsertStoryContent` | Backfill |
 
 ## Notes
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as http from "../http.js";
 import type * as lib_phpbb from "../lib/phpbb.js";
 import type * as lookupTables from "../lookupTables.js";
 import type * as roles from "../roles.js";
+import type * as storyTables from "../storyTables.js";
 
 import type {
   ApiFromModules,
@@ -30,6 +31,7 @@ declare const fullApi: ApiFromModules<{
   "lib/phpbb": typeof lib_phpbb;
   lookupTables: typeof lookupTables;
   roles: typeof roles;
+  storyTables: typeof storyTables;
 }>;
 
 /**

--- a/convex/storyTables.ts
+++ b/convex/storyTables.ts
@@ -1,0 +1,143 @@
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+const storyValidator = {
+  legacyId: v.number(),
+  duo_id: v.optional(v.string()),
+  name: v.string(),
+  set_id: v.optional(v.number()),
+  set_index: v.optional(v.number()),
+  // Temporary migration compatibility with pre-existing rows.
+  // TODO(post-migration): tighten to one type after author identity normalization.
+  authorId: v.optional(v.union(v.number(), v.string())),
+  authorChangeId: v.optional(v.union(v.number(), v.string())),
+  date: v.optional(v.number()),
+  change_date: v.optional(v.number()),
+  date_published: v.optional(v.number()),
+  text: v.string(),
+  public: v.boolean(),
+  legacyImageId: v.optional(v.string()),
+  legacyCourseId: v.number(),
+  json: v.optional(v.any()),
+  status: v.union(v.literal("draft"), v.literal("feedback"), v.literal("finished")),
+  deleted: v.boolean(),
+  todo_count: v.number(),
+};
+
+const storyContentValidator = {
+  legacyStoryId: v.number(),
+  text: v.string(),
+  json: v.any(),
+  lastUpdated: v.number(),
+};
+
+export const upsertStory = mutation({
+  args: {
+    story: v.object(storyValidator),
+    operationKey: v.optional(v.string()),
+  },
+  returns: v.object({
+    inserted: v.boolean(),
+    docId: v.id("stories"),
+  }),
+  handler: async (ctx, args) => {
+    const course = await ctx.db
+      .query("courses")
+      .withIndex("by_id_value", (q) =>
+        q.eq("legacyId", args.story.legacyCourseId),
+      )
+      .unique();
+    if (!course) {
+      throw new Error(
+        `Missing course for legacy id ${args.story.legacyCourseId}`,
+      );
+    }
+
+    const image = args.story.legacyImageId
+      ? await ctx.db
+          .query("images")
+          .withIndex("by_id_value", (q) =>
+            q.eq("legacyId", args.story.legacyImageId!),
+          )
+          .unique()
+      : null;
+
+    const existing = await ctx.db
+      .query("stories")
+      .withIndex("by_legacy_id", (q) => q.eq("legacyId", args.story.legacyId))
+      .unique();
+
+    const doc = {
+      legacyId: args.story.legacyId,
+      duo_id: args.story.duo_id,
+      name: args.story.name,
+      set_id: args.story.set_id,
+      set_index: args.story.set_index,
+      authorId: args.story.authorId,
+      authorChangeId: args.story.authorChangeId,
+      date: args.story.date,
+      change_date: args.story.change_date,
+      date_published: args.story.date_published,
+      text: args.story.text,
+      public: args.story.public,
+      imageId: image?._id,
+      courseId: course._id,
+      json: args.story.json,
+      status: args.story.status,
+      deleted: args.story.deleted,
+      todo_count: args.story.todo_count,
+    };
+
+    if (existing) {
+      await ctx.db.replace(existing._id, doc);
+      return { inserted: false, docId: existing._id };
+    }
+
+    const docId = await ctx.db.insert("stories", doc);
+    return { inserted: true, docId };
+  },
+});
+
+export const upsertStoryContent = mutation({
+  args: {
+    storyContent: v.object(storyContentValidator),
+    operationKey: v.optional(v.string()),
+  },
+  returns: v.object({
+    inserted: v.boolean(),
+    docId: v.id("story_content"),
+  }),
+  handler: async (ctx, args) => {
+    const story = await ctx.db
+      .query("stories")
+      .withIndex("by_legacy_id", (q) =>
+        q.eq("legacyId", args.storyContent.legacyStoryId),
+      )
+      .unique();
+    if (!story) {
+      throw new Error(
+        `Missing story for legacy id ${args.storyContent.legacyStoryId}`,
+      );
+    }
+
+    const existing = await ctx.db
+      .query("story_content")
+      .withIndex("by_story", (q) => q.eq("storyId", story._id))
+      .unique();
+
+    const doc = {
+      storyId: story._id,
+      text: args.storyContent.text,
+      json: args.storyContent.json,
+      lastUpdated: args.storyContent.lastUpdated,
+    };
+
+    if (existing) {
+      await ctx.db.replace(existing._id, doc);
+      return { inserted: false, docId: existing._id };
+    }
+
+    const docId = await ctx.db.insert("story_content", doc);
+    return { inserted: true, docId };
+  },
+});

--- a/scripts/migrate-story-tables.ts
+++ b/scripts/migrate-story-tables.ts
@@ -1,0 +1,191 @@
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+
+import postgres from "postgres";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../convex/_generated/api";
+
+const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL;
+const POSTGRES_URL =
+  process.env.POSTGRES_URL2 ||
+  process.env.POSTGRES_URL ||
+  process.env.DATABASE_URL;
+
+if (!CONVEX_URL) {
+  console.error("Error: CONVEX_URL is not set");
+  process.exit(1);
+}
+
+if (!POSTGRES_URL) {
+  console.error("Error: POSTGRES_URL2/POSTGRES_URL/DATABASE_URL is not set");
+  process.exit(1);
+}
+
+const sql = postgres(POSTGRES_URL, {
+  max: 5,
+  ssl: POSTGRES_URL.includes("localhost")
+    ? false
+    : { rejectUnauthorized: false },
+});
+const client = new ConvexHttpClient(CONVEX_URL);
+
+const BATCH_SIZE = Number(process.env.STORY_MIGRATION_BATCH_SIZE ?? "100");
+const START_ID = Number(process.env.STORY_MIGRATION_START_ID ?? "1");
+const END_ID_RAW = process.env.STORY_MIGRATION_END_ID;
+const END_ID = END_ID_RAW ? Number(END_ID_RAW) : undefined;
+
+type StoryRow = {
+  id: number;
+  duo_id: string | null;
+  name: string | null;
+  set_id: number | null;
+  set_index: number | null;
+  author: number | null;
+  author_change: number | null;
+  date: string | Date | null;
+  change_date: string | Date | null;
+  date_published: string | Date | null;
+  text: string | null;
+  public: boolean | null;
+  image: string | null;
+  course_id: number | null;
+  json: unknown;
+  status: "draft" | "feedback" | "finished" | null;
+  deleted: boolean | null;
+  todo_count: number | null;
+};
+
+type StoryContentRow = {
+  id: number;
+  text: string | null;
+  json: unknown;
+  change_date: string | Date | null;
+  date: string | Date | null;
+};
+
+function optionalString(value: string | null): string | undefined {
+  return value ?? undefined;
+}
+
+function optionalNumber(value: number | null): number | undefined {
+  return value ?? undefined;
+}
+
+function toTimestampMs(value: string | Date | null): number | undefined {
+  if (value === null) return undefined;
+  const timestamp = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function parseJsonLike(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+async function migrateStories() {
+  console.log("Migrating story metadata -> stories...");
+  let total = 0;
+  let lastId = START_ID - 1;
+  for (;;) {
+    const rows = await sql<StoryRow[]>`
+      SELECT id, duo_id, name, set_id, set_index, author, author_change, date, change_date, date_published, text, public, image, course_id, json, status, deleted, todo_count
+      FROM story
+      WHERE id > ${lastId}
+      ${END_ID !== undefined ? sql`AND id <= ${END_ID}` : sql``}
+      ORDER BY id
+      LIMIT ${BATCH_SIZE}
+    `;
+    if (!rows.length) break;
+    for (const row of rows) {
+      if (typeof row.course_id !== "number") {
+        throw new Error(`story id=${row.id} missing course_id`);
+      }
+      await client.mutation(api.storyTables.upsertStory, {
+        story: {
+          legacyId: row.id,
+          duo_id: optionalString(row.duo_id),
+          name: row.name ?? "",
+          set_id: optionalNumber(row.set_id),
+          set_index: optionalNumber(row.set_index),
+          authorId: optionalNumber(row.author),
+          authorChangeId: optionalNumber(row.author_change),
+          date: toTimestampMs(row.date),
+          change_date: toTimestampMs(row.change_date),
+          date_published: toTimestampMs(row.date_published),
+          text: row.text ?? "",
+          public: row.public ?? false,
+          legacyImageId: optionalString(row.image),
+          legacyCourseId: row.course_id,
+          json:
+            row.json === null || row.json === undefined
+              ? undefined
+              : parseJsonLike(row.json),
+          status: row.status ?? "draft",
+          deleted: row.deleted ?? false,
+          todo_count: row.todo_count ?? 0,
+        },
+      });
+    }
+    total += rows.length;
+    lastId = rows[rows.length - 1].id;
+    console.log(`Processed ${total} rows so far (last id=${lastId})...`);
+  }
+  console.log(`Story metadata migration complete: ${total} rows`);
+}
+
+async function migrateStoryContent() {
+  console.log("Migrating story payload -> story_content...");
+  let total = 0;
+  let lastId = START_ID - 1;
+  for (;;) {
+    const rows = await sql<StoryContentRow[]>`
+      SELECT id, text, json, change_date, date
+      FROM story
+      WHERE id > ${lastId}
+      ${END_ID !== undefined ? sql`AND id <= ${END_ID}` : sql``}
+      ORDER BY id
+      LIMIT ${BATCH_SIZE}
+    `;
+    if (!rows.length) break;
+    for (const row of rows) {
+      const parsedJson = parseJsonLike(row.json);
+      if (parsedJson === undefined || parsedJson === null) continue;
+      await client.mutation(api.storyTables.upsertStoryContent, {
+        storyContent: {
+          legacyStoryId: row.id,
+          text: row.text ?? "",
+          json: parsedJson,
+          lastUpdated:
+            toTimestampMs(row.change_date) ?? toTimestampMs(row.date) ?? Date.now(),
+        },
+      });
+    }
+    total += rows.length;
+    lastId = rows[rows.length - 1].id;
+    console.log(`Processed ${total} rows so far (last id=${lastId})...`);
+  }
+  console.log(`Story content migration complete: ${total} rows`);
+}
+
+async function main() {
+  const only = process.env.STORY_MIGRATION_ONLY;
+  if (only === "stories") return void (await migrateStories());
+  if (only === "story_content") return void (await migrateStoryContent());
+
+  await migrateStories();
+  await migrateStoryContent();
+  console.log("Story table migration complete");
+}
+
+main()
+  .catch((error) => {
+    console.error("Story table migration failed", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await sql.end();
+  });

--- a/src/app/editor/story/delete_story/route.ts
+++ b/src/app/editor/story/delete_story/route.ts
@@ -3,6 +3,7 @@ import { sql } from "@/lib/db";
 import { upload_github } from "@/lib/editor/upload_github";
 import { getUser, isContributor } from "@/lib/userInterface";
 import { getPostHogClient } from "@/lib/posthog-server";
+import { mirrorStory } from "@/lib/lookupTableMirror";
 
 export async function POST(req: NextRequest) {
   try {
@@ -34,6 +35,9 @@ async function delete_story(
 ) {
   await sql`UPDATE story SET deleted = true, public = false WHERE id = ${id};`;
   let data = (await sql`SELECT * FROM story WHERE id = ${id};`)[0];
+  if (data) {
+    await mirrorStory(data, `story:${data.id}:delete`);
+  }
   await upload_github(
     data["id"],
     data["course_id"],


### PR DESCRIPTION
## Summary
- point the story migration plan and schema at Convex stories/story_content tables, allowing metadata and payload to be dual-written without dropping text or author fields
- mirror story writes (set, delete, import, approve, publish, admin toggle) through `mirrorStory`/`storyTables` mutations so the mirrored data stays live with the SQL changes
- harden lookup migration script logging and add story backfill references to the docs to track progress

## Testing
- Not run (not requested)