### PR TITLE
[codex] Add audio cutter normalization

### DIFF
--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -13,6 +13,10 @@ import {
 import Regions from "wavesurfer.js/dist/plugins/regions.js";
 import PlayAudio from "@/components/PlayAudio";
 import Input from "@/components/ui/input";
+import {
+  decodeAudioData,
+  normalizeAudioBufferPeak,
+} from "@/lib/audio/client-audio-processing";
 import { getLamejsModule } from "@/lib/lamejs-compat";
 import {
   Dialog,
@@ -791,17 +795,6 @@ async function encodeSegmentAsMp3(
   );
 }
 
-async function decodeAudioFile(file: File) {
-  const audioContext = new AudioContext({ latencyHint: "interactive" });
-  try {
-    const arrayBuffer = await file.arrayBuffer();
-    const decoded = await audioContext.decodeAudioData(arrayBuffer.slice(0));
-    return decoded;
-  } finally {
-    await audioContext.close();
-  }
-}
-
 export default function AudioCutterDialog({
   open,
   onOpenChange,
@@ -837,6 +830,7 @@ export default function AudioCutterDialog({
   const [audioError, setAudioError] = React.useState<string | null>(null);
   const [exportError, setExportError] = React.useState<string | null>(null);
   const [isLoadingAudio, setIsLoadingAudio] = React.useState(false);
+  const [isNormalizingAudio, setIsNormalizingAudio] = React.useState(false);
   const [isExportingSegments, setIsExportingSegments] = React.useState(false);
   const [detectDialogOpen, setDetectDialogOpen] = React.useState(false);
   const [detectionSettings, setDetectionSettings] =
@@ -899,6 +893,7 @@ export default function AudioCutterDialog({
     setAudioError(null);
     setExportError(null);
     setIsLoadingAudio(false);
+    setIsNormalizingAudio(false);
     setIsExportingSegments(false);
     setDetectDialogOpen(false);
     setAudioBuffer(null);
@@ -1563,6 +1558,14 @@ export default function AudioCutterDialog({
     runAutoDetect();
   }, [audioBuffer, runAutoDetect, waveformReady]);
 
+  const updateLoadedAudio = React.useCallback((nextBuffer: AudioBuffer) => {
+    setAudioBuffer(nextBuffer);
+    setAudioUrl((currentUrl) => {
+      if (currentUrl) URL.revokeObjectURL(currentUrl);
+      return URL.createObjectURL(audioBufferToWavBlob(nextBuffer));
+    });
+  }, []);
+
   const onFileChange = React.useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
@@ -1592,13 +1595,9 @@ export default function AudioCutterDialog({
       });
 
       try {
-        const decoded = await decodeAudioFile(file);
+        const decoded = await decodeAudioData(await file.arrayBuffer());
         if (requestToken !== autoDetectRequestRef.current) return;
-        setAudioBuffer(decoded);
-        setAudioUrl((currentUrl) => {
-          if (currentUrl) URL.revokeObjectURL(currentUrl);
-          return URL.createObjectURL(audioBufferToWavBlob(decoded));
-        });
+        updateLoadedAudio(decoded);
       } catch (error) {
         if (requestToken !== autoDetectRequestRef.current) return;
         setAudioBuffer(null);
@@ -1611,8 +1610,29 @@ export default function AudioCutterDialog({
         }
       }
     },
-    [typedRegionsPlugin],
+    [typedRegionsPlugin, updateLoadedAudio],
   );
+
+  const onNormalizeAudio = React.useCallback(async () => {
+    if (!audioBuffer || isNormalizingAudio) return;
+
+    setIsNormalizingAudio(true);
+    setAudioError(null);
+    setExportError(null);
+
+    try {
+      const normalized = normalizeAudioBufferPeak(audioBuffer);
+      if (normalized.changed) {
+        updateLoadedAudio(normalized.buffer);
+      }
+    } catch (error) {
+      setAudioError(
+        getErrorMessage(error, "Could not normalize the loaded audio."),
+      );
+    } finally {
+      setIsNormalizingAudio(false);
+    }
+  }, [audioBuffer, isNormalizingAudio, updateLoadedAudio]);
 
   const onPlayPause = React.useCallback(() => {
     wavesurfer?.playPause();
@@ -1824,6 +1844,21 @@ export default function AudioCutterDialog({
         >
           <UploadIcon className="h-4 w-4" />
           {isLoadingAudio ? "Reading audio..." : "Upload long audio"}
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-[var(--color_base_border)] bg-[var(--body-background-faint)] px-3 text-sm font-medium leading-none transition-colors hover:bg-[var(--color_base_background)] disabled:cursor-default disabled:opacity-70"
+          onClick={() => {
+            void onNormalizeAudio();
+          }}
+          disabled={!audioBuffer || isNormalizingAudio}
+          title={
+            audioBuffer
+              ? "Normalize the loaded source audio"
+              : "Load audio first"
+          }
+        >
+          {isNormalizingAudio ? "Normalizing..." : "Normalize audio"}
         </button>
         <button
           type="button"

--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -1584,6 +1584,7 @@ export default function AudioCutterDialog({
       autoDetectRequestRef.current = requestToken;
       normalizeOperationRef.current += 1;
       setIsLoadingAudio(true);
+      setIsNormalizingAudio(false);
       setAudioError(null);
       setExportError(null);
       setAudioFile(file);

--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -827,6 +827,7 @@ export default function AudioCutterDialog({
   const activeDraftRegionIdRef = React.useRef<string | null>(null);
   const pendingRegionIdsRef = React.useRef<Set<string>>(new Set());
   const autoDetectRequestRef = React.useRef(0);
+  const normalizeOperationRef = React.useRef(0);
   const lastHandledAutoDetectRequestRef = React.useRef(0);
   const [audioFile, setAudioFile] = React.useState<File | null>(null);
   const [audioUrl, setAudioUrl] = React.useState("");
@@ -892,6 +893,7 @@ export default function AudioCutterDialog({
   });
 
   const resetState = React.useCallback(() => {
+    normalizeOperationRef.current += 1;
     activeDraftRegionIdRef.current = null;
     pendingRegionIdsRef.current.clear();
     typedRegionsPlugin.clearRegions();
@@ -1580,6 +1582,7 @@ export default function AudioCutterDialog({
 
       const requestToken = autoDetectRequestRef.current + 1;
       autoDetectRequestRef.current = requestToken;
+      normalizeOperationRef.current += 1;
       setIsLoadingAudio(true);
       setAudioError(null);
       setExportError(null);
@@ -1629,22 +1632,31 @@ export default function AudioCutterDialog({
       return;
     }
 
+    const normalizeToken = normalizeOperationRef.current + 1;
+    normalizeOperationRef.current = normalizeToken;
     setIsNormalizingAudio(true);
     setAudioError(null);
     setExportError(null);
 
     try {
       await waitForNextAnimationFrame();
+      if (normalizeToken !== normalizeOperationRef.current) return;
       const normalized = normalizeAudioBufferPeak(audioBuffer);
-      if (normalized.changed) {
+      if (
+        normalized.changed &&
+        normalizeToken === normalizeOperationRef.current
+      ) {
         updateLoadedAudio(normalized.buffer);
       }
     } catch (error) {
+      if (normalizeToken !== normalizeOperationRef.current) return;
       setAudioError(
         getErrorMessage(error, "Could not normalize the loaded audio."),
       );
     } finally {
-      setIsNormalizingAudio(false);
+      if (normalizeToken === normalizeOperationRef.current) {
+        setIsNormalizingAudio(false);
+      }
     }
   }, [
     audioBuffer,

--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -167,6 +167,12 @@ function getErrorMessage(error: unknown, fallback: string) {
   return error instanceof Error && error.message ? error.message : fallback;
 }
 
+function waitForNextAnimationFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
 function createSegmentId() {
   return `segment-${Math.random().toString(36).slice(2, 10)}`;
 }
@@ -1614,13 +1620,21 @@ export default function AudioCutterDialog({
   );
 
   const onNormalizeAudio = React.useCallback(async () => {
-    if (!audioBuffer || isNormalizingAudio) return;
+    if (
+      !audioBuffer ||
+      isNormalizingAudio ||
+      isExportingSegments ||
+      isLoadingAudio
+    ) {
+      return;
+    }
 
     setIsNormalizingAudio(true);
     setAudioError(null);
     setExportError(null);
 
     try {
+      await waitForNextAnimationFrame();
       const normalized = normalizeAudioBufferPeak(audioBuffer);
       if (normalized.changed) {
         updateLoadedAudio(normalized.buffer);
@@ -1632,7 +1646,13 @@ export default function AudioCutterDialog({
     } finally {
       setIsNormalizingAudio(false);
     }
-  }, [audioBuffer, isNormalizingAudio, updateLoadedAudio]);
+  }, [
+    audioBuffer,
+    isExportingSegments,
+    isLoadingAudio,
+    isNormalizingAudio,
+    updateLoadedAudio,
+  ]);
 
   const onPlayPause = React.useCallback(() => {
     wavesurfer?.playPause();
@@ -1851,7 +1871,12 @@ export default function AudioCutterDialog({
           onClick={() => {
             void onNormalizeAudio();
           }}
-          disabled={!audioBuffer || isNormalizingAudio}
+          disabled={
+            !audioBuffer ||
+            isNormalizingAudio ||
+            isExportingSegments ||
+            isLoadingAudio
+          }
           title={
             audioBuffer
               ? "Normalize the loaded source audio"

--- a/src/app/editor/story/[story]/bulk-audio-editor.tsx
+++ b/src/app/editor/story/[story]/bulk-audio-editor.tsx
@@ -263,7 +263,6 @@ async function expandUploadFiles(files: File[]) {
 
   return expandedFiles;
 }
-
 function rowLabel(item: BulkAudioEditorItem) {
   return item.type === "HEADER" ? "Header" : `Line ${item.order}`;
 }

--- a/src/lib/audio/client-audio-processing.ts
+++ b/src/lib/audio/client-audio-processing.ts
@@ -1,0 +1,160 @@
+import { getLamejsModule } from "@/lib/lamejs-compat";
+
+const DEFAULT_NORMALIZATION_TARGET_PEAK = 0.97;
+const MP3_BITRATE_KBPS = 128;
+const MP3_SAMPLE_BLOCK_SIZE = 1152;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function float32ToInt16Sample(sample: number) {
+  const clampedSample = clamp(sample, -1, 1);
+  return clampedSample < 0
+    ? Math.round(clampedSample * 0x8000)
+    : Math.round(clampedSample * 0x7fff);
+}
+
+function toPlainArrayBuffer(view: Uint8Array | Int8Array) {
+  const arrayBuffer = new ArrayBuffer(view.byteLength);
+  new Uint8Array(arrayBuffer).set(
+    new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+  );
+  return arrayBuffer;
+}
+
+export async function decodeAudioData(arrayBuffer: ArrayBuffer) {
+  const audioContext = new AudioContext({ latencyHint: "interactive" });
+  try {
+    return await audioContext.decodeAudioData(arrayBuffer.slice(0));
+  } finally {
+    await audioContext.close();
+  }
+}
+
+export async function encodeAudioBufferAsMp3(buffer: AudioBuffer) {
+  const { Mp3Encoder } = await getLamejsModule();
+  const sampleRate = buffer.sampleRate;
+  const channelCount = Math.min(2, Math.max(1, buffer.numberOfChannels));
+  const encoder = new Mp3Encoder(channelCount, sampleRate, MP3_BITRATE_KBPS);
+  const channelData = Array.from({ length: channelCount }, (_, index) =>
+    buffer.getChannelData(index),
+  );
+  const mp3Chunks: Uint8Array[] = [];
+
+  for (
+    let frameOffset = 0;
+    frameOffset < buffer.length;
+    frameOffset += MP3_SAMPLE_BLOCK_SIZE
+  ) {
+    const chunkFrameCount = Math.min(
+      MP3_SAMPLE_BLOCK_SIZE,
+      buffer.length - frameOffset,
+    );
+    const leftChunk = new Int16Array(chunkFrameCount);
+    const rightChunk =
+      channelCount > 1 ? new Int16Array(chunkFrameCount) : null;
+
+    for (let chunkIndex = 0; chunkIndex < chunkFrameCount; chunkIndex += 1) {
+      const sourceFrameIndex = frameOffset + chunkIndex;
+      leftChunk[chunkIndex] = float32ToInt16Sample(
+        channelData[0]?.[sourceFrameIndex] ?? 0,
+      );
+      if (rightChunk) {
+        rightChunk[chunkIndex] = float32ToInt16Sample(
+          channelData[1]?.[sourceFrameIndex] ?? 0,
+        );
+      }
+    }
+
+    const encodedChunk = rightChunk
+      ? encoder.encodeBuffer(leftChunk, rightChunk)
+      : encoder.encodeBuffer(leftChunk);
+    if (encodedChunk.length > 0) {
+      mp3Chunks.push(Uint8Array.from(encodedChunk));
+    }
+  }
+
+  const flushChunk = encoder.flush();
+  if (flushChunk.length > 0) {
+    mp3Chunks.push(Uint8Array.from(flushChunk));
+  }
+
+  return new Blob(
+    mp3Chunks.map((chunk) => toPlainArrayBuffer(chunk)),
+    {
+      type: "audio/mpeg",
+    },
+  );
+}
+
+export function normalizeAudioBufferPeak(
+  buffer: AudioBuffer,
+  targetPeak = DEFAULT_NORMALIZATION_TARGET_PEAK,
+) {
+  let peak = 0;
+
+  for (
+    let channelIndex = 0;
+    channelIndex < buffer.numberOfChannels;
+    channelIndex += 1
+  ) {
+    const channel = buffer.getChannelData(channelIndex);
+    for (let sampleIndex = 0; sampleIndex < channel.length; sampleIndex += 1) {
+      peak = Math.max(peak, Math.abs(channel[sampleIndex] ?? 0));
+    }
+  }
+
+  if (!Number.isFinite(peak) || peak <= 0) {
+    return {
+      buffer,
+      changed: false,
+      peak: 0,
+      gain: 1,
+    };
+  }
+
+  const safeTargetPeak = clamp(targetPeak, 0.01, 0.999);
+  const gain = safeTargetPeak / peak;
+  if (Math.abs(gain - 1) < 0.01) {
+    return {
+      buffer,
+      changed: false,
+      peak,
+      gain: 1,
+    };
+  }
+
+  const normalizedBuffer = new AudioBuffer({
+    length: buffer.length,
+    numberOfChannels: buffer.numberOfChannels,
+    sampleRate: buffer.sampleRate,
+  });
+
+  for (
+    let channelIndex = 0;
+    channelIndex < buffer.numberOfChannels;
+    channelIndex += 1
+  ) {
+    const sourceChannel = buffer.getChannelData(channelIndex);
+    const nextChannel = normalizedBuffer.getChannelData(channelIndex);
+    for (
+      let sampleIndex = 0;
+      sampleIndex < sourceChannel.length;
+      sampleIndex += 1
+    ) {
+      nextChannel[sampleIndex] = clamp(
+        (sourceChannel[sampleIndex] ?? 0) * gain,
+        -1,
+        1,
+      );
+    }
+  }
+
+  return {
+    buffer: normalizedBuffer,
+    changed: true,
+    peak,
+    gain,
+  };
+}

--- a/src/lib/audio/client-audio-processing.ts
+++ b/src/lib/audio/client-audio-processing.ts
@@ -114,7 +114,13 @@ export function normalizeAudioBufferPeak(
     };
   }
 
-  const safeTargetPeak = clamp(targetPeak, 0.01, 0.999);
+  const safeTargetPeak = clamp(
+    Number.isFinite(targetPeak)
+      ? targetPeak
+      : DEFAULT_NORMALIZATION_TARGET_PEAK,
+    0.01,
+    0.999,
+  );
   const gain = safeTargetPeak / peak;
   if (Math.abs(gain - 1) < 0.01) {
     return {


### PR DESCRIPTION
## What changed
Adds a `Normalize audio` action to the audio cutter so contributors can normalize the loaded source recording before detecting cuts or exporting staged MP3 segments.

## Why
The normalization request belongs in the cutter workflow, where a single long source recording is loaded, previewed, segmented, and exported. Putting it there ensures the waveform preview and all generated clips use the same normalized source buffer.

## User impact
Contributors can load a long recording in the cutter, click `Normalize audio`, then continue with silence detection, manual trimming, and clip export using the normalized source.

## Root cause
The earlier implementation put normalization in the bulk upload editor instead of the audio cutter, which did not match the intended workflow.

## Validation
- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Normalize audio" button in the audio cutter with a "Normalizing..." state and safeguards to prevent use during other long-running actions.

* **Improvements**
  * Centralized client-side audio decoding, peak normalization and MP3 export for more consistent loading, processing and exporting.
  * UI now reflects loading, export and normalization states.

* **Bug Fixes**
  * Reset now cancels pending normalization and clears related UI indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->