### PR TITLE
Add self-serve account deletion flow

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as account from "../account.js";
 import type * as adminData from "../adminData.js";
 import type * as adminStoryWrite from "../adminStoryWrite.js";
 import type * as adminWrite from "../adminWrite.js";
@@ -49,6 +50,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  account: typeof account;
   adminData: typeof adminData;
   adminStoryWrite: typeof adminStoryWrite;
   adminWrite: typeof adminWrite;

--- a/convex/account.ts
+++ b/convex/account.ts
@@ -1,0 +1,29 @@
+import { components } from "./_generated/api";
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+import { requireSessionLegacyUserId } from "./lib/authorization";
+
+export const deleteCurrentUser = mutation({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const legacyUserId = await requireSessionLegacyUserId(ctx);
+    const user = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
+      model: "user",
+      where: [{ field: "userId", operator: "eq", value: String(legacyUserId) }],
+    })) as { _id?: string | null } | null;
+
+    if (!user?._id) {
+      throw new Error("Account not found.");
+    }
+
+    await ctx.runMutation(components.betterAuth.adapter.deleteOne, {
+      input: {
+        model: "user",
+        where: [{ field: "_id", value: user._id }],
+      },
+    });
+
+    return null;
+  },
+});

--- a/src/app/(stories)/(main)/profile/actions.ts
+++ b/src/app/(stories)/(main)/profile/actions.ts
@@ -21,3 +21,7 @@ export async function setHideStoryQuestionsPreference(hideQuestions: boolean) {
     secure: process.env.NODE_ENV === "production",
   });
 }
+
+export async function deleteCurrentUserAccount() {
+  await fetchAuthMutation(api.account.deleteCurrentUser, {});
+}

--- a/src/app/(stories)/(main)/profile/profile.tsx
+++ b/src/app/(stories)/(main)/profile/profile.tsx
@@ -740,7 +740,11 @@ export default function Profile({ providers }: { providers: ProfileData }) {
               type="button"
               variant="destructive"
               className="mt-0 min-w-[180px]"
+              disabled={deleteState === "pending"}
               onClick={() => {
+                if (deleteState === "pending") {
+                  return;
+                }
                 if (isShowingDeleteAccount) {
                   closeDeleteAccount();
                 } else {

--- a/src/app/(stories)/(main)/profile/profile.tsx
+++ b/src/app/(stories)/(main)/profile/profile.tsx
@@ -8,8 +8,12 @@ import Input from "@/components/ui/input";
 import Switch from "@/components/ui/switch";
 import { GetIcon } from "@/components/icons";
 import { authClient } from "@/lib/auth-client";
+import { resetPostHogUser } from "@/lib/posthog-user";
 import type { ProfileData } from "./data";
-import { setHideStoryQuestionsPreference } from "./actions";
+import {
+  deleteCurrentUserAccount,
+  setHideStoryQuestionsPreference,
+} from "./actions";
 
 const pageShellClass =
   "mx-auto mb-10 max-w-[860px] rounded-[28px] border border-[color:color-mix(in_srgb,var(--header-border)_60%,transparent)] bg-[color:color-mix(in_srgb,var(--body-background)_94%,white)] p-4 shadow-[0_18px_56px_color-mix(in_srgb,#000_10%,transparent)] sm:p-6";
@@ -227,9 +231,17 @@ export default function Profile({ providers }: { providers: ProfileData }) {
     "idle" | "pending" | "success" | "error"
   >("idle");
   const [storyQuestionsError, setStoryQuestionsError] = React.useState("");
+  const [isShowingDeleteAccount, setIsShowingDeleteAccount] =
+    React.useState(false);
+  const [deleteConfirmation, setDeleteConfirmation] = React.useState("");
+  const [deleteState, setDeleteState] = React.useState<
+    "idle" | "pending" | "error"
+  >("idle");
+  const [deleteError, setDeleteError] = React.useState("");
   const avatarName =
     sessionUser?.name?.trim() || savedUsername || providers.name || "U";
   const avatarImage = sessionUser?.image ?? providers.image;
+  const deleteConfirmationTarget = savedUsername.trim() || providers.email;
 
   React.useEffect(() => {
     const storedPendingEmail = window.localStorage.getItem(
@@ -272,6 +284,20 @@ export default function Profile({ providers }: { providers: ProfileData }) {
     setEmailState("idle");
     setEmailError("");
     setIsEditingEmail(false);
+  }
+
+  function openDeleteAccount() {
+    setDeleteConfirmation("");
+    setDeleteState("idle");
+    setDeleteError("");
+    setIsShowingDeleteAccount(true);
+  }
+
+  function closeDeleteAccount() {
+    setDeleteConfirmation("");
+    setDeleteState("idle");
+    setDeleteError("");
+    setIsShowingDeleteAccount(false);
   }
 
   async function requestPasswordReset() {
@@ -389,6 +415,45 @@ export default function Profile({ providers }: { providers: ProfileData }) {
           "Could not update your story question preference.",
       );
     }
+  }
+
+  async function removeAccount() {
+    if (deleteState === "pending") return;
+
+    if (deleteConfirmation.trim() !== deleteConfirmationTarget) {
+      setDeleteState("error");
+      setDeleteError(`Type ${deleteConfirmationTarget} to confirm.`);
+      return;
+    }
+
+    const confirmed = window.confirm(
+      "Delete your account now? This will remove your sign-in account and log you out.",
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setDeleteState("pending");
+    setDeleteError("");
+
+    try {
+      await deleteCurrentUserAccount();
+    } catch (error) {
+      setDeleteState("error");
+      setDeleteError(
+        (error as Error)?.message || "Could not delete your account.",
+      );
+      return;
+    }
+
+    window.localStorage.removeItem("profile_pending_email_change");
+
+    try {
+      await authClient.signOut();
+    } catch {}
+
+    resetPostHogUser();
+    window.location.href = "/";
   }
 
   return (
@@ -664,15 +729,82 @@ export default function Profile({ providers }: { providers: ProfileData }) {
         </section>
 
         <section className={`${cardClass} mt-5`}>
-          <p className={eyebrowClass}>Delete account</p>
-          <h2 className="mt-1 text-[1.45rem] font-bold leading-[1.1]">
-            Manual removal
-          </h2>
-          <p className="mb-0 mt-2 text-[0.96rem] leading-[1.65] text-[var(--title-color-dim)]">
-            If you want to delete your account, contact us on{" "}
-            <Link href="https://discord.gg/4NGVScARR3">Discord</Link>. We
-            typically delete your username and email address upon request.
+          <div className="flex flex-col gap-2 border-b border-[color:color-mix(in_srgb,#e89a9a_35%,transparent)] pb-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className={eyebrowClass}>Delete account</p>
+              <h2 className="mt-1 text-[1.45rem] font-bold leading-[1.1]">
+                Permanently delete your account
+              </h2>
+            </div>
+            <Button
+              type="button"
+              variant="destructive"
+              className="mt-0 min-w-[180px]"
+              onClick={() => {
+                if (isShowingDeleteAccount) {
+                  closeDeleteAccount();
+                } else {
+                  openDeleteAccount();
+                }
+              }}
+            >
+              {isShowingDeleteAccount ? "Close" : "Delete account"}
+            </Button>
+          </div>
+          <p className="mb-0 mt-3 text-[0.96rem] leading-[1.65] text-[var(--title-color-dim)]">
+            Remove your Duostories account and sign out immediately. This action
+            cannot be undone.
           </p>
+          {isShowingDeleteAccount ? (
+            <div className="mt-4 rounded-[20px] border border-[color:color-mix(in_srgb,#e89a9a_45%,transparent)] bg-[color:color-mix(in_srgb,#f7d7d7_28%,var(--body-background))] p-4">
+              <p className={labelClass}>Confirm deletion</p>
+              <p className="mt-0 text-[0.92rem] text-[var(--title-color-dim)]">
+                Type <strong>{deleteConfirmationTarget}</strong> to confirm that
+                you want to permanently delete this account.
+              </p>
+              <Input
+                value={deleteConfirmation}
+                onChange={(e) => setDeleteConfirmation(e.target.value)}
+                placeholder={deleteConfirmationTarget}
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                data-cy="profile-delete-confirmation"
+              />
+              {deleteState === "error" ? (
+                <span
+                  className={errorMessageClass}
+                  data-cy="profile-delete-error"
+                >
+                  {deleteError}
+                </span>
+              ) : null}
+              <div className="mt-4 flex flex-wrap gap-3">
+                <Button
+                  type="button"
+                  variant="destructive"
+                  data-cy="profile-delete-account"
+                  onClick={removeAccount}
+                  disabled={
+                    deleteState === "pending" ||
+                    deleteConfirmation.trim() !== deleteConfirmationTarget
+                  }
+                >
+                  {deleteState === "pending"
+                    ? "Deleting..."
+                    : "Permanently delete my account"}
+                </Button>
+                <Button
+                  type="button"
+                  className="mt-0 min-w-[120px]"
+                  onClick={closeDeleteAccount}
+                  disabled={deleteState === "pending"}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : null}
         </section>
       </div>
     </>


### PR DESCRIPTION
## Summary
- Added a Convex mutation to delete the current authenticated user from the Better Auth user table.
- Replaced the manual Discord-based deletion instructions with an in-app self-serve deletion UI in the profile page.
- Added confirmation gating, error handling, sign-out, PostHog user reset, and redirect after successful deletion.

## Testing
- Not run (not requested).
- Reviewed the updated profile deletion flow for confirmation, pending, and error states.
- Verified the new Convex mutation is exposed through the generated API surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full "Delete account" flow with a destructive toggle, typed confirmation, and final confirm/cancel actions so users can permanently delete their accounts.
  * On successful deletion: clears pending email-change data, signs the user out, resets analytics tracking, and redirects to the home page.
* **UX**
  * Shows deletion status and error messages to guide users through the process and prevent accidental removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->