### PR TITLE
[codex] Guard transcript waveform scroll sync

### DIFF
--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -826,6 +826,12 @@ export default function AudioCutterDialog({
   >({});
   const suppressTranscriptAutoScrollRef = React.useRef(false);
   const transcriptAutoScrollLockTimeoutRef = React.useRef<number | null>(null);
+  const transcriptAutoScrollLockContainerRef = React.useRef<HTMLElement | null>(
+    null,
+  );
+  const transcriptAutoScrollLockScrollListenerRef = React.useRef<
+    (() => void) | null
+  >(null);
   const isSyncingRegionsRef = React.useRef(false);
   const activeDraftRegionIdRef = React.useRef<string | null>(null);
   const pendingRegionIdsRef = React.useRef<Set<string>>(new Set());
@@ -895,22 +901,64 @@ export default function AudioCutterDialog({
     plugins: React.useMemo(() => [regionsPlugin], [regionsPlugin]),
   });
 
+  const releaseTranscriptAutoScrollLock = React.useCallback(() => {
+    const lockContainer = transcriptAutoScrollLockContainerRef.current;
+    const lockScrollListener =
+      transcriptAutoScrollLockScrollListenerRef.current;
+
+    if (lockContainer && lockScrollListener) {
+      lockContainer.removeEventListener("scroll", lockScrollListener);
+    }
+
+    transcriptAutoScrollLockContainerRef.current = null;
+    transcriptAutoScrollLockScrollListenerRef.current = null;
+    suppressTranscriptAutoScrollRef.current = false;
+  }, []);
+
+  const scheduleTranscriptAutoScrollUnlock = React.useCallback(() => {
+    if (transcriptAutoScrollLockTimeoutRef.current !== null) {
+      window.clearTimeout(transcriptAutoScrollLockTimeoutRef.current);
+    }
+    transcriptAutoScrollLockTimeoutRef.current = window.setTimeout(() => {
+      transcriptAutoScrollLockTimeoutRef.current = null;
+      releaseTranscriptAutoScrollLock();
+    }, WAVEFORM_TO_TRANSCRIPT_SYNC_LOCK_MS);
+  }, [releaseTranscriptAutoScrollLock]);
+
   const clearTranscriptAutoScrollLock = React.useCallback(() => {
     if (transcriptAutoScrollLockTimeoutRef.current !== null) {
       window.clearTimeout(transcriptAutoScrollLockTimeoutRef.current);
       transcriptAutoScrollLockTimeoutRef.current = null;
     }
-    suppressTranscriptAutoScrollRef.current = false;
-  }, []);
+    releaseTranscriptAutoScrollLock();
+  }, [releaseTranscriptAutoScrollLock]);
 
-  const lockTranscriptAutoScroll = React.useCallback(() => {
-    clearTranscriptAutoScrollLock();
-    suppressTranscriptAutoScrollRef.current = true;
-    transcriptAutoScrollLockTimeoutRef.current = window.setTimeout(() => {
-      suppressTranscriptAutoScrollRef.current = false;
-      transcriptAutoScrollLockTimeoutRef.current = null;
-    }, WAVEFORM_TO_TRANSCRIPT_SYNC_LOCK_MS);
-  }, [clearTranscriptAutoScrollLock]);
+  const lockTranscriptAutoScroll = React.useCallback(
+    (scrollContainer: HTMLElement | null) => {
+      clearTranscriptAutoScrollLock();
+      suppressTranscriptAutoScrollRef.current = true;
+
+      if (scrollContainer) {
+        const extendTranscriptAutoScrollLock = () => {
+          scheduleTranscriptAutoScrollUnlock();
+        };
+
+        transcriptAutoScrollLockContainerRef.current = scrollContainer;
+        transcriptAutoScrollLockScrollListenerRef.current =
+          extendTranscriptAutoScrollLock;
+        scrollContainer.addEventListener(
+          "scroll",
+          extendTranscriptAutoScrollLock,
+          {
+            passive: true,
+          },
+        );
+      }
+
+      scheduleTranscriptAutoScrollUnlock();
+    },
+    [clearTranscriptAutoScrollLock, scheduleTranscriptAutoScrollUnlock],
+  );
 
   const resetState = React.useCallback(() => {
     clearTranscriptAutoScrollLock();
@@ -1735,7 +1783,7 @@ export default function AudioCutterDialog({
         scrollContainer.scrollWidth - scrollContainer.clientWidth,
       );
 
-      lockTranscriptAutoScroll();
+      lockTranscriptAutoScroll(scrollContainer);
       scrollContainer.scrollTo({
         left: clamp(centeredLeftPx, 0, maxScrollLeft),
         behavior: "smooth",

--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -32,6 +32,7 @@ const WAVEFORM_ZOOM_STEP = 24;
 const DEFAULT_SEGMENT_LENGTH_SECONDS = 1.8;
 const MIN_SEGMENT_LENGTH_SECONDS = 0.25;
 const MIN_PERSISTED_NEW_SEGMENT_SECONDS = 0.1;
+const WAVEFORM_TO_TRANSCRIPT_SYNC_LOCK_MS = 700;
 const SILENCE_WINDOW_SECONDS = 0.02;
 const DEFAULT_DETECTION_MIN_SILENCE_SECONDS = 1;
 const DEFAULT_DETECTION_START_BUFFER_SECONDS = 0.04;
@@ -823,6 +824,8 @@ export default function AudioCutterDialog({
   const transcriptRowRefs = React.useRef<
     Record<number, HTMLButtonElement | null>
   >({});
+  const suppressTranscriptAutoScrollRef = React.useRef(false);
+  const transcriptAutoScrollLockTimeoutRef = React.useRef<number | null>(null);
   const isSyncingRegionsRef = React.useRef(false);
   const activeDraftRegionIdRef = React.useRef<string | null>(null);
   const pendingRegionIdsRef = React.useRef<Set<string>>(new Set());
@@ -892,7 +895,25 @@ export default function AudioCutterDialog({
     plugins: React.useMemo(() => [regionsPlugin], [regionsPlugin]),
   });
 
+  const clearTranscriptAutoScrollLock = React.useCallback(() => {
+    if (transcriptAutoScrollLockTimeoutRef.current !== null) {
+      window.clearTimeout(transcriptAutoScrollLockTimeoutRef.current);
+      transcriptAutoScrollLockTimeoutRef.current = null;
+    }
+    suppressTranscriptAutoScrollRef.current = false;
+  }, []);
+
+  const lockTranscriptAutoScroll = React.useCallback(() => {
+    clearTranscriptAutoScrollLock();
+    suppressTranscriptAutoScrollRef.current = true;
+    transcriptAutoScrollLockTimeoutRef.current = window.setTimeout(() => {
+      suppressTranscriptAutoScrollRef.current = false;
+      transcriptAutoScrollLockTimeoutRef.current = null;
+    }, WAVEFORM_TO_TRANSCRIPT_SYNC_LOCK_MS);
+  }, [clearTranscriptAutoScrollLock]);
+
   const resetState = React.useCallback(() => {
+    clearTranscriptAutoScrollLock();
     normalizeOperationRef.current += 1;
     activeDraftRegionIdRef.current = null;
     pendingRegionIdsRef.current.clear();
@@ -920,7 +941,7 @@ export default function AudioCutterDialog({
       if (currentUrl) URL.revokeObjectURL(currentUrl);
       return "";
     });
-  }, [typedRegionsPlugin]);
+  }, [clearTranscriptAutoScrollLock, typedRegionsPlugin]);
 
   React.useEffect(() => {
     if (!open) {
@@ -930,9 +951,10 @@ export default function AudioCutterDialog({
 
   React.useEffect(() => {
     return () => {
+      clearTranscriptAutoScrollLock();
       if (audioUrl) URL.revokeObjectURL(audioUrl);
     };
-  }, [audioUrl]);
+  }, [audioUrl, clearTranscriptAutoScrollLock]);
 
   React.useEffect(() => {
     setLabelsById((current) => {
@@ -1281,16 +1303,30 @@ export default function AudioCutterDialog({
     const resizeObserver = new ResizeObserver(() => {
       updateViewportRange();
     });
+    const onUserWaveformInteraction = () => {
+      clearTranscriptAutoScrollLock();
+    };
 
     updateViewportRange();
     scrollContainer.addEventListener("scroll", onScroll, { passive: true });
+    scrollContainer.addEventListener("pointerdown", onUserWaveformInteraction, {
+      passive: true,
+    });
+    scrollContainer.addEventListener("wheel", onUserWaveformInteraction, {
+      passive: true,
+    });
     resizeObserver.observe(scrollContainer);
 
     return () => {
       scrollContainer.removeEventListener("scroll", onScroll);
+      scrollContainer.removeEventListener(
+        "pointerdown",
+        onUserWaveformInteraction,
+      );
+      scrollContainer.removeEventListener("wheel", onUserWaveformInteraction);
       resizeObserver.disconnect();
     };
-  }, [updateViewportRange, wavesurfer]);
+  }, [clearTranscriptAutoScrollLock, updateViewportRange, wavesurfer]);
 
   const selectedSegmentIndex = React.useMemo(
     () =>
@@ -1316,6 +1352,8 @@ export default function AudioCutterDialog({
   }, [sortedSegments, viewportRange.end, viewportRange.start]);
 
   React.useEffect(() => {
+    if (suppressTranscriptAutoScrollRef.current) return;
+
     const activeIndexes = [...visibleSegmentIndexes].sort(
       (left, right) => left - right,
     );
@@ -1671,13 +1709,49 @@ export default function AudioCutterDialog({
     wavesurfer?.playPause();
   }, [wavesurfer]);
 
+  const scrollWaveformToSegment = React.useCallback(
+    (segment: Segment) => {
+      if (!waveformReady || zoomPxPerSec <= 0) return;
+
+      const scrollContainer =
+        getWaveformScrollElement(wavesurfer) ?? scrollContainerRef.current;
+      if (!scrollContainer) return;
+
+      const segmentStartPx = segment.start * zoomPxPerSec;
+      const segmentEndPx = segment.end * zoomPxPerSec;
+      const viewportStartPx = scrollContainer.scrollLeft;
+      const viewportEndPx = viewportStartPx + scrollContainer.clientWidth;
+
+      if (segmentStartPx >= viewportStartPx && segmentEndPx <= viewportEndPx) {
+        return;
+      }
+
+      const segmentWidthPx = segmentEndPx - segmentStartPx;
+      const centeredLeftPx =
+        segmentStartPx -
+        Math.max(0, (scrollContainer.clientWidth - segmentWidthPx) / 2);
+      const maxScrollLeft = Math.max(
+        0,
+        scrollContainer.scrollWidth - scrollContainer.clientWidth,
+      );
+
+      lockTranscriptAutoScroll();
+      scrollContainer.scrollTo({
+        left: clamp(centeredLeftPx, 0, maxScrollLeft),
+        behavior: "smooth",
+      });
+    },
+    [lockTranscriptAutoScroll, waveformReady, wavesurfer, zoomPxPerSec],
+  );
+
   const onPlaySegment = React.useCallback(
     (segment: Segment) => {
       setSelectedSegmentId(segment.id);
+      scrollWaveformToSegment(segment);
       if (!wavesurfer) return;
       void wavesurfer.play(segment.start, segment.end);
     },
-    [wavesurfer],
+    [scrollWaveformToSegment, wavesurfer],
   );
 
   const onZoomIn = React.useCallback(() => {


### PR DESCRIPTION
## What changed
- made transcript clicks scroll the waveform to the matching segment before playback
- added a short lock so transcript-initiated waveform scrolling does not trigger transcript auto-scrolling again
- clear that lock on direct waveform interaction so manual waveform scrolling still updates the transcript

## Why
Clicking a transcript row caused the waveform to scroll, and that waveform scroll immediately triggered the existing transcript follow behavior again. The result was a bounce/loop where the transcript kept moving even though the user had interacted with the transcript.

## Impact
Transcript clicks now move the waveform without causing a second transcript jump. Direct waveform scrolling still keeps the transcript aligned with the visible segment.

## Validation
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unwanted transcript auto-scrolling after waveform-driven jumps, improving sync stability.
  * Transcript auto-scroll is paused while the waveform is being scrolled and immediately re-enabled after manual interactions.
* **New Features**
  * Smooth-centering of waveform when navigating to an audio segment so playback starts with the segment in view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->