### PR TITLE
Harden story content migration and cleanup heavy fields

### DIFF
--- a/MIGRATION_WRITE_MATRIX.md
+++ b/MIGRATION_WRITE_MATRIX.md
@@ -55,6 +55,7 @@ Status values:
 | `avatar_mapping` | `scripts/migrate-lookup-tables.ts` | Backfill | Bulk copy from Postgres `avatar_mapping` to Convex. | `api.lookupTables.upsertAvatarMapping` | Backfill |
 | `story` | `scripts/migrate-story-tables.ts` | Backfill | Bulk copy story metadata from Postgres `story` to Convex `stories`. | `api.storyTables.upsertStory` | Backfill |
 | `story_content` | `scripts/migrate-story-tables.ts` | Backfill | Bulk copy heavy payload (`text`, `json`) from Postgres `story` to Convex `story_content`. | `api.storyTables.upsertStoryContent` | Backfill |
+| `story` | `scripts/remove-story-heavy-fields.ts` | Cleanup migration | Strip deprecated heavy fields (`text`, `json`) from existing Convex `stories` documents after `story_content` backfill. | `api.storyTables.stripStoryHeavyFieldsBatch` | Backfill |
 
 ## Notes
 

--- a/scripts/remove-story-heavy-fields.ts
+++ b/scripts/remove-story-heavy-fields.ts
@@ -1,0 +1,50 @@
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../convex/_generated/api";
+
+const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL;
+if (!CONVEX_URL) {
+  console.error("Error: CONVEX_URL is not set");
+  process.exit(1);
+}
+
+const client = new ConvexHttpClient(CONVEX_URL);
+const BATCH_SIZE = Number(process.env.STORY_STRIP_BATCH_SIZE ?? "200");
+
+async function main() {
+  let cursor: string | null = null;
+  let totalUpdated = 0;
+
+  for (;;) {
+    const result: {
+      updated: number;
+      isDone: boolean;
+      continueCursor: string;
+    } = await client.mutation((api as any).storyTables.stripStoryHeavyFieldsBatch, {
+      paginationOpts: {
+        cursor,
+        numItems: BATCH_SIZE,
+      },
+    });
+
+    totalUpdated += result.updated;
+    console.log(
+      `Batch updated=${result.updated}, totalUpdated=${totalUpdated}, isDone=${result.isDone}`,
+    );
+
+    if (result.isDone) break;
+    cursor = result.continueCursor;
+  }
+
+  console.log("Story heavy field cleanup complete.");
+  console.log(
+    "Next step: remove `text` and `json` from convex/schema.ts stories table and run convex deploy.",
+  );
+}
+
+main().catch((error) => {
+  console.error("Story heavy field cleanup failed", error);
+  process.exitCode = 1;
+});

--- a/src/lib/lookupTableMirror.ts
+++ b/src/lib/lookupTableMirror.ts
@@ -328,14 +328,9 @@ export async function mirrorStory(
           date: optionalTimestampMs(row.date),
           change_date: optionalTimestampMs(row.change_date),
           date_published: optionalTimestampMs(row.date_published),
-          text: typeof row.text === "string" ? row.text : "",
           public: row.public ?? false,
           legacyImageId: optionalString(row.image),
           legacyCourseId: row.course_id,
-          json:
-            row.json === null || row.json === undefined
-              ? undefined
-              : parseJsonLike(row.json),
           status,
           deleted: row.deleted ?? false,
           todo_count: row.todo_count ?? 0,


### PR DESCRIPTION
Summary
- make `parseJsonLike` handle double-encoded payloads and ensure content writes retry after metadata repairs so missing stories don’t break backfill
- remove `text`/`json` from story validators/mutations now that content moves to `story_content`, and add a pagination-based mutation plus script to strip those fields from existing docs
- document the cleanup migration in `MIGRATION_WRITE_MATRIX.md`

Testing
- Not run (not requested)