### PR TITLE
Avoid TypeError when IPA match is missing captures

### DIFF
--- a/src/components/editor/story/syntax_parser_new.ts
+++ b/src/components/editor/story/syntax_parser_new.ts
@@ -294,11 +294,11 @@ function speaker_text_trans(
   const translation = data.trans?.match(/\s*~\s*(\S.*\S|\S)\s*/)?.[1] || "";
 
   getInputStringText(text);
-  const ipa_replacements: string[] & { index: number }[] = [];
+  const ipa_replacements: (RegExpMatchArray & { index: number })[] = [];
   let ipa_match = text.match(/([^-|~ ,、，;.。:：_?!…]*){([^}:]*)(:[^}]*)?}/);
 
   while (ipa_match && ipa_match.index !== undefined) {
-    ipa_replacements.push({ index: ipa_match.index });
+    ipa_replacements.push(ipa_match as RegExpMatchArray & { index: number });
     text =
       text.substring(0, ipa_match.index + ipa_match[1].length) +
       text.substring(ipa_match.index + ipa_match[0].length);
@@ -407,7 +407,7 @@ function line_to_audio(
   story_id: number,
   hideRanges: HideRange[],
   transcribe_data: TranscribeData,
-  ipa_replacements: string[] & { index: number }[],
+  ipa_replacements: (RegExpMatchArray & { index: number })[],
   ssml_payload: {
     inser_index: number;
     plan_text?: string | undefined;

--- a/src/lib/editor/audio/audio_edit_tools.ts
+++ b/src/lib/editor/audio/audio_edit_tools.ts
@@ -14,7 +14,7 @@ export function generate_ssml_line(
   ssml: { speaker: string; text: string },
   transcribe_data: TranscribeData,
   hideRanges: HideRange[],
-  ipa_replacements: string[] & { index: number }[],
+  ipa_replacements: (RegExpMatchArray & { index: number })[],
 ) {
   // foo{bar:ipa} replacement
   hideRanges = JSON.parse(JSON.stringify(hideRanges));
@@ -33,6 +33,7 @@ export function generate_ssml_line(
     offset += insert.length;
   }
   for (let match of ipa_replacements) {
+    if (!match[1] || !match[2]) continue;
     let new_words = [`<sub alias="${match[2]}">`, `</sub>`];
     if (match[3]) {
       new_words = [


### PR DESCRIPTION
Summary
- keep IPA replacement matches as `RegExpMatchArray` values so the captured text stays available
- skip replacements that lack the expected capture groups before inserting SSML tags to avoid accessing `match[1].length`

Testing
- Not run (not requested)