### PR TITLE
Add logged-in next-story finish flow

### DIFF
--- a/convex/storyDone.ts
+++ b/convex/storyDone.ts
@@ -9,6 +9,23 @@ const storyDoneInputValidator = v.object({
   time: v.optional(v.number()),
 });
 
+const dashboardCourseValidator = v.object({
+  short: v.string(),
+  name: v.string(),
+  learningLanguageName: v.string(),
+  learningLanguageShort: v.string(),
+  learningLanguageFlag: v.optional(v.union(v.number(), v.string())),
+  learningLanguageFlagFile: v.optional(v.string()),
+});
+
+const nextStepValidator = v.object({
+  course: dashboardCourseValidator,
+  completedCount: v.number(),
+  totalCount: v.number(),
+  nextStoryId: v.union(v.number(), v.null()),
+  reviewStoryId: v.union(v.number(), v.null()),
+});
+
 export const recordStoryDone = mutation({
   args: storyDoneInputValidator.fields,
   returns: v.object({
@@ -174,6 +191,30 @@ export const getLastDoneCourseShortForLegacyUser = query({
   },
 });
 
+export const getNextStoryForCurrentUserInCourse = query({
+  args: {
+    courseShort: v.string(),
+    currentStoryId: v.optional(v.number()),
+  },
+  returns: v.union(nextStepValidator, v.null()),
+  handler: async (ctx, args) => {
+    const legacyUserId = await getCurrentIdentityLegacyUserId(ctx);
+    if (!legacyUserId) return null;
+
+    const course = await ctx.db
+      .query("courses")
+      .withIndex("by_short", (q) => q.eq("short", args.courseShort))
+      .unique();
+    if (!course) return null;
+
+    return await getNextStepForCourse(ctx, {
+      courseId: course._id,
+      legacyUserId,
+      currentStoryId: args.currentStoryId,
+    });
+  },
+});
+
 async function upsertStoryDoneState(
   ctx: MutationCtx,
   args: {
@@ -204,6 +245,94 @@ async function upsertStoryDoneState(
       lastDoneAt: Math.max(row.lastDoneAt, args.lastDoneAt),
     });
   }
+}
+
+async function getNextStepForCourse(
+  ctx: QueryCtx,
+  args: {
+    courseId: Id<"courses">;
+    legacyUserId: number;
+    currentStoryId?: number;
+  },
+) {
+  const course = await ctx.db.get(args.courseId);
+  if (!course?.public || !course.short) return null;
+
+  const learningLanguage = await ctx.db.get(course.learningLanguageId);
+  if (!learningLanguage) return null;
+
+  const publicStories = await ctx.db
+    .query("stories")
+    .withIndex("by_course_public_deleted_set", (q) =>
+      q.eq("courseId", args.courseId).eq("public", true).eq("deleted", false),
+    )
+    .collect();
+
+  const orderedStories = publicStories
+    .filter(
+      (story): story is typeof story & { legacyId: number } =>
+        typeof story.legacyId === "number",
+    )
+    .sort((a, b) => {
+      const setCmp = (a.set_id ?? 0) - (b.set_id ?? 0);
+      if (setCmp !== 0) return setCmp;
+      return (a.set_index ?? 0) - (b.set_index ?? 0);
+    });
+  if (orderedStories.length === 0) return null;
+
+  const doneStoryIds = new Set<number>(
+    await getDoneStoryIdsForCourseIdAndUser(
+      ctx,
+      args.courseId,
+      args.legacyUserId,
+    ),
+  );
+  if (typeof args.currentStoryId === "number") {
+    doneStoryIds.add(args.currentStoryId);
+  }
+
+  const totalCount = orderedStories.length;
+  const completedCount = orderedStories.reduce(
+    (count, story) => count + (doneStoryIds.has(story.legacyId) ? 1 : 0),
+    0,
+  );
+
+  const currentIndex =
+    typeof args.currentStoryId === "number"
+      ? orderedStories.findIndex(
+          (story) => story.legacyId === args.currentStoryId,
+        )
+      : -1;
+
+  let nextStory =
+    currentIndex >= 0
+      ? orderedStories
+          .slice(currentIndex + 1)
+          .find((story) => !doneStoryIds.has(story.legacyId))
+      : undefined;
+  if (!nextStory) {
+    nextStory = orderedStories.find(
+      (story) => !doneStoryIds.has(story.legacyId),
+    );
+  }
+
+  return {
+    course: {
+      short: course.short,
+      name:
+        course.name && course.name.trim().length > 0
+          ? course.name
+          : learningLanguage.name,
+      learningLanguageName: learningLanguage.name,
+      learningLanguageShort: learningLanguage.short,
+      learningLanguageFlag: learningLanguage.flag,
+      learningLanguageFlagFile: learningLanguage.flag_file,
+    },
+    completedCount,
+    totalCount,
+    nextStoryId: nextStory?.legacyId ?? null,
+    reviewStoryId: orderedStories[0]?.legacyId ?? null,
+  };
 }
 
 async function upsertCourseActivity(

--- a/convex/storyRead.ts
+++ b/convex/storyRead.ts
@@ -35,6 +35,16 @@ const storyMetaResultValidator = v.union(
   v.null(),
 );
 
+const storyPreviewResultValidator = v.union(
+  v.object({
+    id: v.number(),
+    title: v.string(),
+    active: v.string(),
+    gilded: v.string(),
+  }),
+  v.null(),
+);
+
 function nonEmptyString(value: unknown) {
   return typeof value === "string" && value.trim().length > 0 ? value : "";
 }
@@ -139,6 +149,50 @@ export const getStoryMetaByLegacyId = query({
       image: image?.legacyId ?? "",
       from_language_long: fromLanguage.name,
       learning_language_long: learningLanguage.name,
+    };
+  },
+});
+
+export const getStoryPreviewByLegacyId = query({
+  args: {
+    storyId: v.number(),
+  },
+  returns: storyPreviewResultValidator,
+  handler: async (ctx, args) => {
+    const story = await ctx.db
+      .query("stories")
+      .withIndex("by_legacy_id", (q) => q.eq("legacyId", args.storyId))
+      .unique();
+    if (!story || story.deleted || typeof story.legacyId !== "number") {
+      return null;
+    }
+
+    const storyContent = await ctx.db
+      .query("story_content")
+      .withIndex("by_story", (q) => q.eq("storyId", story._id))
+      .unique();
+    const image = story.imageId ? await ctx.db.get(story.imageId) : null;
+
+    let parsedJson = storyContent?.json;
+    if (typeof parsedJson === "string") {
+      try {
+        parsedJson = JSON.parse(parsedJson);
+      } catch {
+        parsedJson = null;
+      }
+    }
+
+    const illustrations = parsedJson?.illustrations ?? {};
+    const active =
+      nonEmptyString(illustrations.active) || (image?.active ?? "");
+    const gilded =
+      nonEmptyString(illustrations.gilded) || (image?.gilded ?? active);
+
+    return {
+      id: story.legacyId,
+      title: story.name,
+      active,
+      gilded,
     };
   },
 });

--- a/src/app/(stories)/(main)/page.tsx
+++ b/src/app/(stories)/(main)/page.tsx
@@ -3,9 +3,9 @@ import Header from "./header";
 import CourseList from "./course_list";
 import Icons from "./icons";
 import React from "react";
-import LandingStatsClient from "./landing_stats_client";
 import { preloadQuery } from "convex/nextjs";
 import { api } from "@convex/_generated/api";
+import LandingStatsClient from "./landing_stats_client";
 
 export default async function Page({}) {
   const preloadedLandingData = await preloadQuery(
@@ -13,7 +13,6 @@ export default async function Page({}) {
     {},
   );
 
-  // Render data...
   return (
     <>
       <Header>
@@ -29,7 +28,7 @@ export default async function Page({}) {
           If you want to contribute or discuss the stories, meet us on{" "}
           <Link href="https://discord.gg/4NGVScARR3">Discord</Link>
           <br />
-          or learn more about the project in our <Link href={"/faq"}>FAQ</Link>.
+          or learn more about the project in our <Link href="/faq">FAQ</Link>.
         </p>
         <Icons />
       </Header>

--- a/src/app/(stories)/story/[story_id]/story_wrapper.tsx
+++ b/src/app/(stories)/story/[story_id]/story_wrapper.tsx
@@ -2,9 +2,11 @@
 import React from "react";
 
 import { useRouter } from "next/navigation";
+import { useQuery } from "convex/react";
 import StoryProgress from "@/components/StoryProgress";
 import { useNavigationMode } from "@/components/NavigationModeProvider";
 import { StoryData } from "@/app/(stories)/story/[story_id]/getStory";
+import { api } from "@convex/_generated/api";
 import posthog from "posthog-js";
 import { authClient } from "@/lib/auth-client";
 import {
@@ -12,6 +14,10 @@ import {
   identifyPostHogUser,
   type PostHogUser,
 } from "@/lib/posthog-user";
+
+const STORY_END_NEXT_FLAG_KEY =
+  process.env.NEXT_PUBLIC_POSTHOG_STORY_END_NEXT_FLAG_KEY ?? "";
+const HAS_POSTHOG = Boolean(process.env.NEXT_PUBLIC_POSTHOG_KEY);
 
 export default function StoryWrapper({
   story,
@@ -36,8 +42,29 @@ export default function StoryWrapper({
   const [highlight_name, setHighlightName] = React.useState<string[]>([]);
   const [hideNonHighlighted, setHideNonHighlighted] = React.useState(false);
   const trackedStoryStart = React.useRef(false);
+  const completionInFlight = React.useRef(false);
+  const [isNextStoryEnabled, setIsNextStoryEnabled] = React.useState(
+    !HAS_POSTHOG || STORY_END_NEXT_FLAG_KEY.length === 0,
+  );
   const { data: session } = authClient.useSession();
   const sessionUser = (session?.user ?? null) as PostHogUser | null;
+  const nextStep = useQuery(
+    api.storyDone.getNextStoryForCurrentUserInCourse,
+    sessionUser?.id
+      ? {
+          courseShort: story.course_short,
+          currentStoryId: story.id,
+        }
+      : "skip",
+  );
+  const showNextStoryAction =
+    isNextStoryEnabled && Boolean(nextStep?.nextStoryId);
+  const nextStoryPreview = useQuery(
+    api.storyRead.getStoryPreviewByLegacyId,
+    showNextStoryAction && nextStep?.nextStoryId
+      ? { storyId: nextStep.nextStoryId }
+      : "skip",
+  );
 
   const captureStoryEvent = React.useCallback(
     async (eventName: "story_started" | "story_completed") => {
@@ -69,12 +96,61 @@ export default function StoryWrapper({
     void captureStoryEvent("story_started");
   }, [captureStoryEvent]);
 
-  async function onEnd() {
-    // Track story completed
+  React.useEffect(() => {
+    if (!HAS_POSTHOG || STORY_END_NEXT_FLAG_KEY.length === 0) {
+      setIsNextStoryEnabled(true);
+      return;
+    }
+
+    const update = () => {
+      setIsNextStoryEnabled(
+        posthog.isFeatureEnabled(STORY_END_NEXT_FLAG_KEY) === true,
+      );
+    };
+
+    update();
+    posthog.onFeatureFlags(update);
+  }, []);
+
+  const finishedLabel = showNextStoryAction
+    ? "Next story"
+    : nextStep && !nextStep.nextStoryId
+      ? "Review stories"
+      : undefined;
+
+  async function completeStoryOnce() {
+    if (completionInFlight.current) return false;
+    completionInFlight.current = true;
     await captureStoryEvent("story_completed");
     await storyFinishedIndexUpdate();
+    return true;
+  }
+
+  async function goToOverview() {
+    const didComplete = await completeStoryOnce();
+    if (!didComplete) return;
+    navigateToOverview();
+  }
+
+  function navigateToOverview() {
     const setHash = story.set_id > 0 ? `#${story.set_id}` : "";
     router.push(`/${story.course_short}${setHash}`);
+  }
+
+  async function onEnd() {
+    const didComplete = await completeStoryOnce();
+    if (!didComplete) return;
+    if (showNextStoryAction && nextStep?.nextStoryId) {
+      posthog.capture("story_end_next_clicked", {
+        language: story.learning_language_long,
+        story_id: nextStep.nextStoryId,
+        completed_count: nextStep.completedCount,
+        total_count: nextStep.totalCount,
+      });
+      router.push(`/story/${nextStep.nextStoryId}`);
+      return;
+    }
+    navigateToOverview();
   }
 
   return (
@@ -94,6 +170,10 @@ export default function StoryWrapper({
           show_title_page: mode === "hard",
         }}
         onEnd={onEnd}
+        onBackToOverview={goToOverview}
+        finishedLabel={finishedLabel}
+        nextStoryPreview={nextStoryPreview}
+        showFinishedPrimaryAction={Boolean(finishedLabel)}
       />
     </>
   );

--- a/src/app/(stories)/story/[story_id]/story_wrapper.tsx
+++ b/src/app/(stories)/story/[story_id]/story_wrapper.tsx
@@ -109,7 +109,13 @@ export default function StoryWrapper({
     };
 
     update();
-    posthog.onFeatureFlags(update);
+    const unsubscribe = posthog.onFeatureFlags(update);
+
+    return () => {
+      if (typeof unsubscribe === "function") {
+        unsubscribe();
+      }
+    };
   }, []);
 
   const finishedLabel = showNextStoryAction
@@ -121,9 +127,18 @@ export default function StoryWrapper({
   async function completeStoryOnce() {
     if (completionInFlight.current) return false;
     completionInFlight.current = true;
-    await captureStoryEvent("story_completed");
-    await storyFinishedIndexUpdate();
-    return true;
+    let succeeded = false;
+
+    try {
+      await captureStoryEvent("story_completed");
+      await storyFinishedIndexUpdate();
+      succeeded = true;
+      return true;
+    } finally {
+      if (!succeeded) {
+        completionInFlight.current = false;
+      }
+    }
   }
 
   async function goToOverview() {
@@ -153,6 +168,11 @@ export default function StoryWrapper({
     navigateToOverview();
   }
 
+  const shouldShowDefaultFinishedButton =
+    !sessionUser?.id || nextStep === undefined || nextStep === null;
+  const showFinishedPrimaryAction =
+    shouldShowDefaultFinishedButton || Boolean(finishedLabel);
+
   return (
     <>
       <StoryProgress
@@ -173,7 +193,7 @@ export default function StoryWrapper({
         onBackToOverview={goToOverview}
         finishedLabel={finishedLabel}
         nextStoryPreview={nextStoryPreview}
-        showFinishedPrimaryAction={Boolean(finishedLabel)}
+        showFinishedPrimaryAction={showFinishedPrimaryAction}
       />
     </>
   );

--- a/src/components/StoryFinishedScreen/StoryFinishedScreen.module.css
+++ b/src/components/StoryFinishedScreen/StoryFinishedScreen.module.css
@@ -1,16 +1,23 @@
 /* finished end */
 .page_finished {
-  height: calc(100vh - 100px);
+  min-height: calc(100vh - 100px);
   margin-bottom: 100px;
   width: 100%;
   border-top: 2px solid var(--overview-hr);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 32px 16px 24px;
+  box-sizing: border-box;
 }
 
 .page_finished div {
   text-align: center;
+}
+
+.page_finished > div {
+  max-width: 420px;
+  width: 100%;
 }
 
 .finished_image_container {
@@ -114,5 +121,16 @@
   to {
     opacity: 0.5;
     transform: rotate(-45deg) scale(1);
+  }
+}
+
+@media (max-width: 500px) {
+  .page_finished {
+    padding-top: 24px;
+  }
+
+  .finished_image_container {
+    height: 170px;
+    width: 170px;
   }
 }

--- a/src/components/StoryFooter/StoryFooter.module.css
+++ b/src/components/StoryFooter/StoryFooter.module.css
@@ -57,6 +57,16 @@
   }
 }
 
+.width_wrapper_finished {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(170px, 220px) minmax(0, 1fr) minmax(
+      170px,
+      220px
+    );
+  justify-content: stretch;
+}
+
 .footer_right .width_wrapper {
   justify-content: space-between;
 }
@@ -146,4 +156,150 @@
   height: 31px;
   width: 41px;
   background-image: url(//d35aaqx5ub95lt.cloudfront.net/images/icon-sprite8.svg);
+}
+
+.back_button {
+  appearance: none;
+  background: #e5e5e5;
+  border: 0;
+  border-radius: 15px;
+  box-shadow: inset 0 -4px 0 #cfcfcf;
+  color: #585858;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 700;
+  margin-top: 1px;
+  min-height: 56px;
+  padding: 0 22px;
+  text-transform: uppercase;
+  transition: filter 120ms ease;
+}
+
+.back_button:hover {
+  filter: brightness(0.98);
+}
+
+.finished_center {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.next_preview {
+  min-width: 0;
+  width: 100%;
+}
+
+.next_preview_label {
+  color: var(--title-color-dim);
+  font-size: calc(12 / 16 * 1rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+@media (min-width: 801px) {
+  .next_preview {
+    position: relative;
+  }
+
+  .next_preview_label {
+    left: 0;
+    position: absolute;
+    top: -24px;
+    width: 100%;
+  }
+
+  .next_preview_card {
+    margin-top: 0;
+  }
+}
+
+.next_preview_card {
+  align-items: center;
+  background: color-mix(in srgb, var(--body-background) 90%, white 10%);
+  border: 2px solid var(--overview-hr);
+  border-radius: 18px;
+  display: flex;
+  gap: 12px;
+  margin: 0 auto;
+  max-width: 360px;
+  min-height: 76px;
+  overflow: visible;
+  padding: 10px 12px;
+  padding-left: 18px;
+  position: relative;
+}
+
+.next_preview_image {
+  flex-shrink: 0;
+  height: 52px;
+  margin-left: -6px;
+  overflow: visible;
+  width: 52px;
+}
+
+.next_preview_image img {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  overflow: visible;
+  width: 100%;
+}
+
+.next_preview_copy {
+  min-width: 0;
+}
+
+.next_preview_title {
+  color: var(--text-color-dim);
+  font-size: calc(17 / 16 * 1rem);
+  font-weight: 700;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.next_preview_subtitle {
+  color: var(--title-color-dim);
+  font-size: calc(14 / 16 * 1rem);
+  margin-top: 2px;
+}
+
+.next_preview_empty {
+  min-height: 76px;
+}
+
+.finished_action_spacer {
+  min-height: 56px;
+}
+
+@media (max-width: 800px) {
+  .footer {
+    height: auto;
+    padding: 18px 16px;
+  }
+
+  .width_wrapper_finished {
+    gap: 12px;
+    grid-template-columns: 1fr;
+  }
+
+  .finished_center {
+    order: 2;
+  }
+
+  .back_button {
+    order: 1;
+    width: 100%;
+  }
+
+  .width_wrapper_finished > button:last-child {
+    order: 3;
+    width: 100%;
+  }
 }

--- a/src/components/StoryFooter/StoryFooter.tsx
+++ b/src/components/StoryFooter/StoryFooter.tsx
@@ -18,9 +18,24 @@ function Check() {
 function StoryFooter({
   buttonStatus,
   onClick,
+  onBackToOverview,
+  finishedLabel,
+  nextStoryPreview,
+  learningLanguageName,
+  showFinishedPrimaryAction = true,
 }: {
   buttonStatus: string;
   onClick: () => void;
+  onBackToOverview?: () => void | Promise<void>;
+  finishedLabel?: string;
+  nextStoryPreview?: {
+    id: number;
+    title: string;
+    active: string;
+    gilded: string;
+  } | null;
+  learningLanguageName?: string;
+  showFinishedPrimaryAction?: boolean;
 }) {
   const localisation = useLocalisation();
 
@@ -46,10 +61,49 @@ function StoryFooter({
   if (buttonStatus === "finished") {
     return (
       <div className={styles.footer}>
-        <div className={styles.width_wrapper}>
-          <Button key={"c"} onClick={onContinueClick}>
-            {localisation("button_finished") || "finished"}
-          </Button>
+        <div
+          className={`${styles.width_wrapper} ${styles.width_wrapper_finished}`}
+        >
+          <button
+            type="button"
+            className={styles.back_button}
+            onClick={() => {
+              void onBackToOverview?.();
+            }}
+          >
+            Back to overview
+          </button>
+          <div className={styles.finished_center}>
+            {nextStoryPreview ? (
+              <div className={styles.next_preview}>
+                <div className={styles.next_preview_label}>Up next</div>
+                <div className={styles.next_preview_card}>
+                  <div className={styles.next_preview_image}>
+                    <img src={nextStoryPreview.active} alt="" />
+                  </div>
+                  <div className={styles.next_preview_copy}>
+                    <div className={styles.next_preview_title}>
+                      {nextStoryPreview.title}
+                    </div>
+                    <div className={styles.next_preview_subtitle}>
+                      {learningLanguageName
+                        ? `Continue in ${learningLanguageName}`
+                        : "Next story in this course"}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className={styles.next_preview_empty} />
+            )}
+          </div>
+          {showFinishedPrimaryAction ? (
+            <Button key={"c"} onClick={onContinueClick}>
+              {finishedLabel ?? localisation("button_finished") ?? "finished"}
+            </Button>
+          ) : (
+            <div className={styles.finished_action_spacer} />
+          )}
         </div>
       </div>
     );

--- a/src/components/StoryProgress/StoryProgress.tsx
+++ b/src/components/StoryProgress/StoryProgress.tsx
@@ -157,11 +157,24 @@ function StoryProgress({
   parts_list,
   settings,
   onEnd,
+  onBackToOverview,
+  finishedLabel,
+  nextStoryPreview,
+  showFinishedPrimaryAction,
 }: {
   story?: StoryData;
   parts_list?: StoryElement[][];
   settings: StorySettings;
   onEnd: () => void;
+  onBackToOverview?: () => void | Promise<void>;
+  finishedLabel?: string;
+  nextStoryPreview?: {
+    id: number;
+    title: string;
+    active: string;
+    gilded: string;
+  } | null;
+  showFinishedPrimaryAction?: boolean;
 }) {
   if (story) {
     parts_list = GetParts(story);
@@ -309,7 +322,15 @@ function StoryProgress({
           )}
         </div>
         {!settings.show_all && storyProgress !== -1 && (
-          <StoryFooter buttonStatus={buttonStatus} onClick={next} />
+          <StoryFooter
+            buttonStatus={buttonStatus}
+            onClick={next}
+            onBackToOverview={onBackToOverview}
+            finishedLabel={finishedLabel}
+            nextStoryPreview={nextStoryPreview}
+            learningLanguageName={story.learning_language_long}
+            showFinishedPrimaryAction={showFinishedPrimaryAction}
+          />
         )}
       </div>
     </>


### PR DESCRIPTION
## Summary
- Added Convex queries to compute the next available story for the current logged-in user and to fetch a lightweight story preview for the finish screen.
- Updated the story wrapper and footer so logged-in users can jump to the next story, return to the course overview, or review the course when no next story remains.
- Refined the finished-story UI with a three-column layout, a next-story preview card, and mobile-friendly spacing.
- Applied supporting visual fixes for footer width, privacy policy styling/metadata, dark mode theme tokens, and custom flag outlines.

## Testing
- Not run (not requested).
- Verified the finish-flow logic is wired through `story_wrapper`, `StoryProgress`, and `StoryFooter`.
- Verified the Convex queries return the data needed for next-story navigation and preview rendering.
- Verified the updated styling touches the finish screen, footer, global theme tokens, and privacy policy page.