### PR TITLE
Add warning banner for no-native courses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,4 @@
 
 ## Convex
 - Follow `./convex/convex_rules.md` when making changes in `convex/`.
+- Always deploy Convex after changing files in `convex/` (for example with `pnpm convex deploy`).

--- a/convex/landing.ts
+++ b/convex/landing.ts
@@ -8,6 +8,7 @@ const courseListItemValidator = v.object({
   name: v.string(),
   count: v.number(),
   about: v.string(),
+  tags: v.array(v.string()),
   from_language: v.number(),
   fromLanguageId: v.id("languages"),
   from_language_name: v.string(),
@@ -116,6 +117,7 @@ export const getPublicCourseList = query({
               : learningLanguageName,
           count: course.count ?? 0,
           about: course.about ?? "",
+          tags: course.tags ?? [],
           from_language:
             legacyLanguageIdByConvexId.get(course.fromLanguageId) ?? 0,
           fromLanguageId: course.fromLanguageId as Id<"languages">,
@@ -135,6 +137,7 @@ export const getPublicCourseList = query({
           name: string;
           count: number;
           about: string;
+          tags: string[];
           from_language: number;
           fromLanguageId: Id<"languages">;
           from_language_name: string;
@@ -478,6 +481,7 @@ export const getPublicCoursePageData = query({
           : learningLanguageName,
       count: course.count ?? 0,
       about: course.about ?? "",
+      tags: course.tags ?? [],
       from_language: legacyFromLanguageId,
       fromLanguageId: course.fromLanguageId as Id<"languages">,
       from_language_name: fromLanguageName,

--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -49,7 +49,7 @@ function About({ about }: { about: string }) {
 
 function NoNativeWarning() {
   return (
-    <div className="mx-auto mt-4 max-w-[720px] rounded-xl border border-yellow-700/50 bg-yellow-50 px-4 py-3 text-yellow-900">
+    <div className="mx-auto mt-4 mb-4 max-w-[720px] rounded-xl border border-yellow-700/50 bg-yellow-50 px-4 py-3 text-yellow-900">
       <p className="font-bold">Course quality note</p>
       <p className="mt-1">
         This course does not currently have a native speaker translator or

--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -166,6 +166,7 @@ export default function CoursePageClient({
         </p>
       </Header>
       <div>
+        {showNoNativeWarning ? <NoNativeWarning /> : null}
         <div
           className="mx-auto mb-6 flex w-full max-w-[720px] cursor-pointer items-center justify-between gap-3 rounded-xl border border-[var(--overview-hr)] px-4 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--overview-hr)]"
           role="button"
@@ -194,7 +195,6 @@ export default function CoursePageClient({
           </div>
         </div>
         {course.about ? <About about={course.about} /> : null}
-        {showNoNativeWarning ? <NoNativeWarning /> : null}
         {storiesBySet.map((set) => (
           <SetGrid
             key={set.setId}

--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -47,6 +47,28 @@ function About({ about }: { about: string }) {
   );
 }
 
+function NoNativeWarning() {
+  return (
+    <div className="mx-auto mt-4 max-w-[720px] rounded-xl border border-yellow-700/50 bg-yellow-50 px-4 py-3 text-yellow-900">
+      <p className="font-bold">Course quality note</p>
+      <p className="mt-1">
+        This course does not currently have a native speaker translator or
+        proofreader, so some stories may not be 100% correct. If you are a
+        native speaker and want to help improve this course, please join our{" "}
+        <a
+          className="underline underline-offset-2"
+          href="https://discord.gg/4NGVScARR3"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Discord server
+        </a>
+        .
+      </p>
+    </div>
+  );
+}
+
 export default function CoursePageClient({
   course_id,
   preloadedCourse,
@@ -110,7 +132,6 @@ export default function CoursePageClient({
       }))
       .sort((a, b) => a.setId - b.setId);
   }, [course]);
-
   if (!course) {
     return (
       <Header>
@@ -118,6 +139,9 @@ export default function CoursePageClient({
       </Header>
     );
   }
+  const rawTags = course.tags ?? [];
+  const normalizedTags = rawTags.map((tag) => tag.trim().toLowerCase());
+  const showNoNativeWarning = normalizedTags.includes("no-native");
 
   return (
     <>
@@ -170,6 +194,7 @@ export default function CoursePageClient({
           </div>
         </div>
         {course.about ? <About about={course.about} /> : null}
+        {showNoNativeWarning ? <NoNativeWarning /> : null}
         {storiesBySet.map((set) => (
           <SetGrid
             key={set.setId}

--- a/src/app/(stories)/(main)/get_course_data.ts
+++ b/src/app/(stories)/(main)/get_course_data.ts
@@ -9,6 +9,7 @@ export interface CourseData {
   name: string;
   count: number;
   about: string;
+  tags: string[];
   from_language: number;
   fromLanguageId: Id<"languages">;
   from_language_name: string;


### PR DESCRIPTION
Summary
- include course tags in landing queries and course data so client knows when a course is marked `no-native`
- render a warning box on the course page when the `no-native` tag is present
- added instructions about urgent Convex deploys (per agent notes)

Testing
- Not run (not requested)