### PR TITLE
Handle grapheme-aware transcript tokenization

### DIFF
--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -32,6 +32,10 @@ import type {
   AudioCutterPreparedSegment,
   AudioCutterTranscriptItem,
 } from "@/app/editor/story/[story]/audio-cutter-storage";
+import {
+  getGraphemeLength,
+  getTranscriptWordTokens,
+} from "@/app/editor/story/[story]/audio-cutter-text";
 
 const DEFAULT_WAVEFORM_ZOOM = 180;
 const MIN_WAVEFORM_ZOOM = 24;
@@ -442,16 +446,6 @@ function clampTimeToKeepRanges(timeSeconds: number, keepRanges: TimeRange[]) {
   return keepRanges[keepRanges.length - 1]?.end ?? timeSeconds;
 }
 
-function getTranscriptWordTokens(text: string) {
-  return [...text.matchAll(/[\p{L}\p{N}]+(?:['’-][\p{L}\p{N}]+)*/gu)].map(
-    (match) => ({
-      text: match[0],
-      start: match.index ?? 0,
-      end: (match.index ?? 0) + match[0].length,
-    }),
-  );
-}
-
 function getApproximateWordMarks(text: string, segment: Segment): AudioMark[] {
   const tokens = getTranscriptWordTokens(text);
   if (tokens.length === 0) return [];
@@ -467,7 +461,7 @@ function getApproximateWordMarks(text: string, segment: Segment): AudioMark[] {
   if (keepRanges.length === 0 || totalKeepDuration <= 0) return [];
 
   const weights = tokens.map((token) =>
-    Math.max(1, Array.from(token.text).length),
+    Math.max(1, getGraphemeLength(token.text)),
   );
   const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
   if (totalWeight <= 0) return [];

--- a/src/app/editor/story/[story]/audio-cutter-text.test.ts
+++ b/src/app/editor/story/[story]/audio-cutter-text.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getGraphemeLength,
+  getTranscriptWordTokens,
+} from "./audio-cutter-text";
+
+test("keeps Devanagari combining marks with their word token", () => {
+  const text = "सुप्रभात, प्रीती!";
+  const tokens = getTranscriptWordTokens(text);
+
+  assert.deepEqual(
+    tokens.map((token) => token.text),
+    ["सुप्रभात", "प्रीती"],
+  );
+  assert.deepEqual(
+    tokens.map(({ start, end }) => text.slice(start, end)),
+    ["सुप्रभात", "प्रीती"],
+  );
+});
+
+test("counts Devanagari grapheme clusters instead of code points", () => {
+  assert.equal(getGraphemeLength("सुप्रभात"), 4);
+});

--- a/src/app/editor/story/[story]/audio-cutter-text.ts
+++ b/src/app/editor/story/[story]/audio-cutter-text.ts
@@ -1,0 +1,20 @@
+const transcriptWordPattern =
+  /[\p{L}\p{N}\p{M}]+(?:['’-][\p{L}\p{N}\p{M}]+)*/gu;
+
+const graphemeSegmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+export function getTranscriptWordTokens(text: string) {
+  return [...text.matchAll(transcriptWordPattern)].map((match) => ({
+    text: match[0],
+    start: match.index ?? 0,
+    end: (match.index ?? 0) + match[0].length,
+  }));
+}
+
+export function getGraphemeLength(text: string) {
+  if (!graphemeSegmenter) return Array.from(text).length;
+  return [...graphemeSegmenter.segment(text)].length;
+}


### PR DESCRIPTION
## Summary
- Extracted transcript tokenization and grapheme-length logic into `audio-cutter-text.ts` for reuse.
- Expanded word matching to include combining marks so scripts like Devanagari stay intact within tokens.
- Switched approximate word weighting to count grapheme clusters instead of code points.
- Added tests covering token boundaries and grapheme counting for Devanagari text.

## Testing
- `Not run`