### PR TITLE
Preserve editor state when story text changes

### DIFF
--- a/src/app/editor/story/[story]/v2/editor_v2.tsx
+++ b/src/app/editor/story/[story]/v2/editor_v2.tsx
@@ -215,25 +215,7 @@ export default function EditorV2({
   >(undefined);
   const [bulkAudioOpen, setBulkAudioOpen] =
     React.useState(initialBulkAudioOpen);
-  const storySnapshot = React.useMemo(
-    () => ({
-      id: story_data.id,
-      text: story_data.text ?? "",
-    }),
-    [story_data.id, story_data.text],
-  );
-  const storyId = storySnapshot.id;
-  const storyText = storySnapshot.text;
-  const storyInitialTextRef = React.useRef({
-    id: storyId,
-    text: storyText,
-  });
-  if (storyInitialTextRef.current.id !== storyId) {
-    storyInitialTextRef.current = {
-      id: storyId,
-      text: storyText,
-    };
-  }
+  const storyId = story_data.id;
   const model = useStoryEditorModel({
     isAdmin,
     storyData: story_data,
@@ -243,8 +225,15 @@ export default function EditorV2({
     learningLanguage: language_data,
     fromLanguage: language_data2,
   });
-  const { audioInsertLines, dirty, isDeleting, isSaving, parsedStory, save } =
-    model;
+  const {
+    audioInsertLines,
+    dirty,
+    getInitialText,
+    isDeleting,
+    isSaving,
+    parsedStory,
+    save,
+  } = model;
 
   const releaseTrackedAudioEditorAnchor = React.useCallback(() => {
     audioEditorAnchorRef.current?.release();
@@ -292,7 +281,7 @@ export default function EditorV2({
     previousStoryIdRef.current = storyId;
 
     // Reset editor-local state when switching stories, even if the text matches.
-    setDocText(normalizeDocText(storyInitialTextRef.current.text));
+    setDocText(normalizeDocText(getInitialText().text));
     setRevision(0);
     setLineNo(1);
     hasAppliedInitialFocusRef.current = false;
@@ -301,7 +290,7 @@ export default function EditorV2({
     if (previousStoryId !== null && previousStoryId !== storyId) {
       setBulkAudioOpen(false);
     }
-  }, [releaseTrackedAudioEditorAnchor, storyId]);
+  }, [getInitialText, releaseTrackedAudioEditorAnchor, storyId]);
 
   React.useEffect(
     () => () => {
@@ -315,7 +304,7 @@ export default function EditorV2({
   useScrollLinking(view, previewRef, svgParentRef);
 
   React.useEffect(() => {
-    const initialStory = storyInitialTextRef.current;
+    const initialStory = getInitialText();
     if (initialStory.id !== storyId) return;
 
     const sync = EditorView.updateListener.of((update) => {
@@ -350,7 +339,7 @@ export default function EditorV2({
       viewRef.current = null;
       setView(undefined);
     };
-  }, [storyId]);
+  }, [getInitialText, storyId]);
 
   React.useEffect(() => {
     const editorView = viewRef.current ?? view;

--- a/src/app/editor/story/[story]/v2/editor_v2.tsx
+++ b/src/app/editor/story/[story]/v2/editor_v2.tsx
@@ -222,7 +222,18 @@ export default function EditorV2({
     }),
     [story_data.id, story_data.text],
   );
+  const storyId = storySnapshot.id;
   const storyText = storySnapshot.text;
+  const storyInitialTextRef = React.useRef({
+    id: storyId,
+    text: storyText,
+  });
+  if (storyInitialTextRef.current.id !== storyId) {
+    storyInitialTextRef.current = {
+      id: storyId,
+      text: storyText,
+    };
+  }
   const model = useStoryEditorModel({
     isAdmin,
     storyData: story_data,
@@ -232,15 +243,8 @@ export default function EditorV2({
     learningLanguage: language_data,
     fromLanguage: language_data2,
   });
-  const {
-    audioInsertLines,
-    dirty,
-    isDeleting,
-    isSaving,
-    markServerSynced,
-    parsedStory,
-    save,
-  } = model;
+  const { audioInsertLines, dirty, isDeleting, isSaving, parsedStory, save } =
+    model;
 
   const releaseTrackedAudioEditorAnchor = React.useCallback(() => {
     audioEditorAnchorRef.current?.release();
@@ -285,19 +289,19 @@ export default function EditorV2({
 
   React.useEffect(() => {
     const previousStoryId = previousStoryIdRef.current;
-    previousStoryIdRef.current = storySnapshot.id;
+    previousStoryIdRef.current = storyId;
 
     // Reset editor-local state when switching stories, even if the text matches.
-    setDocText(normalizeDocText(storySnapshot.text));
+    setDocText(normalizeDocText(storyInitialTextRef.current.text));
     setRevision(0);
     setLineNo(1);
     hasAppliedInitialFocusRef.current = false;
     releaseTrackedAudioEditorAnchor();
     setAudioEditorData(undefined);
-    if (previousStoryId !== null && previousStoryId !== storySnapshot.id) {
+    if (previousStoryId !== null && previousStoryId !== storyId) {
       setBulkAudioOpen(false);
     }
-  }, [releaseTrackedAudioEditorAnchor, storySnapshot]);
+  }, [releaseTrackedAudioEditorAnchor, storyId]);
 
   React.useEffect(
     () => () => {
@@ -311,6 +315,9 @@ export default function EditorV2({
   useScrollLinking(view, previewRef, svgParentRef);
 
   React.useEffect(() => {
+    const initialStory = storyInitialTextRef.current;
+    if (initialStory.id !== storyId) return;
+
     const sync = EditorView.updateListener.of((update) => {
       const currentLine = update.state.doc.lineAt(
         update.state.selection.main.from,
@@ -327,7 +334,7 @@ export default function EditorV2({
     });
 
     const state = EditorState.create({
-      doc: normalizeDocText(storySnapshot.text),
+      doc: normalizeDocText(initialStory.text),
       extensions: [basicSetup, sync, example(), highlightStyle],
     });
 
@@ -343,22 +350,7 @@ export default function EditorV2({
       viewRef.current = null;
       setView(undefined);
     };
-  }, [storySnapshot]);
-
-  React.useEffect(() => {
-    const view = viewRef.current;
-    if (!view) return;
-    if (dirty) return;
-
-    const remoteText = normalizeDocText(storyText);
-    const localText = view.state.doc.toString();
-    if (localText === remoteText) return;
-
-    markServerSynced(remoteText);
-    view.dispatch({
-      changes: { from: 0, to: view.state.doc.length, insert: remoteText },
-    });
-  }, [dirty, markServerSynced, storyText]);
+  }, [storyId]);
 
   React.useEffect(() => {
     const editorView = viewRef.current ?? view;

--- a/src/app/editor/story/[story]/v2/use_story_editor_model.ts
+++ b/src/app/editor/story/[story]/v2/use_story_editor_model.ts
@@ -71,7 +71,6 @@ type EditorModel = {
   clearSaveError: () => void;
   lastSavedAt: number | null;
   dirty: boolean;
-  markServerSynced: (text: string) => void;
 };
 
 export function useStoryEditorModel({
@@ -101,21 +100,33 @@ export function useStoryEditorModel({
     }),
     [storyData.id, storyData.text],
   );
+  const storyId = storySnapshot.id;
   const storyText = storySnapshot.text;
+  const storyInitialTextRef = React.useRef({
+    id: storyId,
+    text: storyText,
+  });
+  if (storyInitialTextRef.current.id !== storyId) {
+    storyInitialTextRef.current = {
+      id: storyId,
+      text: storyText,
+    };
+  }
   const [lastSavedText, setLastSavedText] = React.useState(
     normalizeDocText(storyText),
   );
   const [image, setImage] = React.useState<ImageLike | null>(null);
 
   React.useEffect(() => {
+    if (storyInitialTextRef.current.id !== storyId) return;
     // Reset editor-save state when switching stories, even if the text matches.
     setIsSaving(false);
     setIsDeleting(false);
     setSaveError(false);
     setSaveErrorMessage("There was an error saving.");
     setLastSavedAt(null);
-    setLastSavedText(normalizeDocText(storySnapshot.text));
-  }, [storySnapshot]);
+    setLastSavedText(normalizeDocText(storyInitialTextRef.current.text));
+  }, [storyId]);
 
   const [parsedStoryBase, parsedMeta, audioInsertLines] = React.useMemo(
     () =>
@@ -315,10 +326,6 @@ export function useStoryEditorModel({
     toFriendlyError,
   ]);
 
-  const markServerSynced = React.useCallback((text: string) => {
-    setLastSavedText(normalizeDocText(text));
-  }, []);
-
   return {
     parsedStory,
     parsedMeta,
@@ -332,6 +339,5 @@ export function useStoryEditorModel({
     clearSaveError: () => setSaveError(false),
     lastSavedAt,
     dirty: normalizeDocText(docText) !== lastSavedText,
-    markServerSynced,
   };
 }

--- a/src/app/editor/story/[story]/v2/use_story_editor_model.ts
+++ b/src/app/editor/story/[story]/v2/use_story_editor_model.ts
@@ -31,6 +31,11 @@ type UseStoryEditorModelArgs = {
   fromLanguage?: LanguageLike;
 };
 
+type StoryInitialText = {
+  id: number;
+  text: string;
+};
+
 function normalizeDocText(text: string): string {
   return text.replace(/\r\n/g, "\n");
 }
@@ -71,6 +76,7 @@ type EditorModel = {
   clearSaveError: () => void;
   lastSavedAt: number | null;
   dirty: boolean;
+  getInitialText: () => StoryInitialText;
 };
 
 export function useStoryEditorModel({
@@ -116,6 +122,10 @@ export function useStoryEditorModel({
     normalizeDocText(storyText),
   );
   const [image, setImage] = React.useState<ImageLike | null>(null);
+  const getInitialText = React.useCallback(
+    () => storyInitialTextRef.current,
+    [],
+  );
 
   React.useEffect(() => {
     if (storyInitialTextRef.current.id !== storyId) return;
@@ -339,5 +349,6 @@ export function useStoryEditorModel({
     clearSaveError: () => setSaveError(false),
     lastSavedAt,
     dirty: normalizeDocText(docText) !== lastSavedText,
+    getInitialText,
   };
 }


### PR DESCRIPTION
## Summary
- Keep the editor’s local document state stable across story text updates by keying resets off the story ID instead of raw snapshot text.
- Capture each story’s initial text in a ref so switching stories still reinitializes the editor and save state correctly.
- Remove the model-level server sync helper and rely on the preserved initial snapshot for dirty-state handling.

## Testing
- Not run.
- Reviewed the diff for editor/story model state reset behavior across story switches.
- Confirmed the change removes the previous remote-text overwrite path while preserving story-change resets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editor now fully resets document text, cursor/line position, focused state and audio UI when switching stories, preventing stale content or audio carryover.
  * Improved editor initialization and sync behavior to reduce inconsistencies and crashes when loading or switching stories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->