### PR TITLE
Exclude deleted stories from import count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,4 +11,4 @@
 
 ## Convex
 - Follow `./convex/convex_rules.md` when making changes in `convex/`.
-- Always deploy Convex after changing files in `convex/` (for example with `pnpm convex deploy`).
+- Always deploy Convex after changing files in `convex/` to the dev deployment (for example with `pnpm convex dev --once`), not prod.

--- a/convex/editorRead.ts
+++ b/convex/editorRead.ts
@@ -423,6 +423,7 @@ export const getEditorCourseImport = query({
 
     const targetCountByDuoId = new Map<string, number>();
     for (const story of targetStories) {
+      if (story.deleted) continue;
       if (!story.duo_id) continue;
       targetCountByDuoId.set(
         story.duo_id,


### PR DESCRIPTION
Summary
- stop counting deleted stories in `targetStories` when computing per-story import counts so deleted entries no longer inflate counters
- clarify the AGENTS guidance to deploy Convex to the dev environment instead of prod after convex changes

Testing
- Not run (not requested)