### PR TITLE
Track audio insert anchors through editor edits

### DIFF
--- a/src/app/editor/story/[story]/editor_state.ts
+++ b/src/app/editor/story/[story]/editor_state.ts
@@ -1,9 +1,11 @@
 import type { EditorView } from "codemirror";
 import type {
+  Audio,
   StoryElementHeader,
   StoryElementLine,
 } from "@/components/editor/story/syntax_parser_types";
 import { type processStoryFile } from "@/components/editor/story/syntax_parser_new";
+import type { AudioInsertAnchor } from "@/lib/editor/audio/audio_edit_tools";
 
 type AudioInsertLinesType = ReturnType<typeof processStoryFile>[2];
 
@@ -12,5 +14,10 @@ export type EditorStateType = {
   view: EditorView;
   select: (line: string, scroll: boolean) => void;
   audio_insert_lines: AudioInsertLinesType | undefined;
+  create_audio_insert_anchor: (
+    ssml: Audio["ssml"],
+  ) => AudioInsertAnchor | undefined;
+  track_audio_insert_anchor: (anchor: AudioInsertAnchor) => () => void;
+  insert_audio_at_anchor: (text: string, anchor: AudioInsertAnchor) => void;
   show_audio_editor: (data: StoryElementLine | StoryElementHeader) => void;
 };

--- a/src/app/editor/story/[story]/v2/editor_v2.tsx
+++ b/src/app/editor/story/[story]/v2/editor_v2.tsx
@@ -336,7 +336,16 @@ export default function EditorV2({
   const onAudioSave = React.useCallback(
     (filename: string, timingText: string) => {
       const view = viewRef.current;
-      const trackedAnchor = audioEditorAnchorRef.current;
+      let trackedAnchor = audioEditorAnchorRef.current;
+      if (!trackedAnchor) {
+        const audio = getElementAudio(audioEditorData);
+        trackedAnchor = audio?.ssml
+          ? (trackAudioInsertAnchor(audio.ssml) ?? null)
+          : null;
+        if (trackedAnchor) {
+          audioEditorAnchorRef.current = trackedAnchor;
+        }
+      }
       if (!view || !trackedAnchor) return;
       insert_audio_at_anchor(
         `$${filename}${timingText}`,
@@ -344,7 +353,7 @@ export default function EditorV2({
         trackedAnchor.anchor,
       );
     },
-    [],
+    [audioEditorData, trackAudioInsertAnchor],
   );
 
   const soundRecorderNext = React.useCallback(() => {

--- a/src/app/editor/story/[story]/v2/editor_v2.tsx
+++ b/src/app/editor/story/[story]/v2/editor_v2.tsx
@@ -17,10 +17,14 @@ import type { EditorStateType } from "@/app/editor/story/[story]/editor_state";
 import SoundRecorder from "@/app/editor/story/[story]/sound-recorder";
 import { useStoryEditorPreferences } from "@/app/editor/_components/story_editor_preferences";
 import {
-  insert_audio_line,
+  create_audio_insert_anchor,
+  insert_audio_at_anchor,
+  map_audio_insert_anchor,
   timings_to_text,
+  type AudioInsertAnchor,
 } from "@/lib/editor/audio/audio_edit_tools";
 import type {
+  Audio,
   StoryElementHeader,
   StoryElementLine,
 } from "@/components/editor/story/syntax_parser_types";
@@ -64,6 +68,14 @@ function normalizeDocText(text: string): string {
   return text.replace(/\r\n/g, "\n");
 }
 
+function getElementAudio(
+  element: StoryElementLine | StoryElementHeader | undefined,
+): Audio | undefined {
+  if (!element) return undefined;
+  if (element.type === "HEADER") return element.audio;
+  return element.line.content.audio ?? element.audio;
+}
+
 export default function EditorV2({
   isAdmin,
   story_data,
@@ -81,6 +93,13 @@ export default function EditorV2({
   const marginRef = React.useRef<SVGSVGElement>(null);
   const svgParentRef = React.useRef<SVGSVGElement>(null);
   const viewRef = React.useRef<EditorView | null>(null);
+  const trackedAudioAnchorsRef = React.useRef<Set<AudioInsertAnchor>>(
+    new Set(),
+  );
+  const audioEditorAnchorRef = React.useRef<{
+    anchor: AudioInsertAnchor;
+    release: () => void;
+  } | null>(null);
   const [view, setView] = React.useState<EditorView | undefined>(undefined);
 
   const language_data = (useQuery(api.editorRead.getEditorLanguageByLegacyId, {
@@ -111,14 +130,6 @@ export default function EditorV2({
   );
   const storyText = storySnapshot.text;
 
-  React.useEffect(() => {
-    // Reset editor-local state when switching stories, even if the text matches.
-    setDocText(normalizeDocText(storySnapshot.text));
-    setRevision(0);
-    setLineNo(1);
-    setAudioEditorData(undefined);
-  }, [storySnapshot]);
-
   const model = useStoryEditorModel({
     isAdmin,
     storyData: story_data,
@@ -138,6 +149,64 @@ export default function EditorV2({
     save,
   } = model;
 
+  const releaseTrackedAudioEditorAnchor = React.useCallback(() => {
+    audioEditorAnchorRef.current?.release();
+    audioEditorAnchorRef.current = null;
+  }, []);
+
+  const trackAudioInsertAnchor = React.useCallback(
+    (ssml: Audio["ssml"]) => {
+      const view = viewRef.current;
+      if (!view || !audioInsertLines) return undefined;
+      const anchor = create_audio_insert_anchor(ssml, view, audioInsertLines);
+      if (!anchor) return undefined;
+      trackedAudioAnchorsRef.current.add(anchor);
+      return {
+        anchor,
+        release: () => {
+          trackedAudioAnchorsRef.current.delete(anchor);
+        },
+      };
+    },
+    [audioInsertLines],
+  );
+
+  const openAudioEditor = React.useCallback(
+    (data: StoryElementLine | StoryElementHeader | undefined) => {
+      releaseTrackedAudioEditorAnchor();
+      if (!data) {
+        setAudioEditorData(undefined);
+        return;
+      }
+      const audio = getElementAudio(data);
+      const trackedAnchor = audio?.ssml
+        ? trackAudioInsertAnchor(audio.ssml)
+        : undefined;
+      if (trackedAnchor) {
+        audioEditorAnchorRef.current = trackedAnchor;
+      }
+      setAudioEditorData(data);
+    },
+    [releaseTrackedAudioEditorAnchor, trackAudioInsertAnchor],
+  );
+
+  React.useEffect(() => {
+    // Reset editor-local state when switching stories, even if the text matches.
+    setDocText(normalizeDocText(storySnapshot.text));
+    setRevision(0);
+    setLineNo(1);
+    releaseTrackedAudioEditorAnchor();
+    setAudioEditorData(undefined);
+  }, [releaseTrackedAudioEditorAnchor, storySnapshot]);
+
+  React.useEffect(
+    () => () => {
+      releaseTrackedAudioEditorAnchor();
+      trackedAudioAnchorsRef.current.clear();
+    },
+    [releaseTrackedAudioEditorAnchor],
+  );
+
   useResizeEditor(editorRef.current, previewRef.current, marginRef.current);
   useScrollLinking(view, previewRef.current, svgParentRef.current);
 
@@ -149,6 +218,9 @@ export default function EditorV2({
       setLineNo(currentLine);
 
       if (update.docChanged) {
+        for (const anchor of trackedAudioAnchorsRef.current) {
+          map_audio_insert_anchor(anchor, update.changes);
+        }
         setDocText(update.state.doc.toString());
         setRevision((prev) => prev + 1);
       }
@@ -264,16 +336,15 @@ export default function EditorV2({
   const onAudioSave = React.useCallback(
     (filename: string, timingText: string) => {
       const view = viewRef.current;
-      if (!view || !audioEditorData?.audio) return;
-      if (!audioInsertLines) return;
-      insert_audio_line(
+      const trackedAnchor = audioEditorAnchorRef.current;
+      if (!view || !trackedAnchor) return;
+      insert_audio_at_anchor(
         `$${filename}${timingText}`,
-        audioEditorData.audio.ssml,
         view,
-        audioInsertLines,
+        trackedAnchor.anchor,
       );
     },
-    [audioEditorData, audioInsertLines],
+    [],
   );
 
   const soundRecorderNext = React.useCallback(() => {
@@ -284,11 +355,11 @@ export default function EditorV2({
         element.type === "LINE" &&
         (element.trackingProperties?.line_index ?? 0) > index
       ) {
-        setAudioEditorData(element);
+        openAudioEditor(element);
         break;
       }
     }
-  }, [audioEditorData, parsedStory.elements]);
+  }, [audioEditorData, openAudioEditor, parsedStory.elements]);
 
   const soundRecorderPrevious = React.useCallback(() => {
     if (!audioEditorData) return;
@@ -298,15 +369,14 @@ export default function EditorV2({
         (element.type === "LINE" || element.type === "HEADER") &&
         (element.trackingProperties?.line_index ?? 0) < index
       ) {
-        setAudioEditorData(element);
+        openAudioEditor(element);
         break;
       }
     }
-  }, [audioEditorData, parsedStory.elements]);
+  }, [audioEditorData, openAudioEditor, parsedStory.elements]);
 
   const editorStateForPreview: EditorStateType | undefined =
     React.useMemo(() => {
-      const view = viewRef.current;
       if (!view) return undefined;
       return {
         line_no: lineNo,
@@ -323,14 +393,27 @@ export default function EditorV2({
           );
         },
         audio_insert_lines: audioInsertLines,
-        show_audio_editor: (data) => setAudioEditorData(data),
+        create_audio_insert_anchor: (ssml) =>
+          audioInsertLines
+            ? create_audio_insert_anchor(ssml, view, audioInsertLines)
+            : undefined,
+        track_audio_insert_anchor: (anchor) => {
+          trackedAudioAnchorsRef.current.add(anchor);
+          return () => {
+            trackedAudioAnchorsRef.current.delete(anchor);
+          };
+        },
+        insert_audio_at_anchor: (text, anchor) =>
+          insert_audio_at_anchor(text, view, anchor),
+        show_audio_editor: (data) => openAudioEditor(data),
       };
-    }, [audioInsertLines, lineNo]);
+    }, [audioInsertLines, lineNo, openAudioEditor, view]);
 
   const audioEditorDataContent =
     (audioEditorData?.type === "LINE" && audioEditorData.line.content) ||
     (audioEditorData?.type === "HEADER" &&
       audioEditorData.learningLanguageTitleContent);
+  const audioEditorAudio = getElementAudio(audioEditorData);
 
   return (
     <div id="body" className="flex h-full min-h-0 flex-col">
@@ -381,22 +464,19 @@ export default function EditorV2({
         next_story={story_navigation.nextStory}
       />
       {audioEditorData &&
-        audioEditorData.audio &&
+        audioEditorAudio &&
         audioEditorDataContent &&
         model.parsedStory && (
           <SoundRecorder
             key={audioEditorData.trackingProperties.line_index}
             content={audioEditorDataContent}
             initialTimingText={timings_to_text({
-              filename: audioEditorData.audio.url ?? "",
-              keypoints: audioEditorData.audio.keypoints ?? [],
+              filename: audioEditorAudio.url ?? "",
+              keypoints: audioEditorAudio.keypoints ?? [],
             })}
-            url={
-              "https://ptoqrnbx8ghuucmt.public.blob.vercel-storage.com/" +
-              audioEditorData.audio.url
-            }
+            url={`https://ptoqrnbx8ghuucmt.public.blob.vercel-storage.com/${audioEditorAudio.url}`}
             story_id={story_data.id}
-            onClose={() => setAudioEditorData(undefined)}
+            onClose={() => openAudioEditor(undefined)}
             onSave={onAudioSave}
             soundRecorderNext={soundRecorderNext}
             soundRecorderPrevious={soundRecorderPrevious}
@@ -441,7 +521,7 @@ export default function EditorV2({
           <StoryEditorPreview
             story={model.parsedStory}
             editorState={editorStateForPreview}
-            onOpenAudioEditor={(data) => setAudioEditorData(data)}
+            onOpenAudioEditor={openAudioEditor}
           />
         </div>
       </div>

--- a/src/components/EditorSSMLDisplay/EditorSSMLDisplay.tsx
+++ b/src/components/EditorSSMLDisplay/EditorSSMLDisplay.tsx
@@ -4,7 +4,6 @@ import { MicIcon } from "lucide-react";
 import {
   generate_audio_line,
   timings_to_text,
-  insert_audio_line,
 } from "@/lib/editor/audio/audio_edit_tools";
 import type {
   Audio,
@@ -34,18 +33,22 @@ export default function EditorSSMLDisplay({
 
   async function reload() {
     setLoading(true);
+    let releaseAnchor: (() => void) | undefined;
     try {
       if (!editor) return;
+      const anchor = editor.create_audio_insert_anchor(ssml);
+      if (!anchor) return;
+      releaseAnchor = editor.track_audio_insert_anchor(anchor);
       let { filename, keypoints } = await generate_audio_line(ssml);
       let text = timings_to_text({ filename, keypoints });
-      if (editor.audio_insert_lines) {
-        insert_audio_line(text, ssml, editor.view, editor.audio_insert_lines);
-      }
+      editor.insert_audio_at_anchor(text, anchor);
     } catch (e) {
       console.error("error", e);
       setError(true);
+    } finally {
+      releaseAnchor?.();
+      setLoading(false);
     }
-    setLoading(false);
   }
 
   return (

--- a/src/lib/editor/audio/audio_edit_tools.ts
+++ b/src/lib/editor/audio/audio_edit_tools.ts
@@ -1,4 +1,5 @@
 import { fetch_post } from "@/lib/fetch_post";
+import type { ChangeDesc } from "@codemirror/state";
 import {
   add_word_marks_replacements,
   find_replace_with_mapping,
@@ -277,6 +278,12 @@ export async function generate_audio_line(ssml: {
   };
 }
 
+export type AudioInsertAnchor = {
+  kind: "replace" | "insert";
+  from: number;
+  to: number;
+};
+
 export function content_to_audio(content: string) {
   let binaryString = window.atob(content);
   let binaryData = new Uint8Array(binaryString.length);
@@ -344,28 +351,76 @@ export function insert_audio_line(
   view: EditorView,
   audio_insert_lines: [number | undefined, number][],
 ) {
-  let [line, line_insert] = audio_insert_lines[ssml.inser_index];
+  const anchor = create_audio_insert_anchor(ssml, view, audio_insert_lines);
+  if (!anchor) return;
+  insert_audio_at_anchor(text, view, anchor);
+}
+
+export function create_audio_insert_anchor(
+  ssml: {
+    inser_index: number;
+  },
+  view: EditorView,
+  audio_insert_lines: [number | undefined, number][],
+): AudioInsertAnchor | undefined {
+  const insertTarget = audio_insert_lines[ssml.inser_index];
+  if (!insertTarget) return undefined;
+
+  const [line, line_insert] = insertTarget;
   if (line !== undefined) {
-    let line_state = view.state.doc.line(line);
-    view.dispatch(
-      view.state.update({
-        changes: {
-          from: line_state.from,
-          to: line_state.to,
-          insert: text,
-        },
-      }),
-    );
-  } else {
-    let line_state = view.state.doc.line(line_insert - 1);
-    view.dispatch(
-      view.state.update({
-        changes: {
-          from: line_state.from,
-          to: line_state.from,
-          insert: text + "\n",
-        },
-      }),
-    );
+    const lineNumber = Math.min(Math.max(1, line), view.state.doc.lines);
+    const line_state = view.state.doc.line(lineNumber);
+    return {
+      kind: "replace",
+      from: line_state.from,
+      to: line_state.to,
+    };
   }
+
+  const lineNumber = Math.min(
+    Math.max(1, line_insert - 1),
+    view.state.doc.lines,
+  );
+  const line_state = view.state.doc.line(lineNumber);
+  return {
+    kind: "insert",
+    from: line_state.from,
+    to: line_state.from,
+  };
+}
+
+export function map_audio_insert_anchor(
+  anchor: AudioInsertAnchor,
+  changes: ChangeDesc,
+) {
+  if (anchor.kind === "replace") {
+    anchor.from = changes.mapPos(anchor.from, 1);
+    anchor.to = changes.mapPos(anchor.to, -1);
+    return;
+  }
+
+  const mapped = changes.mapPos(anchor.from, 1);
+  anchor.from = mapped;
+  anchor.to = mapped;
+}
+
+export function insert_audio_at_anchor(
+  text: string,
+  view: EditorView,
+  anchor: AudioInsertAnchor,
+) {
+  const insertText = anchor.kind === "insert" ? `${text}\n` : text;
+  const from = anchor.from;
+  view.dispatch(
+    view.state.update({
+      changes: {
+        from,
+        to: anchor.to,
+        insert: insertText,
+      },
+    }),
+  );
+  anchor.kind = "replace";
+  anchor.from = from;
+  anchor.to = from + text.length;
 }

--- a/src/lib/editor/audio/audio_edit_tools.ts
+++ b/src/lib/editor/audio/audio_edit_tools.ts
@@ -394,8 +394,9 @@ export function map_audio_insert_anchor(
   changes: ChangeDesc,
 ) {
   if (anchor.kind === "replace") {
-    anchor.from = changes.mapPos(anchor.from, 1);
-    anchor.to = changes.mapPos(anchor.to, -1);
+    // Keep replacement anchors wrapped around the edited content.
+    anchor.from = changes.mapPos(anchor.from, -1);
+    anchor.to = changes.mapPos(anchor.to, 1);
     return;
   }
 
@@ -410,6 +411,7 @@ export function insert_audio_at_anchor(
   anchor: AudioInsertAnchor,
 ) {
   const insertText = anchor.kind === "insert" ? `${text}\n` : text;
+  const insertedLength = insertText.length;
   const from = anchor.from;
   view.dispatch(
     view.state.update({
@@ -422,5 +424,5 @@ export function insert_audio_at_anchor(
   );
   anchor.kind = "replace";
   anchor.from = from;
-  anchor.to = from + text.length;
+  anchor.to = from + insertedLength;
 }


### PR DESCRIPTION
## Summary
- Added anchor tracking for audio insert locations so SSML audio can still be inserted after unrelated document edits.
- Updated the editor and SSML display flow to create, track, map, and release audio anchors while the editor is open.
- Consolidated audio insertion logic around `insert_audio_at_anchor` to support both replacement and newline-terminated insert cases.
- Expanded editor state passed to preview/audio tooling to expose anchor creation and insertion helpers.

## Testing
- Not run
- Expected validation: `pnpm run format`
- Expected validation: `pnpm run lint`
- Expected validation: `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anchor-based audio insertion for more accurate placement of generated audio into stories.

* **Refactor**
  * Redesigned audio editor lifecycle and tracking so anchors persist and remap reliably across document edits.
  * Moved audio insertion handling into a unified insert flow for consistency.

* **Bug Fixes**
  * Improved cleanup and release of audio anchors to avoid stale or misplaced audio after navigation or unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->