### PR TITLE
Add Discord ID lookup to admin user search

### DIFF
--- a/convex/adminData.ts
+++ b/convex/adminData.ts
@@ -6,9 +6,20 @@ import {
 } from "./_generated/server";
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
+import type { Id as AuthId } from "./betterAuth/_generated/dataModel";
 import { components } from "./_generated/api";
 
 type AuthCtx = MutationCtx | QueryCtx;
+type AuthUserRow = {
+  _id: string;
+  userId?: string | null;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  createdAt?: number | null;
+  role?: string | null;
+  emailVerified?: boolean | null;
+};
 
 async function isAdmin(ctx: AuthCtx) {
   const identity = (await ctx.auth.getUserIdentity()) as {
@@ -99,16 +110,49 @@ async function findAuthUserByLegacyId(ctx: AuthCtx, legacyId: number) {
   return (await ctx.runQuery(components.betterAuth.adapter.findOne, {
     model: "user",
     where: [{ field: "userId", operator: "eq", value: String(legacyId) }],
-  })) as {
-    _id: string;
-    userId?: string | null;
-    name?: string | null;
-    email?: string | null;
-    image?: string | null;
-    createdAt?: number | null;
-    role?: string | null;
-    emailVerified?: boolean | null;
-  } | null;
+  })) as AuthUserRow | null;
+}
+
+function authUserMatchesAdminFilters(
+  user: AuthUserRow,
+  activatedFilter: "all" | "yes" | "no",
+  roleFilter: "all" | "user" | "contributor" | "admin",
+) {
+  if (activatedFilter === "yes" && user.emailVerified !== true) return false;
+  if (activatedFilter === "no" && user.emailVerified !== false) return false;
+
+  if (roleFilter === "admin") return user.role === "admin";
+  if (roleFilter === "contributor") return user.role === "contributor";
+  if (roleFilter === "user") {
+    return user.role !== "admin" && user.role !== "contributor";
+  }
+  return true;
+}
+
+async function findAuthUserByDiscordAccountId(
+  ctx: AuthCtx,
+  discordAccountId: string,
+  activatedFilter: "all" | "yes" | "no",
+  roleFilter: "all" | "user" | "contributor" | "admin",
+) {
+  const account = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
+    model: "account",
+    where: [
+      { field: "providerId", operator: "eq", value: "discord" },
+      { field: "accountId", operator: "eq", value: discordAccountId },
+    ],
+  })) as { userId?: string | null } | null;
+
+  if (!account?.userId) return null;
+
+  const user = (await ctx.runQuery(components.betterAuth.adapter.get, {
+    id: account.userId as AuthId<"user">,
+  })) as AuthUserRow | null;
+
+  if (!user) return null;
+  return authUserMatchesAdminFilters(user, activatedFilter, roleFilter)
+    ? user
+    : null;
 }
 
 function toAdminUser(
@@ -295,11 +339,27 @@ export const getAdminUsersPage = query({
 
     const matchedUsers =
       searchMode === "id"
-        ? await ctx.runQuery(components.betterAuth.adapter.searchUsersById, {
-            activatedFilter: args.activatedFilter,
-            roleFilter: args.roleFilter,
-            id: searchTerm,
-          })
+        ? [
+            ...(await ctx.runQuery(
+              components.betterAuth.adapter.searchUsersById,
+              {
+                activatedFilter: args.activatedFilter,
+                roleFilter: args.roleFilter,
+                id: searchTerm,
+              },
+            )),
+            ...[
+              await findAuthUserByDiscordAccountId(
+                ctx,
+                searchTerm,
+                args.activatedFilter,
+                args.roleFilter,
+              ),
+            ].filter((user): user is AuthUserRow => user !== null),
+          ].filter(
+            (user, index, users) =>
+              users.findIndex((other) => other._id === user._id) === index,
+          )
         : searchMode === "email"
           ? await ctx.runQuery(
               components.betterAuth.adapter.searchUsersByEmailPrefix,

--- a/src/app/admin/users/user_list.tsx
+++ b/src/app/admin/users/user_list.tsx
@@ -236,7 +236,7 @@ export default function UserList({
         <div className="flex flex-wrap items-center gap-3.5">
           <Input
             label="Search"
-            placeholder="Username, email, or ID"
+            placeholder="Username, email, user ID, or Discord ID"
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Summary
- Extend admin user search in ID mode to also resolve Discord account IDs through Better Auth.
- Preserve existing activated/role filter behavior when matching Discord-linked users.
- Update the admin users search placeholder to mention Discord ID support.

## Testing
- Not run
- Not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin user search now supports Discord account ID lookups in addition to username, email, and user ID
  * Updated search input placeholder text to indicate Discord ID search capability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rgerum/unofficial-duolingo-stories/pull/500)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->