### PR TITLE
Adjust translation tooltip to avoid pronunciation overlap

### DIFF
--- a/src/components/StoryLineHints/StoryLineHints.module.css
+++ b/src/components/StoryLineHints/StoryLineHints.module.css
@@ -152,6 +152,10 @@
   z-index: 10;
 }
 
+.tooltiptext_with_pronunciation {
+  transform: translate(-50%, -8px);
+}
+
 /* Show the tooltip text when you mouse over the tooltip container */
 .tooltip:not([data-hidden="true"]):hover .tooltiptext {
   visibility: visible;
@@ -177,7 +181,7 @@
 .ruby_text {
   position: absolute;
   left: 50%;
-  bottom: calc(100% - 4px);
+  bottom: calc(100% - 6px);
   transform: translateX(-50%);
   white-space: nowrap;
   pointer-events: none;

--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -196,6 +196,10 @@ function StoryLineHints({
       (show_trans ? styles.tooltiptext_editor : styles.tooltiptext) +
       " " +
       content.lang_hints;
+    const tooltip_extra_class =
+      !show_trans && hint_translation && hint_pronunciation
+        ? ` ${styles.tooltiptext_with_pronunciation}`
+        : "";
 
     elements.push(
       <Tooltip
@@ -213,7 +217,7 @@ function StoryLineHints({
             </span>
           ) : null
         ) : has_translation_hint ? (
-          <span className={hint_text_class}>
+          <span className={hint_text_class + tooltip_extra_class}>
             <span>{hint_translation}</span>
           </span>
         ) : null}


### PR DESCRIPTION
- Summary
  - move the translation tooltip text 5px higher when a pronunciation hint is shown to prevent visual overlap
  - adjust ruby text positioning so the hint stack spacing matches the new tooltip offset
- Testing
  - Not run (not requested)