### PR TITLE
Add admin view for repairing imported story matches

### DIFF
--- a/convex/adminData.ts
+++ b/convex/adminData.ts
@@ -58,6 +58,38 @@ const adminStoryValidator = v.object({
   approvals: v.array(adminApprovalValidator),
 });
 
+const adminStoryImportRepairSourceValidator = v.object({
+  id: v.number(),
+  name: v.string(),
+  duoId: v.union(v.string(), v.null()),
+  setId: v.union(v.number(), v.null()),
+  setIndex: v.union(v.number(), v.null()),
+});
+
+const adminStoryImportRepairRowValidator = v.object({
+  targetStoryId: v.number(),
+  targetName: v.string(),
+  targetDuoId: v.union(v.string(), v.null()),
+  targetSetId: v.union(v.number(), v.null()),
+  targetSetIndex: v.union(v.number(), v.null()),
+  currentSourceStoryId: v.union(v.number(), v.null()),
+  currentSourceStoryName: v.union(v.string(), v.null()),
+  suggestedSourceStoryId: v.union(v.number(), v.null()),
+  suggestedSourceStoryName: v.union(v.string(), v.null()),
+  status: v.union(
+    v.literal("matched"),
+    v.literal("missing"),
+    v.literal("mismatch"),
+    v.literal("ambiguous"),
+  ),
+  suggestionReason: v.string(),
+});
+
+const adminStoryImportRepairValidator = v.object({
+  sourceStories: v.array(adminStoryImportRepairSourceValidator),
+  rows: v.array(adminStoryImportRepairRowValidator),
+});
+
 const yesNoAllFilterValidator = v.union(
   v.literal("all"),
   v.literal("yes"),
@@ -608,6 +640,179 @@ export const getAdminStoryByLegacyId = query({
               : "Unknown",
         }))
         .filter((approval) => approval.id > 0),
+    };
+  },
+});
+
+export const getAdminStoryImportRepairData = query({
+  args: {
+    sourceCourseLegacyId: v.number(),
+    targetCourseLegacyId: v.number(),
+  },
+  returns: adminStoryImportRepairValidator,
+  handler: async (ctx, args) => {
+    if (!(await isAdmin(ctx))) {
+      return { sourceStories: [], rows: [] };
+    }
+
+    const [sourceCourse, targetCourse] = await Promise.all([
+      ctx.db
+        .query("courses")
+        .withIndex("by_id_value", (q) =>
+          q.eq("legacyId", args.sourceCourseLegacyId),
+        )
+        .unique(),
+      ctx.db
+        .query("courses")
+        .withIndex("by_id_value", (q) =>
+          q.eq("legacyId", args.targetCourseLegacyId),
+        )
+        .unique(),
+    ]);
+    if (!sourceCourse || !targetCourse) {
+      return { sourceStories: [], rows: [] };
+    }
+
+    const [sourceStoriesRaw, targetStoriesRaw] = await Promise.all([
+      ctx.db
+        .query("stories")
+        .withIndex("by_course", (q) => q.eq("courseId", sourceCourse._id))
+        .collect(),
+      ctx.db
+        .query("stories")
+        .withIndex("by_course", (q) => q.eq("courseId", targetCourse._id))
+        .collect(),
+    ]);
+
+    const sourceStories = sourceStoriesRaw
+      .filter(
+        (
+          story,
+        ): story is typeof story & {
+          legacyId: number;
+        } => !story.deleted && typeof story.legacyId === "number",
+      )
+      .sort((a, b) => {
+        const setCompare = (a.set_id ?? 0) - (b.set_id ?? 0);
+        if (setCompare !== 0) return setCompare;
+        return (a.set_index ?? 0) - (b.set_index ?? 0);
+      });
+
+    const targetStories = targetStoriesRaw
+      .filter(
+        (
+          story,
+        ): story is typeof story & {
+          legacyId: number;
+        } => !story.deleted && typeof story.legacyId === "number",
+      )
+      .sort((a, b) => {
+        const setCompare = (a.set_id ?? 0) - (b.set_id ?? 0);
+        if (setCompare !== 0) return setCompare;
+        return (a.set_index ?? 0) - (b.set_index ?? 0);
+      });
+
+    const sourceByDuoId = new Map<string, typeof sourceStories>();
+    const sourceBySetKey = new Map<string, typeof sourceStories>();
+
+    for (const story of sourceStories) {
+      if (story.duo_id) {
+        const storiesForDuoId = sourceByDuoId.get(story.duo_id) ?? [];
+        storiesForDuoId.push(story);
+        sourceByDuoId.set(story.duo_id, storiesForDuoId);
+      }
+      if (
+        typeof story.set_id === "number" &&
+        typeof story.set_index === "number"
+      ) {
+        const setKey = `${story.set_id}:${story.set_index}`;
+        const storiesForSet = sourceBySetKey.get(setKey) ?? [];
+        storiesForSet.push(story);
+        sourceBySetKey.set(setKey, storiesForSet);
+      }
+    }
+
+    const rows = targetStories
+      .map((targetStory) => {
+        const currentMatches = targetStory.duo_id
+          ? (sourceByDuoId.get(targetStory.duo_id) ?? [])
+          : [];
+        const suggestedMatches =
+          typeof targetStory.set_id === "number" &&
+          typeof targetStory.set_index === "number"
+            ? (sourceBySetKey.get(
+                `${targetStory.set_id}:${targetStory.set_index}`,
+              ) ?? [])
+            : [];
+
+        const currentSource =
+          currentMatches.length === 1 ? currentMatches[0] : null;
+        const suggestedSource =
+          suggestedMatches.length === 1 ? suggestedMatches[0] : null;
+
+        let status: "matched" | "missing" | "mismatch" | "ambiguous" =
+          "matched";
+        let suggestionReason =
+          "Current duo_id already matches the source story.";
+
+        if (currentMatches.length > 1) {
+          status = "ambiguous";
+          suggestionReason =
+            "Current duo_id matches multiple source stories. Pick one manually.";
+        } else if (!currentSource && suggestedSource) {
+          status = "missing";
+          suggestionReason =
+            "No unique duo_id match. Suggested via set_id/set_index.";
+        } else if (!currentSource) {
+          status = "missing";
+          suggestionReason =
+            "No unique source match found. Pick the correct story manually.";
+        } else if (
+          suggestedSource &&
+          suggestedSource.legacyId !== currentSource.legacyId
+        ) {
+          status = "mismatch";
+          suggestionReason =
+            "Current duo_id points to a different source than set_id/set_index.";
+        }
+
+        return {
+          targetStoryId: targetStory.legacyId,
+          targetName: targetStory.name,
+          targetDuoId: targetStory.duo_id ?? null,
+          targetSetId: targetStory.set_id ?? null,
+          targetSetIndex: targetStory.set_index ?? null,
+          currentSourceStoryId: currentSource?.legacyId ?? null,
+          currentSourceStoryName: currentSource?.name ?? null,
+          suggestedSourceStoryId: suggestedSource?.legacyId ?? null,
+          suggestedSourceStoryName: suggestedSource?.name ?? null,
+          status,
+          suggestionReason,
+        };
+      })
+      .sort((a, b) => {
+        const statusOrder = {
+          mismatch: 0,
+          ambiguous: 1,
+          missing: 2,
+          matched: 3,
+        } as const;
+        const statusCompare = statusOrder[a.status] - statusOrder[b.status];
+        if (statusCompare !== 0) return statusCompare;
+        const setCompare = (a.targetSetId ?? 0) - (b.targetSetId ?? 0);
+        if (setCompare !== 0) return setCompare;
+        return (a.targetSetIndex ?? 0) - (b.targetSetIndex ?? 0);
+      });
+
+    return {
+      sourceStories: sourceStories.map((story) => ({
+        id: story.legacyId,
+        name: story.name,
+        duoId: story.duo_id ?? null,
+        setId: story.set_id ?? null,
+        setIndex: story.set_index ?? null,
+      })),
+      rows,
     };
   },
 });

--- a/convex/adminStoryWrite.ts
+++ b/convex/adminStoryWrite.ts
@@ -84,3 +84,82 @@ export const removeApproval = mutation({
     return null;
   },
 });
+
+export const repairImportedStoryMatch = mutation({
+  args: {
+    targetLegacyStoryId: v.number(),
+    sourceLegacyStoryId: v.number(),
+    sourceCourseLegacyId: v.optional(v.number()),
+    targetCourseLegacyId: v.optional(v.number()),
+    operationKey: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const [targetStory, sourceStory] = await Promise.all([
+      ctx.db
+        .query("stories")
+        .withIndex("by_legacy_id", (q) =>
+          q.eq("legacyId", args.targetLegacyStoryId),
+        )
+        .unique(),
+      ctx.db
+        .query("stories")
+        .withIndex("by_legacy_id", (q) =>
+          q.eq("legacyId", args.sourceLegacyStoryId),
+        )
+        .unique(),
+    ]);
+
+    if (!targetStory || typeof targetStory.legacyId !== "number") {
+      throw new Error(`Target story ${args.targetLegacyStoryId} not found`);
+    }
+    if (!sourceStory || typeof sourceStory.legacyId !== "number") {
+      throw new Error(`Source story ${args.sourceLegacyStoryId} not found`);
+    }
+    if (!sourceStory.duo_id) {
+      throw new Error(
+        `Source story ${args.sourceLegacyStoryId} has no duo_id to repair from`,
+      );
+    }
+
+    const [targetCourse, sourceCourse] = await Promise.all([
+      ctx.db.get(targetStory.courseId),
+      ctx.db.get(sourceStory.courseId),
+    ]);
+
+    if (!targetCourse || !sourceCourse) {
+      throw new Error("Source or target course not found");
+    }
+    if (targetCourse._id === sourceCourse._id) {
+      throw new Error(
+        "Source and target stories must belong to different courses",
+      );
+    }
+    if (args.sourceCourseLegacyId !== undefined) {
+      if (sourceCourse.legacyId !== args.sourceCourseLegacyId) {
+        throw new Error(
+          "Source story does not belong to the selected source course",
+        );
+      }
+    }
+    if (args.targetCourseLegacyId !== undefined) {
+      if (targetCourse.legacyId !== args.targetCourseLegacyId) {
+        throw new Error(
+          "Target story does not belong to the selected target course",
+        );
+      }
+    }
+
+    await ctx.db.patch(targetStory._id, {
+      duo_id: sourceStory.duo_id,
+      set_id: sourceStory.set_id,
+      set_index: sourceStory.set_index,
+      imageId: sourceStory.imageId,
+      change_date: Date.now(),
+    });
+
+    return null;
+  },
+});

--- a/src/app/admin/story/page.tsx
+++ b/src/app/admin/story/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Input from "@/components/ui/input";
@@ -36,9 +37,17 @@ export default function Page() {
               />
             </div>
           </div>
-          <Button onClick={go} disabled={!id.trim()}>
-            Open Story
-          </Button>
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              className="underline underline-offset-2"
+              href="/admin/story/repair"
+            >
+              Open Repair View
+            </Link>
+            <Button onClick={go} disabled={!id.trim()}>
+              Open Story
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/admin/story/repair/page.tsx
+++ b/src/app/admin/story/repair/page.tsx
@@ -1,0 +1,5 @@
+import RepairImportMatches from "./repair_import_matches";
+
+export default function Page() {
+  return <RepairImportMatches />;
+}

--- a/src/app/admin/story/repair/repair_import_matches.tsx
+++ b/src/app/admin/story/repair/repair_import_matches.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "@convex/_generated/api";
+import Button from "@/components/ui/button";
+import Input from "@/components/ui/input";
+import { Spinner, SpinnerBlue } from "@/components/ui/spinner";
+
+function parseOptionalNumber(value: string) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function courseLabel(course: {
+  id: number;
+  short: string | null;
+  learning_language: number;
+  from_language: number;
+  name: string | null;
+}) {
+  const short = course.short?.trim() || "no-short";
+  const name = course.name?.trim();
+  return name
+    ? `${short} · #${course.id} · ${name}`
+    : `${short} · #${course.id}`;
+}
+
+function sourceOptionLabel(story: {
+  id: number;
+  name: string;
+  setId: number | null;
+  setIndex: number | null;
+}) {
+  const setPart = `${String(story.setId ?? 0).padStart(2, "0")}-${String(
+    story.setIndex ?? 0,
+  ).padStart(2, "0")}`;
+  return `${setPart} · ${story.id} · ${story.name}`;
+}
+
+function statusBadgeClassName(status: string) {
+  if (status === "mismatch") {
+    return "bg-[color:color-mix(in_srgb,#f59e0b_18%,transparent)] text-[#9a6700]";
+  }
+  if (status === "ambiguous") {
+    return "bg-[color:color-mix(in_srgb,#ef4444_18%,transparent)] text-[#9b1c1c]";
+  }
+  if (status === "missing") {
+    return "bg-[color:color-mix(in_srgb,#3b82f6_16%,transparent)] text-[#1d4ed8]";
+  }
+  return "bg-[color:color-mix(in_srgb,#10b981_16%,transparent)] text-[#047857]";
+}
+
+export default function RepairImportMatches() {
+  const coursesData = useQuery(api.adminData.getAdminCourses, {});
+  const repairMutation = useMutation(
+    api.adminStoryWrite.repairImportedStoryMatch,
+  );
+
+  const [sourceCourseId, setSourceCourseId] = useState<number | null>(null);
+  const [targetCourseId, setTargetCourseId] = useState<number | null>(null);
+  const [sourceQuery, setSourceQuery] = useState("es-en");
+  const [targetQuery, setTargetQuery] = useState("");
+  const [showOnlySuspicious, setShowOnlySuspicious] = useState(true);
+  const [selectedSourceByTargetId, setSelectedSourceByTargetId] = useState<
+    Record<number, number>
+  >({});
+  const [savingTargetId, setSavingTargetId] = useState<number | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const sourceCourses = useMemo(
+    () => coursesData?.courses.filter((course) => course.official) ?? [],
+    [coursesData],
+  );
+
+  const targetCourses = useMemo(
+    () => coursesData?.courses.filter((course) => !course.official) ?? [],
+    [coursesData],
+  );
+
+  const filteredSourceCourses = useMemo(() => {
+    const query = sourceQuery.trim().toLowerCase();
+    if (!query) return sourceCourses;
+    return sourceCourses.filter((course) => {
+      const short = course.short?.toLowerCase() ?? "";
+      const name = course.name?.toLowerCase() ?? "";
+      return (
+        short.includes(query) ||
+        name.includes(query) ||
+        String(course.id).includes(query)
+      );
+    });
+  }, [sourceCourses, sourceQuery]);
+
+  const filteredTargetCourses = useMemo(() => {
+    const query = targetQuery.trim().toLowerCase();
+    if (!query) return targetCourses;
+    return targetCourses.filter((course) => {
+      const short = course.short?.toLowerCase() ?? "";
+      const name = course.name?.toLowerCase() ?? "";
+      return (
+        short.includes(query) ||
+        name.includes(query) ||
+        String(course.id).includes(query)
+      );
+    });
+  }, [targetCourses, targetQuery]);
+
+  useEffect(() => {
+    if (sourceCourses.length === 0 && targetCourses.length === 0) return;
+    if (sourceCourseId === null) {
+      const defaultSource =
+        sourceCourses.find((course) => course.short === "es-en") ??
+        sourceCourses[0] ??
+        null;
+      setSourceCourseId(defaultSource?.id ?? null);
+    }
+    if (targetCourseId === null) {
+      setTargetCourseId(targetCourses[0]?.id ?? null);
+    }
+  }, [sourceCourses, targetCourses, sourceCourseId, targetCourseId]);
+
+  const repairData = useQuery(
+    api.adminData.getAdminStoryImportRepairData,
+    sourceCourseId !== null &&
+      targetCourseId !== null &&
+      sourceCourseId !== targetCourseId
+      ? {
+          sourceCourseLegacyId: sourceCourseId,
+          targetCourseLegacyId: targetCourseId,
+        }
+      : "skip",
+  );
+
+  useEffect(() => {
+    if (!repairData) return;
+    const nextSelections: Record<number, number> = {};
+    for (const row of repairData.rows) {
+      const preferredSourceId =
+        row.suggestedSourceStoryId ?? row.currentSourceStoryId;
+      if (preferredSourceId !== null) {
+        nextSelections[row.targetStoryId] = preferredSourceId;
+      }
+    }
+    setSelectedSourceByTargetId(nextSelections);
+  }, [repairData]);
+
+  const visibleRows = useMemo(() => {
+    if (!repairData) return [];
+    if (!showOnlySuspicious) return repairData.rows;
+    return repairData.rows.filter((row) => row.status !== "matched");
+  }, [repairData, showOnlySuspicious]);
+
+  const selectedSourceCourse =
+    sourceCourses.find((course) => course.id === sourceCourseId) ?? null;
+  const selectedTargetCourse =
+    targetCourses.find((course) => course.id === targetCourseId) ?? null;
+
+  if (coursesData === undefined) {
+    return (
+      <div className="mx-auto my-6 mb-10 w-[min(1240px,calc(100vw-32px))]">
+        <div className="rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
+          <Spinner />
+        </div>
+      </div>
+    );
+  }
+
+  if (sourceCourses.length === 0 && targetCourses.length === 0) {
+    return (
+      <div className="mx-auto my-6 mb-10 w-[min(1240px,calc(100vw-32px))]">
+        <div className="rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
+          No courses available for repair.
+        </div>
+      </div>
+    );
+  }
+
+  async function saveRepair(targetStoryId: number) {
+    const sourceStoryId = selectedSourceByTargetId[targetStoryId];
+    if (!sourceStoryId) return;
+
+    setSavingTargetId(targetStoryId);
+    setErrorMessage(null);
+    try {
+      await repairMutation({
+        targetLegacyStoryId: targetStoryId,
+        sourceLegacyStoryId: sourceStoryId,
+        sourceCourseLegacyId: sourceCourseId ?? undefined,
+        targetCourseLegacyId: targetCourseId ?? undefined,
+        operationKey: `story:${targetStoryId}:admin_repair_import:${sourceStoryId}`,
+      });
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to save repair.",
+      );
+    } finally {
+      setSavingTargetId(null);
+    }
+  }
+
+  return (
+    <div className="mx-auto my-6 mb-10 w-[min(1240px,calc(100vw-32px))]">
+      <div className="rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="m-0 text-[1.6rem] leading-[1.2]">
+              Repair Imported Story Matches
+            </h1>
+            <p className="mt-2 mb-0 max-w-[820px] text-[var(--text-color-dim)]">
+              This updates the target story metadata to the selected source
+              story so the existing golden import logic matches again. Story
+              text and translations stay unchanged.
+            </p>
+          </div>
+          <Link
+            className="whitespace-nowrap underline underline-offset-2"
+            href="/admin/story"
+          >
+            Back to Story Search
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+          <label className="grid gap-1">
+            <span className="font-bold">Source course</span>
+            <Input
+              placeholder="Search official source courses"
+              value={sourceQuery}
+              onChange={(event) => setSourceQuery(event.target.value)}
+            />
+            <select
+              className="w-full rounded-[16px] border-2 border-[var(--input-border)] bg-[var(--input-background)] px-[17px] py-[10px] text-[var(--text-color)] outline-none transition focus:border-[color:color-mix(in_srgb,var(--link-blue)_45%,var(--input-border))] focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--link-blue)_12%,transparent)]"
+              value={sourceCourseId ?? ""}
+              onChange={(event) =>
+                setSourceCourseId(parseOptionalNumber(event.target.value))
+              }
+            >
+              {filteredSourceCourses.length === 0 ? (
+                <option value="">No matching official source courses</option>
+              ) : (
+                filteredSourceCourses.map((course) => (
+                  <option key={course.id} value={course.id}>
+                    {courseLabel(course)}
+                  </option>
+                ))
+              )}
+            </select>
+          </label>
+
+          <label className="grid gap-1">
+            <span className="font-bold">Target course</span>
+            <Input
+              placeholder="Search target courses"
+              value={targetQuery}
+              onChange={(event) => setTargetQuery(event.target.value)}
+            />
+            <select
+              className="w-full rounded-[16px] border-2 border-[var(--input-border)] bg-[var(--input-background)] px-[17px] py-[10px] text-[var(--text-color)] outline-none transition focus:border-[color:color-mix(in_srgb,var(--link-blue)_45%,var(--input-border))] focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--link-blue)_12%,transparent)]"
+              value={targetCourseId ?? ""}
+              onChange={(event) =>
+                setTargetCourseId(parseOptionalNumber(event.target.value))
+              }
+            >
+              {filteredTargetCourses.length === 0 ? (
+                <option value="">No matching target courses</option>
+              ) : (
+                filteredTargetCourses.map((course) => (
+                  <option key={course.id} value={course.id}>
+                    {courseLabel(course)}
+                  </option>
+                ))
+              )}
+            </select>
+          </label>
+
+          <label className="flex items-end gap-2 pb-2">
+            <input
+              checked={showOnlySuspicious}
+              type="checkbox"
+              onChange={(event) => setShowOnlySuspicious(event.target.checked)}
+            />
+            <span>Only suspicious rows</span>
+          </label>
+        </div>
+
+        {sourceCourseId === targetCourseId ? (
+          <p className="mt-4 text-[#9b1c1c]">
+            Source and target course must be different.
+          </p>
+        ) : null}
+
+        <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-[var(--text-color-dim)]">
+          <span>
+            Source:{" "}
+            {selectedSourceCourse ? courseLabel(selectedSourceCourse) : "-"}
+          </span>
+          <span>
+            Target:{" "}
+            {selectedTargetCourse ? courseLabel(selectedTargetCourse) : "-"}
+          </span>
+        </div>
+
+        {errorMessage ? (
+          <p className="mt-4 text-[#9b1c1c]">{errorMessage}</p>
+        ) : null}
+
+        {repairData === undefined &&
+        sourceCourseId !== null &&
+        targetCourseId !== null &&
+        sourceCourseId !== targetCourseId ? (
+          <Spinner />
+        ) : null}
+
+        {repairData && (
+          <>
+            <div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-[var(--text-color-dim)]">
+              <span>{repairData.rows.length} target stories loaded</span>
+              <span>{visibleRows.length} rows shown</span>
+              <span>
+                {repairData.sourceStories.length} source stories available
+              </span>
+            </div>
+
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full min-w-[1100px] border-collapse text-left [&_th]:border-b [&_th]:border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] [&_th]:px-3 [&_th]:py-2 [&_td]:border-b [&_td]:border-[color:color-mix(in_srgb,var(--header-border)_45%,transparent)] [&_td]:px-3 [&_td]:py-3">
+                <thead>
+                  <tr>
+                    <th>Target story</th>
+                    <th>Current match</th>
+                    <th>Suggested match</th>
+                    <th>Reason</th>
+                    <th>Assign source</th>
+                    <th />
+                  </tr>
+                </thead>
+                <tbody>
+                  {visibleRows.length === 0 ? (
+                    <tr>
+                      <td
+                        colSpan={6}
+                        className="text-center text-[var(--text-color-dim)]"
+                      >
+                        No rows match the current filter.
+                      </td>
+                    </tr>
+                  ) : (
+                    visibleRows.map((row) => {
+                      const selectedSourceId =
+                        selectedSourceByTargetId[row.targetStoryId] ?? "";
+                      const hasSelection = typeof selectedSourceId === "number";
+                      const isSaving = savingTargetId === row.targetStoryId;
+                      return (
+                        <tr key={row.targetStoryId}>
+                          <td className="align-top">
+                            <div className="font-bold">{row.targetName}</div>
+                            <div className="mt-1 text-sm text-[var(--text-color-dim)]">
+                              #{row.targetStoryId} · set{" "}
+                              {String(row.targetSetId ?? 0).padStart(2, "0")}-
+                              {String(row.targetSetIndex ?? 0).padStart(2, "0")}
+                            </div>
+                            <div className="mt-1 text-xs text-[var(--text-color-dim)]">
+                              duo_id: {row.targetDuoId ?? "none"}
+                            </div>
+                            <div className="mt-2">
+                              <span
+                                className={`inline-flex rounded-full px-2 py-1 text-xs font-bold uppercase ${statusBadgeClassName(
+                                  row.status,
+                                )}`}
+                              >
+                                {row.status}
+                              </span>
+                            </div>
+                          </td>
+                          <td className="align-top">
+                            {row.currentSourceStoryId ? (
+                              <>
+                                <div className="font-bold">
+                                  #{row.currentSourceStoryId}
+                                </div>
+                                <div>{row.currentSourceStoryName}</div>
+                              </>
+                            ) : (
+                              <span className="text-[var(--text-color-dim)]">
+                                No unique current match
+                              </span>
+                            )}
+                          </td>
+                          <td className="align-top">
+                            {row.suggestedSourceStoryId ? (
+                              <>
+                                <div className="font-bold">
+                                  #{row.suggestedSourceStoryId}
+                                </div>
+                                <div>{row.suggestedSourceStoryName}</div>
+                              </>
+                            ) : (
+                              <span className="text-[var(--text-color-dim)]">
+                                No automatic suggestion
+                              </span>
+                            )}
+                          </td>
+                          <td className="align-top text-sm text-[var(--text-color-dim)]">
+                            {row.suggestionReason}
+                          </td>
+                          <td className="align-top">
+                            <select
+                              className="w-full rounded-[14px] border border-[var(--input-border)] bg-[var(--input-background)] px-3 py-2 text-sm"
+                              value={selectedSourceId}
+                              onChange={(event) =>
+                                setSelectedSourceByTargetId((current) => {
+                                  const nextValue = parseOptionalNumber(
+                                    event.target.value,
+                                  );
+                                  if (nextValue === null) {
+                                    const nextState = { ...current };
+                                    delete nextState[row.targetStoryId];
+                                    return nextState;
+                                  }
+                                  return {
+                                    ...current,
+                                    [row.targetStoryId]: nextValue,
+                                  };
+                                })
+                              }
+                            >
+                              <option value="">Select source story</option>
+                              {repairData.sourceStories.map((story) => (
+                                <option key={story.id} value={story.id}>
+                                  {sourceOptionLabel(story)}
+                                </option>
+                              ))}
+                            </select>
+                          </td>
+                          <td className="align-top">
+                            <Button
+                              size="sm"
+                              disabled={!hasSelection || isSaving}
+                              onClick={() => void saveRepair(row.targetStoryId)}
+                            >
+                              {isSaving ? (
+                                <span className="inline-flex items-center gap-2">
+                                  Saving <SpinnerBlue />
+                                </span>
+                              ) : (
+                                "Apply"
+                              )}
+                            </Button>
+                          </td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Added a new admin repair view for imported story matches, with course filtering, row status indicators, and per-row source selection.
- Added Convex query support to compare source and target stories, classify mismatches, and surface suggested repairs.
- Added a Convex mutation to apply the selected source story metadata to a target story.
- Linked the new repair view from the existing admin story search page.

## Testing
- Not run (not requested).
- Concrete checks to run: open `/admin/story/repair` and verify source/target course selection loads rows.
- Concrete checks to run: confirm suspicious rows show `mismatch`, `ambiguous`, or `missing` statuses and that `Apply` updates the target story match.
- Concrete checks to run: run `pnpm run format` and `pnpm typecheck` after the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin repair view for correcting imported story matches
  * Includes filters for source and target courses to narrow results
  * Displays validation status and suggested corrections for each story
  * Allows manual adjustment and application of corrected match mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->