### PR TITLE
Polish admin UI spacing and shared button styles

### DIFF
--- a/src/app/admin/AdminDialogTrigger.tsx
+++ b/src/app/admin/AdminDialogTrigger.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  buttonInnerClassName,
+  buttonRootClassName,
+} from "@/components/ui/button";
+import * as EditDialog from "./edit_dialog";
+
+interface AdminDialogTriggerProps {
+  children: ReactNode;
+  isNew?: boolean;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+export default function AdminDialogTrigger({
+  children,
+  isNew,
+  onOpenChange,
+  open,
+}: AdminDialogTriggerProps) {
+  return (
+    <EditDialog.Root open={open} onOpenChange={onOpenChange}>
+      <EditDialog.Trigger asChild>
+        <button
+          className={buttonRootClassName({ className: "ml-auto" })}
+          type="button"
+        >
+          <span className={buttonInnerClassName({})}>
+            {isNew ? "Add" : "Edit"}
+          </span>
+        </button>
+      </EditDialog.Trigger>
+      {children}
+    </EditDialog.Root>
+  );
+}

--- a/src/app/admin/AdminHeader.tsx
+++ b/src/app/admin/AdminHeader.tsx
@@ -3,6 +3,11 @@ import React from "react";
 import { requireAdmin } from "@/lib/userInterface";
 import { LoggedInButtonWrappedClient } from "@/components/login/LoggedInButtonWrappedClient";
 
+const adminButtonClassName =
+  "flex min-w-[105px] cursor-pointer flex-row items-center px-3.5 text-[var(--text-color-dim)] no-underline hover:brightness-75 hover:contrast-[2.5] hover:text-[var(--text-color)] max-[1120px]:w-auto max-[1120px]:min-w-0 max-[1120px]:flex-col max-[1120px]:px-2 max-[760px]:min-w-fit max-[760px]:flex-row max-[760px]:px-2.5";
+const adminNavClassName =
+  "sticky top-0 z-[200] box-border flex h-[60px] w-full flex-row items-center overflow-x-auto overflow-y-hidden border-b-2 border-[var(--header-border)] bg-[var(--body-background)] px-5 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden [&>*]:flex-none max-w-[100vw] max-[1120px]:px-3 max-[760px]:h-auto max-[760px]:min-h-14 max-[760px]:gap-1 max-[760px]:py-2";
+
 function AdminButton({
   children,
   href,
@@ -12,11 +17,7 @@ function AdminButton({
   href: string;
 } & React.HTMLAttributes<HTMLAnchorElement>) {
   return (
-    <Link
-      className="text-[var(--text-color-dim)] px-3.5 cursor-pointer items-center flex flex-row min-w-[105px] no-underline hover:brightness-75 hover:contrast-[2.5] hover:text-[var(--text-color)] max-[1120px]:flex-col max-[1120px]:min-w-0 max-[1120px]:w-auto max-[1120px]:px-2 max-[760px]:flex-row max-[760px]:px-2.5 max-[760px]:min-w-fit"
-      href={href}
-      {...delegated}
-    >
+    <Link className={adminButtonClassName} href={href} {...delegated}>
       <div>
         <img
           alt="import button"
@@ -33,7 +34,7 @@ export default async function AdminHeader() {
   await requireAdmin();
 
   return (
-    <nav className="box-border w-full h-[60px] border-b-2 border-[var(--header-border)] bg-[var(--body-background)] flex flex-row items-center sticky px-5 top-0 z-[200] max-w-[100vw] overflow-x-auto overflow-y-hidden [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden [&>*]:flex-none max-[1120px]:px-3 max-[760px]:h-auto max-[760px]:min-h-[56px] max-[760px]:py-2 max-[760px]:gap-1">
+    <nav className={adminNavClassName}>
       <b className="pr-2.5 max-[1120px]:hidden">Admin Interface</b>
       <AdminButton href="/admin/users">Users</AdminButton>
       <AdminButton href="/admin/languages">Languages</AdminButton>

--- a/src/app/admin/adminDetailStyles.ts
+++ b/src/app/admin/adminDetailStyles.ts
@@ -1,0 +1,8 @@
+export const adminDetailPageClass =
+  "mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]";
+
+export const adminDetailCardClass =
+  "rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]";
+
+export const adminDetailLabelClass =
+  "text-left text-[var(--text-color-dim)] md:text-right";

--- a/src/app/admin/adminTableStyles.ts
+++ b/src/app/admin/adminTableStyles.ts
@@ -1,0 +1,5 @@
+export const adminTableContainerClass =
+  "relative isolate overflow-auto rounded-xl border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]";
+
+export const adminTableHeadCellClass =
+  "sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-sm uppercase tracking-wide text-[var(--button-color)]";

--- a/src/app/admin/courses/courses.tsx
+++ b/src/app/admin/courses/courses.tsx
@@ -5,7 +5,10 @@ import Flag from "@/components/ui/flag";
 import * as EditDialog from "../edit_dialog";
 import React, { useState } from "react";
 import styled from "styled-components";
-import Button from "@/components/ui/button";
+import Button, {
+  buttonInnerClassName,
+  buttonRootClassName,
+} from "@/components/ui/button";
 import Tag from "@/components/ui/badge";
 import Input from "@/components/ui/input";
 import FlagName from "../FlagName";
@@ -39,9 +42,13 @@ interface AdminLanguageProps {
 }
 
 const statusYesClass =
-  "inline-block min-w-[38px] rounded-full bg-[color:color-mix(in_srgb,#21c55d_22%,transparent)] px-2.5 py-0.5 text-center text-[0.82rem] font-bold text-[#0a6b2d]";
+  "inline-block min-w-10 rounded-full bg-[color:color-mix(in_srgb,#21c55d_22%,transparent)] px-2.5 py-0.5 text-center text-sm font-bold text-[#0a6b2d]";
 const statusNoClass =
-  "inline-block min-w-[38px] rounded-full bg-[color:color-mix(in_srgb,#ef4444_20%,transparent)] px-2.5 py-0.5 text-center text-[0.82rem] font-bold text-[#9b1c1c]";
+  "inline-block min-w-10 rounded-full bg-[color:color-mix(in_srgb,#ef4444_20%,transparent)] px-2.5 py-0.5 text-center text-sm font-bold text-[#9b1c1c]";
+const adminTableContainerClass =
+  "relative isolate overflow-auto rounded-xl border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]";
+const adminTableHeadCellClass =
+  "sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-sm uppercase tracking-wide text-[var(--button-color)]";
 
 function InputLanguage({
   name,
@@ -273,12 +280,19 @@ function EditCourse({
     }
   }
 
+  const triggerButtonRootClassName = buttonRootClassName({
+    className: "ml-auto",
+  });
+  const triggerButtonInnerClassName = buttonInnerClassName({});
+
   return (
     <EditDialog.Root open={open} onOpenChange={setOpen}>
       <EditDialog.Trigger asChild>
-        <Button style={{ marginLeft: "auto" }}>
-          {is_new ? "Add" : "Edit"}
-        </Button>
+        <button className={triggerButtonRootClassName} type="button">
+          <span className={triggerButtonInnerClassName}>
+            {is_new ? "Add" : "Edit"}
+          </span>
+        </button>
       </EditDialog.Trigger>
       <EditDialog.Content>
         <EditDialog.DialogTitle>
@@ -340,15 +354,15 @@ function EditCourse({
             value={about}
             setValue={setAbout}
           />
-          <div className="mt-[25px] flex flex-wrap justify-between gap-2">
+          <div className="mt-6 flex flex-wrap justify-between gap-2">
             {error ? (
-              <div className="rounded-[10px] bg-[var(--error-red)] p-2.5 text-white">
+              <div className="rounded-lg bg-[var(--error-red)] p-2.5 text-white">
                 An error occurred.
               </div>
             ) : (
               <div></div>
             )}
-            <Button className="Button green">Save changes</Button>
+            <Button>Save changes</Button>
           </div>
         </form>
       </EditDialog.Content>
@@ -450,7 +464,7 @@ function TableRow({
           {course.about}
         </div>
       </td>
-      <td className="sticky right-0 z-[2] min-w-[138px] bg-inherit px-4 py-2.5 text-right whitespace-nowrap">
+      <td className="sticky right-0 z-[2] min-w-36 bg-inherit px-4 py-2.5 text-right whitespace-nowrap">
         <EditCourse
           obj={course}
           languages={languages}
@@ -503,7 +517,7 @@ export function CourseList({
   }
 
   return (
-    <div className="relative isolate mx-auto my-6 mb-9 box-border w-full max-w-[min(1240px,calc(100vw-48px))] rounded-[18px] border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-[18px] shadow-[0_18px_42px_color-mix(in_srgb,#000_14%,transparent)]">
+    <div className="relative isolate mx-auto my-6 mb-9 box-border w-full max-w-[min(1240px,calc(100vw-48px))] rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
       <div className="flex flex-wrap items-end justify-between gap-4 px-0.5 pb-3">
         <Input
           label={"Search"}
@@ -528,7 +542,7 @@ export function CourseList({
           updateCourse={updateCourse}
         />
       </div>
-      <div className="relative isolate overflow-auto rounded-[14px] border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]">
+      <div className={adminTableContainerClass}>
         <table
           id="story_list"
           data-cy="story_list"
@@ -537,52 +551,31 @@ export function CourseList({
         >
           <thead>
             <tr>
-              <th className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"></th>
-              <th className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"></th>
-              <th
-                className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
-                data-js-sort-colnum="0"
-              >
+              <th className={adminTableHeadCellClass}></th>
+              <th className={adminTableHeadCellClass}></th>
+              <th className={adminTableHeadCellClass} data-js-sort-colnum="0">
                 learning_language
               </th>
-              <th
-                className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
-                data-js-sort-colnum="1"
-              >
+              <th className={adminTableHeadCellClass} data-js-sort-colnum="1">
                 from_language
               </th>
-              <th
-                className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
-                data-js-sort-colnum="1"
-              >
+              <th className={adminTableHeadCellClass} data-js-sort-colnum="1">
                 public
               </th>
-              <th
-                className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
-                data-js-sort-colnum="2"
-              >
+              <th className={adminTableHeadCellClass} data-js-sort-colnum="2">
                 name
               </th>
-              <th
-                className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
-                data-js-sort-colnum="2"
-              >
+              <th className={adminTableHeadCellClass} data-js-sort-colnum="2">
                 conlang
               </th>
-              <th
-                className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
-                data-js-sort-colnum="2"
-              >
+              <th className={adminTableHeadCellClass} data-js-sort-colnum="2">
                 tags
               </th>
-              <th
-                className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
-                data-js-sort-colnum="3"
-              >
+              <th className={adminTableHeadCellClass} data-js-sort-colnum="3">
                 about
               </th>
               <th
-                className="sticky top-0 right-0 z-[3] min-w-[138px] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
+                className={`${adminTableHeadCellClass} right-0 z-[3] min-w-36`}
                 data-js-sort-colnum="4"
               ></th>
             </tr>

--- a/src/app/admin/courses/courses.tsx
+++ b/src/app/admin/courses/courses.tsx
@@ -5,13 +5,15 @@ import Flag from "@/components/ui/flag";
 import * as EditDialog from "../edit_dialog";
 import React, { useState } from "react";
 import styled from "styled-components";
-import Button, {
-  buttonInnerClassName,
-  buttonRootClassName,
-} from "@/components/ui/button";
+import Button from "@/components/ui/button";
 import Tag from "@/components/ui/badge";
 import Input from "@/components/ui/input";
 import FlagName from "../FlagName";
+import AdminDialogTrigger from "../AdminDialogTrigger";
+import {
+  adminTableContainerClass,
+  adminTableHeadCellClass,
+} from "../adminTableStyles";
 import { useMutation } from "convex/react";
 import { api } from "@convex/_generated/api";
 
@@ -45,11 +47,6 @@ const statusYesClass =
   "inline-block min-w-10 rounded-full bg-[color:color-mix(in_srgb,#21c55d_22%,transparent)] px-2.5 py-0.5 text-center text-sm font-bold text-[#0a6b2d]";
 const statusNoClass =
   "inline-block min-w-10 rounded-full bg-[color:color-mix(in_srgb,#ef4444_20%,transparent)] px-2.5 py-0.5 text-center text-sm font-bold text-[#9b1c1c]";
-const adminTableContainerClass =
-  "relative isolate overflow-auto rounded-xl border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]";
-const adminTableHeadCellClass =
-  "sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-sm uppercase tracking-wide text-[var(--button-color)]";
-
 function InputLanguage({
   name,
   label,
@@ -280,20 +277,8 @@ function EditCourse({
     }
   }
 
-  const triggerButtonRootClassName = buttonRootClassName({
-    className: "ml-auto",
-  });
-  const triggerButtonInnerClassName = buttonInnerClassName({});
-
   return (
-    <EditDialog.Root open={open} onOpenChange={setOpen}>
-      <EditDialog.Trigger asChild>
-        <button className={triggerButtonRootClassName} type="button">
-          <span className={triggerButtonInnerClassName}>
-            {is_new ? "Add" : "Edit"}
-          </span>
-        </button>
-      </EditDialog.Trigger>
+    <AdminDialogTrigger open={open} onOpenChange={setOpen} isNew={is_new}>
       <EditDialog.Content>
         <EditDialog.DialogTitle>
           {is_new ? "Add" : "Edit"} course
@@ -366,7 +351,7 @@ function EditCourse({
           </div>
         </form>
       </EditDialog.Content>
-    </EditDialog.Root>
+    </AdminDialogTrigger>
   );
 }
 

--- a/src/app/admin/edit_dialog.tsx
+++ b/src/app/admin/edit_dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle as UiDialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import StandardButton from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export const Root = Dialog;
@@ -15,7 +16,7 @@ export const Trigger = DialogTrigger;
 export function Content({ children }: { children: React.ReactNode }) {
   return (
     <DialogContent showCloseButton={false}>
-      <div className="relative overflow-x-hidden p-[25px] max-[700px]:p-4">
+      <div className="relative overflow-x-hidden p-6 max-[700px]:p-4">
         {children}
         <DialogClose asChild>
           <button
@@ -50,27 +51,16 @@ export function DialogDescription({
   ...props
 }: React.ComponentProps<typeof UiDialogDescription>) {
   return (
-    <UiDialogDescription
-      className={cn("my-[10px] mb-5", className)}
-      {...props}
-    />
+    <UiDialogDescription className={cn("mt-2.5 mb-5", className)} {...props} />
   );
 }
 
-export function Button({
-  className,
-  ...props
-}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      className={cn(
-        "rounded-[15px] border-none border-b-4 border-[var(--button-border)] bg-[var(--button-background)] px-[30px] py-[13px] text-[1rem] font-bold uppercase text-[var(--button-color)]",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+export const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof StandardButton>
+>(function EditDialogButton(props, ref) {
+  return <StandardButton ref={ref} {...props} />;
+});
 
 export function Fieldset({
   className,
@@ -79,7 +69,7 @@ export function Fieldset({
   return (
     <fieldset
       className={cn(
-        "mb-[10px] grid w-full grid-cols-[110px_minmax(0,1fr)] items-center gap-x-4 gap-y-2 border-0 p-0 max-[700px]:grid-cols-1 max-[700px]:gap-y-1.5",
+        "mb-2.5 grid w-full grid-cols-[110px_minmax(0,1fr)] items-center gap-x-4 gap-y-2 border-0 p-0 max-[700px]:grid-cols-1 max-[700px]:gap-y-1.5",
         className,
       )}
       {...props}
@@ -94,7 +84,7 @@ export function Label({
   return (
     <label
       className={cn(
-        "overflow-hidden text-right text-[calc(16/16*1rem)] whitespace-nowrap text-ellipsis max-[700px]:text-left",
+        "overflow-hidden text-right text-base whitespace-nowrap text-ellipsis max-[700px]:text-left",
         className,
       )}
       {...props}
@@ -103,7 +93,7 @@ export function Label({
 }
 
 const dialogInputClassName =
-  "w-full min-w-0 rounded-[16px] border-2 border-[var(--input-border)] bg-[var(--input-background)] px-[17px] py-[10px] text-[calc(16/16*1rem)] text-[var(--text-color)] outline-none";
+  "w-full min-w-0 rounded-2xl border-2 border-[var(--input-border)] bg-[var(--input-background)] px-4 py-2.5 text-base text-[var(--text-color)] outline-none";
 
 export const Input = React.forwardRef<
   HTMLInputElement,
@@ -140,7 +130,7 @@ function InputArea({
   return (
     <textarea
       className={cn(
-        "w-full min-w-0 rounded-[16px] border-2 border-[var(--input-border)] bg-[var(--input-background)] px-[17px] py-[10px] text-[1rem] text-[var(--text-color)] outline-none",
+        "w-full min-w-0 rounded-2xl border-2 border-[var(--input-border)] bg-[var(--input-background)] px-4 py-2.5 text-base text-[var(--text-color)] outline-none",
         className,
       )}
       {...props}

--- a/src/app/admin/languages/language_list.tsx
+++ b/src/app/admin/languages/language_list.tsx
@@ -8,7 +8,10 @@ import React, { useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@convex/_generated/api";
 import * as EditDialog from "../edit_dialog";
-import Button from "@/components/ui/button";
+import Button, {
+  buttonInnerClassName,
+  buttonRootClassName,
+} from "@/components/ui/button";
 
 interface Language {
   id?: number;
@@ -25,6 +28,11 @@ interface EditLanguageProps {
   updateLanguage: (lang: Language) => void;
   is_new?: boolean;
 }
+
+const adminTableContainerClass =
+  "relative isolate overflow-auto rounded-xl border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]";
+const adminTableHeadCellClass =
+  "sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-sm uppercase tracking-wide text-[var(--button-color)]";
 
 function EditLanguage({ obj, updateLanguage, is_new }: EditLanguageProps) {
   const [open, setOpen] = useState(false);
@@ -85,12 +93,19 @@ function EditLanguage({ obj, updateLanguage, is_new }: EditLanguageProps) {
     }
   }
 
+  const triggerButtonRootClassName = buttonRootClassName({
+    className: "ml-auto",
+  });
+  const triggerButtonInnerClassName = buttonInnerClassName({});
+
   return (
     <EditDialog.Root open={open} onOpenChange={setOpen}>
       <EditDialog.Trigger asChild>
-        <EditDialog.Button style={{ marginLeft: "auto" }}>
-          {is_new ? "Add" : "Edit"}
-        </EditDialog.Button>
+        <button className={triggerButtonRootClassName} type="button">
+          <span className={triggerButtonInnerClassName}>
+            {is_new ? "Add" : "Edit"}
+          </span>
+        </button>
       </EditDialog.Trigger>
       <EditDialog.Content>
         <EditDialog.DialogTitle>
@@ -137,17 +152,15 @@ function EditLanguage({ obj, updateLanguage, is_new }: EditLanguageProps) {
           value={rtl}
           setValue={setRTL}
         />
-        <div className="mt-[25px] flex flex-wrap justify-between gap-2">
+        <div className="mt-6 flex flex-wrap justify-between gap-2">
           {error ? (
-            <div className="rounded-[10px] bg-[var(--error-red)] p-2.5 text-white">
+            <div className="rounded-lg bg-[var(--error-red)] p-2.5 text-white">
               An error occurred.
             </div>
           ) : (
             <div></div>
           )}
-          <Button className="Button green" onClick={send}>
-            Save changes
-          </Button>
+          <Button onClick={send}>Save changes</Button>
         </div>
       </EditDialog.Content>
     </EditDialog.Root>
@@ -250,7 +263,7 @@ export default function LanguageList({ all_languages }: LanguageListProps) {
         );
 
   return (
-    <div className="relative isolate mx-auto my-6 mb-9 box-border w-full max-w-[min(1240px,calc(100vw-48px))] rounded-[18px] border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-[18px] shadow-[0_18px_42px_color-mix(in_srgb,#000_14%,transparent)]">
+    <div className="relative isolate mx-auto my-6 mb-9 box-border w-full max-w-[min(1240px,calc(100vw-48px))] rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
       <div className="flex flex-wrap items-end justify-between gap-4 px-0.5 pb-3">
         <Input label="Search" value={search} onChange={setSearch} />
         <EditLanguage
@@ -266,7 +279,7 @@ export default function LanguageList({ all_languages }: LanguageListProps) {
           updateLanguage={updateLanguage}
         />
       </div>
-      <div className="relative isolate overflow-auto rounded-[14px] border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]">
+      <div className={adminTableContainerClass}>
         <table
           id="story_list"
           data-cy="story_list"
@@ -288,7 +301,7 @@ export default function LanguageList({ all_languages }: LanguageListProps) {
               ].map((header, idx) => (
                 <th
                   key={`${header}-${idx}`}
-                  className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
+                  className={adminTableHeadCellClass}
                 >
                   {header}
                 </th>

--- a/src/app/admin/languages/language_list.tsx
+++ b/src/app/admin/languages/language_list.tsx
@@ -8,10 +8,12 @@ import React, { useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "@convex/_generated/api";
 import * as EditDialog from "../edit_dialog";
-import Button, {
-  buttonInnerClassName,
-  buttonRootClassName,
-} from "@/components/ui/button";
+import Button from "@/components/ui/button";
+import AdminDialogTrigger from "../AdminDialogTrigger";
+import {
+  adminTableContainerClass,
+  adminTableHeadCellClass,
+} from "../adminTableStyles";
 
 interface Language {
   id?: number;
@@ -28,11 +30,6 @@ interface EditLanguageProps {
   updateLanguage: (lang: Language) => void;
   is_new?: boolean;
 }
-
-const adminTableContainerClass =
-  "relative isolate overflow-auto rounded-xl border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]";
-const adminTableHeadCellClass =
-  "sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-sm uppercase tracking-wide text-[var(--button-color)]";
 
 function EditLanguage({ obj, updateLanguage, is_new }: EditLanguageProps) {
   const [open, setOpen] = useState(false);
@@ -93,20 +90,8 @@ function EditLanguage({ obj, updateLanguage, is_new }: EditLanguageProps) {
     }
   }
 
-  const triggerButtonRootClassName = buttonRootClassName({
-    className: "ml-auto",
-  });
-  const triggerButtonInnerClassName = buttonInnerClassName({});
-
   return (
-    <EditDialog.Root open={open} onOpenChange={setOpen}>
-      <EditDialog.Trigger asChild>
-        <button className={triggerButtonRootClassName} type="button">
-          <span className={triggerButtonInnerClassName}>
-            {is_new ? "Add" : "Edit"}
-          </span>
-        </button>
-      </EditDialog.Trigger>
+    <AdminDialogTrigger open={open} onOpenChange={setOpen} isNew={is_new}>
       <EditDialog.Content>
         <EditDialog.DialogTitle>
           {is_new ? "Add" : "Edit"} Language
@@ -163,7 +148,7 @@ function EditLanguage({ obj, updateLanguage, is_new }: EditLanguageProps) {
           <Button onClick={send}>Save changes</Button>
         </div>
       </EditDialog.Content>
-    </EditDialog.Root>
+    </AdminDialogTrigger>
   );
 }
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 export default function Page({}) {
   return (
     <div className="mx-auto my-6 w-[min(860px,calc(100vw-32px))] rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-6 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
-      <div>Admin</div>
+      <div className="text-xl font-semibold">Admin</div>
     </div>
   );
 }

--- a/src/app/admin/story/[story_id]/story_display.tsx
+++ b/src/app/admin/story/[story_id]/story_display.tsx
@@ -10,17 +10,15 @@ import Button, {
 } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import {
+  adminDetailCardClass,
+  adminDetailLabelClass,
+  adminDetailPageClass,
+} from "../../adminDetailStyles";
+import {
   togglePublished,
   removeApproval as removeApprovalAction,
 } from "./actions";
 import { cn } from "@/lib/utils";
-
-const adminDetailPageClass =
-  "mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]";
-const adminDetailCardClass =
-  "rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]";
-const adminDetailLabelClass =
-  "text-left text-[var(--text-color-dim)] md:text-right";
 const dangerButtonRootClassName = buttonRootClassName({
   className:
     "mt-0 cursor-pointer bg-[color:color-mix(in_srgb,#ef4444_36%,transparent)] text-[#9b1c1c]",

--- a/src/app/admin/story/[story_id]/story_display.tsx
+++ b/src/app/admin/story/[story_id]/story_display.tsx
@@ -4,12 +4,31 @@ import Link from "next/link";
 import { useQuery } from "convex/react";
 import { api } from "@convex/_generated/api";
 import Switch from "@/components/ui/switch";
-import Button from "@/components/ui/button";
+import Button, {
+  buttonInnerClassName,
+  buttonRootClassName,
+} from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import {
   togglePublished,
   removeApproval as removeApprovalAction,
 } from "./actions";
+import { cn } from "@/lib/utils";
+
+const adminDetailPageClass =
+  "mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]";
+const adminDetailCardClass =
+  "rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]";
+const adminDetailLabelClass =
+  "text-left text-[var(--text-color-dim)] md:text-right";
+const dangerButtonRootClassName = buttonRootClassName({
+  className:
+    "mt-0 cursor-pointer bg-[color:color-mix(in_srgb,#ef4444_36%,transparent)] text-[#9b1c1c]",
+});
+const dangerButtonInnerClassName = cn(
+  buttonInnerClassName({ size: "sm" }),
+  "bg-[color:color-mix(in_srgb,#ef4444_20%,transparent)] text-[#9b1c1c]",
+);
 
 export default function StoryDisplay({ storyId }: { storyId: number }) {
   const story = useQuery(api.adminData.getAdminStoryByLegacyId, {
@@ -18,8 +37,8 @@ export default function StoryDisplay({ storyId }: { storyId: number }) {
 
   if (story === undefined) {
     return (
-      <div className="mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]">
-        <div className="rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
+      <div className={adminDetailPageClass}>
+        <div className={adminDetailCardClass}>
           <Spinner />
         </div>
       </div>
@@ -28,10 +47,8 @@ export default function StoryDisplay({ storyId }: { storyId: number }) {
 
   if (!story) {
     return (
-      <div className="mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]">
-        <div className="rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
-          Story not found.
-        </div>
+      <div className={adminDetailPageClass}>
+        <div className={adminDetailCardClass}>Story not found.</div>
       </div>
     );
   }
@@ -60,8 +77,8 @@ export default function StoryDisplay({ storyId }: { storyId: number }) {
   }
 
   return (
-    <div className="mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]">
-      <div className="rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
+    <div className={adminDetailPageClass}>
+      <div className={adminDetailCardClass}>
         <div className="mb-3.5 flex flex-wrap items-center justify-between gap-3">
           <Link
             className="whitespace-nowrap underline underline-offset-2"
@@ -85,19 +102,13 @@ export default function StoryDisplay({ storyId }: { storyId: number }) {
             height={132}
           />
           <div>
-            <h1 className="m-0 text-[2rem] leading-[1.15]">{storyData.name}</h1>
+            <h1 className="m-0 text-3xl leading-tight">{storyData.name}</h1>
             <div className="mt-3 mb-5 grid grid-cols-1 gap-x-3 gap-y-2 md:grid-cols-[160px_minmax(0,1fr)]">
-              <div className="text-left text-[var(--text-color-dim)] md:text-right">
-                Story ID
-              </div>
+              <div className={adminDetailLabelClass}>Story ID</div>
               <div className="min-w-0 break-words">{storyData.id}</div>
-              <div className="text-left text-[var(--text-color-dim)] md:text-right">
-                Legacy ID
-              </div>
+              <div className={adminDetailLabelClass}>Legacy ID</div>
               <div className="min-w-0 break-words">{storyId}</div>
-              <div className="text-left text-[var(--text-color-dim)] md:text-right">
-                Published
-              </div>
+              <div className={adminDetailLabelClass}>Published</div>
               <div className="min-w-0 break-words">
                 <span className="inline-flex items-center gap-2">
                   <Switch
@@ -107,9 +118,7 @@ export default function StoryDisplay({ storyId }: { storyId: number }) {
                   {storyData.public ? "Yes" : "No"}
                 </span>
               </div>
-              <div className="text-left text-[var(--text-color-dim)] md:text-right">
-                Course
-              </div>
+              <div className={adminDetailLabelClass}>Course</div>
               <div className="min-w-0 break-words">
                 <Link
                   className="underline underline-offset-2"
@@ -122,7 +131,7 @@ export default function StoryDisplay({ storyId }: { storyId: number }) {
           </div>
         </div>
 
-        <h2 className="my-5 text-[1.2rem]">Approvals</h2>
+        <h2 className="my-5 text-xl">Approvals</h2>
         {storyData.approvals.length === 0 ? (
           <div>No approvals.</div>
         ) : (
@@ -140,11 +149,11 @@ export default function StoryDisplay({ storyId }: { storyId: number }) {
                   {formatApprovalDate(approval.date)} - {approval.name}
                 </span>
                 <button
-                  className="cursor-pointer rounded-[10px] border-none bg-[color:color-mix(in_srgb,#ef4444_20%,transparent)] px-3 py-2 font-bold text-[#9b1c1c]"
+                  className={dangerButtonRootClassName}
                   type="button"
                   onClick={() => deleteApproval(approval.id)}
                 >
-                  Remove
+                  <span className={dangerButtonInnerClassName}>Remove</span>
                 </button>
               </li>
             ))}

--- a/src/app/admin/story/page.tsx
+++ b/src/app/admin/story/page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
 
   return (
     <div className="mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]">
-      <div className="relative isolate mx-auto my-6 mb-9 box-border w-full rounded-[18px] border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-[18px] shadow-[0_18px_42px_color-mix(in_srgb,#000_14%,transparent)]">
+      <div className="relative isolate mx-auto my-6 mb-9 box-border w-full rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
         <div className="flex flex-wrap items-end justify-between gap-4 px-0.5 pb-3">
           <div className="flex flex-wrap items-center gap-3">
             <label className="whitespace-nowrap font-bold" htmlFor="story-id">

--- a/src/app/admin/users/[user_id]/user_display.tsx
+++ b/src/app/admin/users/[user_id]/user_display.tsx
@@ -6,17 +6,15 @@ import Switch from "@/components/ui/switch";
 import Button from "@/components/ui/button";
 import type { AdminUser } from "./schema";
 import {
+  adminDetailCardClass,
+  adminDetailLabelClass,
+  adminDetailPageClass,
+} from "../../adminDetailStyles";
+import {
   setUserActivatedAction,
   setUserWriteAction,
   setUserDeleteAction,
 } from "./actions";
-
-const adminDetailPageClass =
-  "mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]";
-const adminDetailCardClass =
-  "rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]";
-const adminDetailLabelClass =
-  "text-left text-[var(--text-color-dim)] md:text-right";
 
 async function setUserActivated(data: {
   id: number;

--- a/src/app/admin/users/[user_id]/user_display.tsx
+++ b/src/app/admin/users/[user_id]/user_display.tsx
@@ -11,6 +11,13 @@ import {
   setUserDeleteAction,
 } from "./actions";
 
+const adminDetailPageClass =
+  "mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]";
+const adminDetailCardClass =
+  "rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]";
+const adminDetailLabelClass =
+  "text-left text-[var(--text-color-dim)] md:text-right";
+
 async function setUserActivated(data: {
   id: number;
   activated: 0 | 1 | boolean;
@@ -76,8 +83,8 @@ export default function UserDisplay({ user }: { user: AdminUser }) {
   }
 
   return (
-    <div className="mx-auto my-6 mb-10 w-[min(860px,calc(100vw-32px))]">
-      <div className="rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
+    <div className={adminDetailPageClass}>
+      <div className={adminDetailCardClass}>
         <div className="mb-3.5 flex flex-wrap items-center justify-between gap-3">
           <Link
             className="whitespace-nowrap underline underline-offset-2"
@@ -89,58 +96,42 @@ export default function UserDisplay({ user }: { user: AdminUser }) {
         </div>
 
         <div className="mb-4 flex items-center justify-between gap-3">
-          <h1 className="m-0 text-[2rem] leading-[1.15]">{userData.name}</h1>
+          <h1 className="m-0 text-3xl leading-tight">{userData.name}</h1>
         </div>
 
         <div className="mt-3 mb-5 grid grid-cols-1 gap-x-3 gap-y-2 md:grid-cols-[160px_minmax(0,1fr)]">
-          <div className="text-left text-[var(--text-color-dim)] md:text-right">
-            User ID
-          </div>
+          <div className={adminDetailLabelClass}>User ID</div>
           <div className="min-w-0 break-words">{userData.id}</div>
 
-          <div className="text-left text-[var(--text-color-dim)] md:text-right">
-            Email
-          </div>
+          <div className={adminDetailLabelClass}>Email</div>
           <div className="min-w-0 break-words">{userData.email}</div>
 
-          <div className="text-left text-[var(--text-color-dim)] md:text-right">
-            Registered
-          </div>
+          <div className={adminDetailLabelClass}>Registered</div>
           <div className="min-w-0 break-words">{`${userData.regdate}`}</div>
 
-          <div className="text-left text-[var(--text-color-dim)] md:text-right">
-            Activated
-          </div>
+          <div className={adminDetailLabelClass}>Activated</div>
           <div className="min-w-0 break-words">
             <Activate user={user} />
           </div>
 
-          <div className="text-left text-[var(--text-color-dim)] md:text-right">
-            Contributor
-          </div>
+          <div className={adminDetailLabelClass}>Contributor</div>
           <div className="min-w-0 break-words">
             <Write user={user} />
           </div>
 
-          <div className="text-left text-[var(--text-color-dim)] md:text-right">
-            Admin
-          </div>
+          <div className={adminDetailLabelClass}>Admin</div>
           <div className="min-w-0 break-words">
             {userData.admin ? "Yes" : "No"}
           </div>
 
-          <div className="text-left text-[var(--text-color-dim)] md:text-right">
-            Discord
-          </div>
+          <div className={adminDetailLabelClass}>Discord</div>
           <div className="min-w-0 break-words">
             {userData.discordLinked
               ? `Linked${userData.discordAccountId ? ` (${userData.discordAccountId})` : ""}`
               : "Not linked"}
           </div>
 
-          <div className="text-left text-[var(--text-color-dim)] md:text-right">
-            Stories role
-          </div>
+          <div className={adminDetailLabelClass}>Stories role</div>
           <div className="min-w-0 break-words">
             {userData.discordStoriesRole ?? "None"}
             {userData.discordStoriesSyncStatus

--- a/src/app/admin/users/[user_id]/user_display.tsx
+++ b/src/app/admin/users/[user_id]/user_display.tsx
@@ -4,12 +4,12 @@ import { useState } from "react";
 import Link from "next/link";
 import Switch from "@/components/ui/switch";
 import Button from "@/components/ui/button";
-import type { AdminUser } from "./schema";
 import {
   adminDetailCardClass,
   adminDetailLabelClass,
   adminDetailPageClass,
-} from "../../adminDetailStyles";
+} from "@/app/admin/adminDetailStyles";
+import type { AdminUser } from "./schema";
 import {
   setUserActivatedAction,
   setUserWriteAction,

--- a/src/app/admin/users/user_list.tsx
+++ b/src/app/admin/users/user_list.tsx
@@ -9,8 +9,11 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Button, {
+  buttonInnerClassName,
+  buttonRootClassName,
+} from "@/components/ui/button";
 import Input from "@/components/ui/input";
-import Button from "@/components/ui/button";
 import { SpinnerBlue } from "@/components/ui/spinner";
 import type { AdminUser } from "./[user_id]/schema";
 
@@ -60,11 +63,11 @@ function buildQueryString(query: string, limit: number, filters: AdminFilters) {
 }
 
 const statusYesClass =
-  "inline-block min-w-[38px] rounded-full bg-[color:color-mix(in_srgb,#21c55d_22%,transparent)] px-2.5 py-0.5 text-center text-[0.82rem] font-bold text-[#0a6b2d]";
+  "inline-block min-w-10 rounded-full bg-[color:color-mix(in_srgb,#21c55d_22%,transparent)] px-2.5 py-0.5 text-center text-sm font-bold text-[#0a6b2d]";
 const statusNoClass =
-  "inline-block min-w-[38px] rounded-full bg-[color:color-mix(in_srgb,#ef4444_20%,transparent)] px-2.5 py-0.5 text-center text-[0.82rem] font-bold text-[#9b1c1c]";
+  "inline-block min-w-10 rounded-full bg-[color:color-mix(in_srgb,#ef4444_20%,transparent)] px-2.5 py-0.5 text-center text-sm font-bold text-[#9b1c1c]";
 const statusInfoClass =
-  "inline-block min-w-[38px] rounded-full bg-[color:color-mix(in_srgb,#3b82f6_18%,transparent)] px-2.5 py-0.5 text-center text-[0.82rem] font-bold text-[#124f9c]";
+  "inline-block min-w-10 rounded-full bg-[color:color-mix(in_srgb,#3b82f6_18%,transparent)] px-2.5 py-0.5 text-center text-sm font-bold text-[#124f9c]";
 
 function getRoleLabel(user: AdminUserList) {
   if (user.admin) return "Admin";
@@ -96,11 +99,16 @@ const tableHeaders: Array<{ label: string; title?: string; key: string }> = [
   { key: "actions", label: "", title: "Actions" },
 ];
 
+const adminTableContainerClass =
+  "relative isolate overflow-auto rounded-xl border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]";
+const adminTableHeadCellClass =
+  "sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-sm uppercase tracking-wide text-[var(--button-color)]";
+
 function ActivatedStatus({ activated }: { activated: boolean | undefined }) {
   if (!activated) {
     return (
       <span
-        className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,#ef4444_16%,transparent)] text-[1rem] font-bold text-[#9b1c1c]"
+        className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,#ef4444_16%,transparent)] text-base font-bold text-[#9b1c1c]"
         title="Not activated"
       >
         -
@@ -110,7 +118,7 @@ function ActivatedStatus({ activated }: { activated: boolean | undefined }) {
 
   return (
     <span
-      className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,#21c55d_18%,transparent)] text-[1.05rem] font-bold text-[#0a6b2d]"
+      className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,#21c55d_18%,transparent)] text-base font-bold text-[#0a6b2d]"
       title="Activated"
     >
       ✓
@@ -224,7 +232,7 @@ export default function UserList({
   }
 
   return (
-    <div className="relative isolate mx-auto my-6 mb-9 box-border w-full max-w-[min(1240px,calc(100vw-48px))] rounded-[18px] border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-[18px] shadow-[0_18px_42px_color-mix(in_srgb,#000_14%,transparent)]">
+    <div className="relative isolate mx-auto my-6 mb-9 box-border w-full max-w-[min(1240px,calc(100vw-48px))] rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
       <div className="flex flex-wrap items-end justify-between gap-4 px-0.5 pb-3">
         <div className="flex flex-wrap items-center gap-3.5">
           <Input
@@ -235,7 +243,7 @@ export default function UserList({
             onKeyDown={handleKeyDown}
           />
           <div className="flex flex-wrap items-center gap-2.5">
-            <label className="inline-flex items-center gap-2 text-[0.95rem] text-[var(--text-color-dim)]">
+            <label className="inline-flex items-center gap-2 text-base text-[var(--text-color-dim)]">
               Activated
               <select
                 className="min-w-[90px] rounded-xl border-2 border-[var(--input-border)] bg-[var(--input-background)] px-2.5 py-1.5 text-[var(--text-color)]"
@@ -249,7 +257,7 @@ export default function UserList({
                 <option value="no">No</option>
               </select>
             </label>
-            <label className="inline-flex items-center gap-2 text-[0.95rem] text-[var(--text-color-dim)]">
+            <label className="inline-flex items-center gap-2 text-base text-[var(--text-color-dim)]">
               Role
               <select
                 className="min-w-[120px] rounded-xl border-2 border-[var(--input-border)] bg-[var(--input-background)] px-2.5 py-1.5 text-[var(--text-color)]"
@@ -281,14 +289,14 @@ export default function UserList({
         </div>
       </div>
 
-      <div className="relative isolate overflow-auto rounded-[14px] border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]">
+      <div className={adminTableContainerClass}>
         <table className="w-max min-w-full border-collapse">
           <thead>
             <tr>
               {tableHeaders.map((header) => (
                 <th
                   key={header.key}
-                  className="sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-[0.84rem] uppercase tracking-[0.03em] text-[var(--button-color)]"
+                  className={adminTableHeadCellClass}
                   title={header.title}
                 >
                   {header.label}
@@ -341,11 +349,14 @@ export default function UserList({
                   </td>
                   <td className="px-4 py-2.5 text-right whitespace-nowrap">
                     <Link
-                      className="inline-flex min-w-[82px] items-center justify-center rounded-[10px] border-b-[3px] border-[var(--button-border)] bg-[var(--button-background)] px-3 py-1.5 font-bold no-underline"
+                      className={buttonRootClassName({
+                        className: "mt-0 inline-block min-w-20 no-underline",
+                      })}
                       href={`/admin/users/${user.id}`}
-                      style={{ color: "#fff" }}
                     >
-                      Open
+                      <span className={buttonInnerClassName({ size: "sm" })}>
+                        Open
+                      </span>
                     </Link>
                   </td>
                 </tr>

--- a/src/app/admin/users/user_list.tsx
+++ b/src/app/admin/users/user_list.tsx
@@ -15,6 +15,10 @@ import Button, {
 } from "@/components/ui/button";
 import Input from "@/components/ui/input";
 import { SpinnerBlue } from "@/components/ui/spinner";
+import {
+  adminTableContainerClass,
+  adminTableHeadCellClass,
+} from "../adminTableStyles";
 import type { AdminUser } from "./[user_id]/schema";
 
 export type AdminUserList = AdminUser & { admin?: boolean; rowKey?: string };
@@ -98,11 +102,6 @@ const tableHeaders: Array<{ label: string; title?: string; key: string }> = [
   { key: "stories", label: "Stories" },
   { key: "actions", label: "", title: "Actions" },
 ];
-
-const adminTableContainerClass =
-  "relative isolate overflow-auto rounded-xl border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)]";
-const adminTableHeadCellClass =
-  "sticky top-0 z-[1] bg-[color:color-mix(in_srgb,var(--button-background)_88%,#fff)] px-3 py-2 text-left text-sm uppercase tracking-wide text-[var(--button-color)]";
 
 function ActivatedStatus({ activated }: { activated: boolean | undefined }) {
   if (!activated) {


### PR DESCRIPTION
## Summary
- Standardized admin page spacing, card shapes, and table chrome across users, languages, courses, and story views.
- Reworked admin header and detail pages to use shared layout constants and more consistent typography.
- Consolidated admin dialog/button usage onto the shared button primitives, including trigger and danger-action styles.
- Refined status chips, table headers, and action columns for a more uniform admin interface.

## Testing
- Not run (PR summary based on code diff only).
- Visual check recommended for admin list pages, detail pages, and edit dialogs at desktop and mobile widths.
- `pnpm run format` not run.
- `pnpm run lint` not run.
- `pnpm typecheck` not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified add/edit dialog trigger for admin actions and clearer "Add"/"Edit" labeling.

* **Style**
  * Refined visual styling across admin pages: updated typography, spacing, padding, shadows, and border radii for consistency.
  * Standardized table headers, container layout, and action column sizing for improved readability and alignment.
  * Harmonized button appearance and dialog form spacing for a more cohesive admin UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->