### PR TITLE
Center story title image and align primary button border

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,10 +13,10 @@ export default function Button({
   variant?: string;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   const baseClass =
-    "group mt-1 rounded-[15px] border-0 p-0 text-[var(--button-color)] transition-[box-shadow,transform,background-color] duration-100 bg-[var(--button-border)]";
-  const primaryClass = primary
+    "group mt-1 rounded-[15px] border-0 p-0 transition-[box-shadow,transform,background-color] duration-100";
+  const borderToneClass = primary
     ? " bg-[var(--button-blue-border)] text-[var(--button-blue-color)]"
-    : "";
+    : " bg-[var(--button-border)] text-[var(--button-color)]";
   const wrapperClass =
     "block rounded-[inherit] px-[30px] py-[10px] text-[1rem] font-bold uppercase transition-transform duration-500 ease-out group-hover:brightness-110 group-hover:duration-100 group-hover:[transform:translateY(-5px)] group-active:duration-75 group-active:ease-out group-active:[transform:translateY(-2px)] [transform:translateY(-4px)]";
   const wrapperToneClass = primary
@@ -38,7 +38,7 @@ export default function Button({
   }
 
   return (
-    <button className={`${baseClass}${primaryClass}`} {...delegated}>
+    <button className={`${baseClass}${borderToneClass}`} {...delegated}>
       <span className={`${wrapperClass}${wrapperToneClass}`}>{children}</span>
     </button>
   );

--- a/src/components/StoryTitlePage/StoryTitlePage.module.css
+++ b/src/components/StoryTitlePage/StoryTitlePage.module.css
@@ -15,6 +15,11 @@
   width: 100%;
 }
 
+.story_title_page_image img {
+  display: block;
+  margin-inline: auto;
+}
+
 .story_title_page_title {
   font-weight: 700;
   color: #4b4b4b;

--- a/src/components/StoryTitlePage/StoryTitlePage.tsx
+++ b/src/components/StoryTitlePage/StoryTitlePage.tsx
@@ -19,7 +19,7 @@ function StoryTitlePage({
 
   return (
     <div className={styles.story_title_page}>
-      <div>
+      <div className={styles.story_title_page_image}>
         <img width="180" src={header.illustrationUrl} alt={"title image"} />
       </div>
       <div className={styles.story_title_page_title}>


### PR DESCRIPTION
Summary
- center the story title illustration so it respects the story page layout
- keep primary buttons blue for both background and border while leaving default buttons unstyled

Testing
- Not run (not requested)