### PR TITLE
Remove PostHog gating from next-story action

### DIFF
--- a/src/app/(stories)/story/[story_id]/story_wrapper.tsx
+++ b/src/app/(stories)/story/[story_id]/story_wrapper.tsx
@@ -15,10 +15,6 @@ import {
   type PostHogUser,
 } from "@/lib/posthog-user";
 
-const STORY_END_NEXT_FLAG_KEY =
-  process.env.NEXT_PUBLIC_POSTHOG_STORY_END_NEXT_FLAG_KEY ?? "";
-const HAS_POSTHOG = Boolean(process.env.NEXT_PUBLIC_POSTHOG_KEY);
-
 export default function StoryWrapper({
   story,
   hideStoryQuestions,
@@ -46,9 +42,6 @@ export default function StoryWrapper({
   const [hideNonHighlighted, setHideNonHighlighted] = React.useState(false);
   const trackedStoryStart = React.useRef(false);
   const completionInFlight = React.useRef(false);
-  const [isNextStoryEnabled, setIsNextStoryEnabled] = React.useState(
-    !HAS_POSTHOG || STORY_END_NEXT_FLAG_KEY.length === 0,
-  );
   const { data: session } = authClient.useSession();
   const sessionUser = (session?.user ?? null) as PostHogUser | null;
   const role = typeof sessionUser?.role === "string" ? sessionUser.role : null;
@@ -71,8 +64,7 @@ export default function StoryWrapper({
         }
       : "skip",
   );
-  const showNextStoryAction =
-    isNextStoryEnabled && Boolean(nextStep?.nextStoryId);
+  const showNextStoryAction = Boolean(nextStep?.nextStoryId);
   const nextStoryPreview = useQuery(
     api.storyRead.getStoryPreviewByLegacyId,
     showNextStoryAction && nextStep?.nextStoryId
@@ -109,28 +101,6 @@ export default function StoryWrapper({
     trackedStoryStart.current = true;
     void captureStoryEvent("story_started");
   }, [captureStoryEvent]);
-
-  React.useEffect(() => {
-    if (!HAS_POSTHOG || STORY_END_NEXT_FLAG_KEY.length === 0) {
-      setIsNextStoryEnabled(true);
-      return;
-    }
-
-    const update = () => {
-      setIsNextStoryEnabled(
-        posthog.isFeatureEnabled(STORY_END_NEXT_FLAG_KEY) === true,
-      );
-    };
-
-    update();
-    const unsubscribe = posthog.onFeatureFlags(update);
-
-    return () => {
-      if (typeof unsubscribe === "function") {
-        unsubscribe();
-      }
-    };
-  }, []);
 
   const finishedLabel = showNextStoryAction
     ? "Next story"


### PR DESCRIPTION
## Summary
- Removed the PostHog feature-flag gate around the story end "Next story" action.
- Simplified `StoryWrapper` so the next-story CTA now renders whenever `nextStep.nextStoryId` exists.
- Deleted the client-side feature flag state and subscription logic tied to `NEXT_PUBLIC_POSTHOG_STORY_END_NEXT_FLAG_KEY`.

## Testing
- Not run (PR content only).
- Confirmed the diff is limited to `src/app/(stories)/story/[story_id]/story_wrapper.tsx`.
- Reviewed the control flow to ensure `nextStoryPreview` still depends only on `nextStep.nextStoryId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the "Next story" action logic. The feature is now gated solely by the presence of a next story, eliminating external gate dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->