### PR TITLE
fix: keep punctuation with preceding words

### DIFF
--- a/src/components/StoryLineHints/StoryLineHints.test.ts
+++ b/src/components/StoryLineHints/StoryLineHints.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { keepClosingPunctuationWithWord } from "./text";
+
+test("keepClosingPunctuationWithWord prevents breaks before closing punctuation", () => {
+  assert.equal(
+    keepClosingPunctuationWithWord("hello ! Are you sure ?"),
+    "hello\u00a0! Are you sure\u00a0?",
+  );
+});
+
+test("keepClosingPunctuationWithWord keeps line breaks as break opportunities", () => {
+  assert.equal(
+    keepClosingPunctuationWithWord("hello \n!"),
+    "hello \n!",
+  );
+});
+
+test("keepClosingPunctuationWithWord preserves existing non-breaking spaces", () => {
+  assert.equal(
+    keepClosingPunctuationWithWord("hello\u00a0!"),
+    "hello\u00a0!",
+  );
+});

--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -1,4 +1,5 @@
 import React, { CSSProperties } from "react";
+import { keepClosingPunctuationWithWord } from "./text";
 import { ContentWithHints } from "@/components/editor/story/syntax_parser_types";
 import type { EditorStateType } from "@/app/editor/story/[story]/editor_state";
 import { cn } from "@/lib/utils";
@@ -180,7 +181,9 @@ function StoryLineHints({
           was_hidden_for_challenge && !is_hidden ? true : undefined
         }
       >
-        {visibleContent.text.substring(start, end)}
+        {keepClosingPunctuationWithWord(
+          visibleContent.text.substring(start, end),
+        )}
       </span>,
     ];
     if (visibleContent.text.substring(start, end).indexOf("\n") !== -1)

--- a/src/components/StoryLineHints/text.ts
+++ b/src/components/StoryLineHints/text.ts
@@ -1,0 +1,6 @@
+const closingPunctuationPattern =
+  /([^\S\r\n])([!%),.:;?\]}\u2026\u00bb\u203a\u201d\u2019\u3002\u3001\uff0c\uff0e\uff01\uff1f\uff1b\uff1a\uff09\uff3d\uff5d\u3011\u300b\u300d\u300f\u3009]+)/g;
+
+export function keepClosingPunctuationWithWord(text: string) {
+  return text.replace(closingPunctuationPattern, "\u00a0$2");
+}

--- a/src/components/StoryQuestionMultipleChoice/StoryQuestionMultipleChoice.tsx
+++ b/src/components/StoryQuestionMultipleChoice/StoryQuestionMultipleChoice.tsx
@@ -3,6 +3,7 @@ import React from "react";
 //import useChoiceButtons from "./questions_useChoiceButtons";
 //import { EditorHook } from "../editor_hooks";
 import StoryLineHints from "../StoryLineHints";
+import { keepClosingPunctuationWithWord } from "../StoryLineHints/text";
 //import { EditorContext, StoryContext } from "../story";
 import StoryQuestionPrompt from "../StoryQuestionPrompt";
 import CheckButton from "../CheckButton";
@@ -71,7 +72,7 @@ function StoryQuestionMultipleChoice({
             <CheckButton type={buttonState[index]} />
             <div>
               {typeof answer == "string" ? (
-                answer
+                keepClosingPunctuationWithWord(answer)
               ) : (
                 <StoryLineHints content={answer} />
               )}

--- a/src/components/StoryQuestionPrompt/StoryQuestionPrompt.tsx
+++ b/src/components/StoryQuestionPrompt/StoryQuestionPrompt.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import StoryLineHints from "../StoryLineHints";
+import { keepClosingPunctuationWithWord } from "../StoryLineHints/text";
 import { ContentWithHints } from "@/components/editor/story/syntax_parser_types";
 
 function StoryQuestionPrompt({
@@ -12,7 +13,9 @@ function StoryQuestionPrompt({
 }) {
   if (question === undefined) return null;
   if (typeof question === "string")
-    return <div className={lang}>{question}</div>;
+    return (
+      <div className={lang}>{keepClosingPunctuationWithWord(question)}</div>
+    );
   return (
     <div className={lang}>
       <StoryLineHints content={question} />

--- a/src/components/StoryTextLineSimple/StoryTextLineSimple.tsx
+++ b/src/components/StoryTextLineSimple/StoryTextLineSimple.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { keepClosingPunctuationWithWord } from "../StoryLineHints/text";
 import { cn } from "@/lib/utils";
 
 function StoryTextLineSimple({
@@ -23,7 +24,12 @@ function StoryTextLineSimple({
       <span className="inline-block w-[100px] shrink-0 text-right font-bold">
         {speaker}:
       </span>
-      <span className="flex-1"> {children}</span>
+      <span className="flex-1">
+        {" "}
+        {typeof children === "string"
+          ? keepClosingPunctuationWithWord(children)
+          : children}
+      </span>
       <span className="text-right font-mono font-bold">{id}</span>
     </div>
   );


### PR DESCRIPTION
## Summary

- keeps closing punctuation with the preceding word at render time
- applies the same display helper to story text, simple text lines, prompts, and string multiple-choice answers
- adds a focused helper test for punctuation, newlines, and existing non-breaking spaces

Closes #262.

## Test plan

- `git diff --check`
- `pnpm exec tsx --test src/components/StoryLineHints/StoryLineHints.test.ts` could not complete locally because Corepack/dependency setup timed out in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved text wrapping in story components to keep closing punctuation attached to preceding words, preventing unwanted line breaks before punctuation marks.

* **Tests**
  * Added test coverage for punctuation and word boundary behavior across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->