### PR TITLE
Show current user's approval state in story list

### DIFF
--- a/convex/editorRead.ts
+++ b/convex/editorRead.ts
@@ -2,6 +2,7 @@ import { query, type QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { components } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
+import { getSessionLegacyUserId } from "./lib/authorization";
 import { courseContributorValidator } from "./lib/courseContributors";
 
 type LanguageDoc = Doc<"languages">;
@@ -323,6 +324,7 @@ export const getEditorStoriesByCourseLegacyId = query({
     console.timeEnd(imagesTimer);
 
     console.time(authorsTimer);
+    const currentLegacyUserId = await getSessionLegacyUserId(ctx);
     const authorLegacyIds = Array.from(
       new Set(
         stories
@@ -351,6 +353,20 @@ export const getEditorStoriesByCourseLegacyId = query({
       getUserNameByAuthDocId(ctx, authorAuthDocIds),
     ]);
     console.timeEnd(authorsTimer);
+
+    const storyIdsApprovedByCurrentUser = new Set<Id<"stories">>();
+    if (currentLegacyUserId !== null) {
+      const currentUserApprovals = await ctx.db
+        .query("story_approval")
+        .withIndex("by_user", (q) => q.eq("legacyUserId", currentLegacyUserId))
+        .collect();
+      const visibleStoryIds = new Set(stories.map((story) => story._id));
+      for (const approval of currentUserApprovals) {
+        if (visibleStoryIds.has(approval.storyId)) {
+          storyIdsApprovedByCurrentUser.add(approval.storyId);
+        }
+      }
+    }
 
     const result = stories.map((story: StoryDoc) => {
       const authorId = toNumber(story.authorId);
@@ -386,6 +402,7 @@ export const getEditorStoriesByCourseLegacyId = query({
         public: story.public,
         todo_count: story.todo_count ?? 0,
         approvalCount: approvalCount ?? 0,
+        approvedByCurrentUser: storyIdsApprovedByCurrentUser.has(story._id),
         author:
           typeof authorId === "number"
             ? (nameByLegacyId.get(authorId) ?? `User ${authorId}`)

--- a/src/app/editor/(course)/edit_list.tsx
+++ b/src/app/editor/(course)/edit_list.tsx
@@ -7,11 +7,16 @@ import {
   useRef,
   useState,
 } from "react";
-import { SpinnerBlue } from "@/components/ui/spinner";
 import { useRouter } from "next/navigation";
 import { useMutation } from "convex/react";
 import { api } from "@convex/_generated/api";
 import ContributorList from "@/components/ContributorList";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import Input from "@/components/ui/input";
 import { matchesStorySearch, parseStorySearch } from "@/lib/story-search";
 import {
@@ -354,6 +359,7 @@ export default function EditList({
                   id={story.id}
                   name={story.name}
                   count={story.approvalCount ?? 0}
+                  approvedByCurrentUser={story.approvedByCurrentUser}
                   status={story.status}
                   public={story.public}
                   official={course.official}
@@ -441,13 +447,14 @@ function DropDownStatus(props: {
   id: number;
   name: string;
   count: number;
+  approvedByCurrentUser: boolean;
   status: string;
   public: boolean;
   official: boolean;
   onStoryStateChange: (
     nextStoryState: Pick<
       StoryListDataProps,
-      "status" | "public" | "approvalCount"
+      "status" | "public" | "approvalCount" | "approvedByCurrentUser"
     >,
   ) => void;
 }) {
@@ -455,6 +462,10 @@ function DropDownStatus(props: {
   let [status, set_status] = useState(props.status);
   let [count, setCount] = useState(props.count);
   let [isPublic, setIsPublic] = useState(props.public);
+  let [approvedByCurrentUser, setApprovedByCurrentUser] = useState(
+    props.approvedByCurrentUser,
+  );
+  let [isConfirmingApproval, setIsConfirmingApproval] = useState(false);
   const toggleApprovalMutation = useMutation(
     api.storyApproval.toggleStoryApproval,
   );
@@ -469,17 +480,26 @@ function DropDownStatus(props: {
   }, [props.count]);
 
   useEffect(() => {
+    setApprovedByCurrentUser(props.approvedByCurrentUser);
+  }, [props.approvedByCurrentUser]);
+
+  useEffect(() => {
     setIsPublic(props.public);
   }, [props.public]);
 
   if (props.official) return <></>;
 
-  async function addApproval() {
-    const confirmed = window.confirm(
-      `Did you check the story "${props.name}" and think it is ready to be published? If you want to give your approval click "ok".\n\nIn case you already gave an approval. "ok" will remove it.`,
-    );
-    if (!confirmed) return;
+  function requestApprovalToggle() {
+    if (loading === 1) return;
+    if (approvedByCurrentUser) {
+      void toggleApproval();
+      return;
+    }
+    setIsConfirmingApproval(true);
+  }
 
+  async function toggleApproval() {
+    setIsConfirmingApproval(false);
     setLoading(1);
     try {
       const response = await toggleApprovalMutation({
@@ -499,10 +519,12 @@ function DropDownStatus(props: {
             : isPublic;
         setCount(count);
         setIsPublic(nextIsPublic);
+        setApprovedByCurrentUser(response.action === "added");
         props.onStoryStateChange({
           status: response.story_status,
           public: nextIsPublic,
           approvalCount: count,
+          approvedByCurrentUser: response.action === "added",
         });
         if (response.published.length) {
           router.refresh();
@@ -533,27 +555,76 @@ function DropDownStatus(props: {
           {status_wrapper(status, isPublic)}
         </span>
       }{" "}
-      {loading === 1 ? (
-        <SpinnerBlue />
-      ) : loading === -1 ? (
-        <img
-          title="an error occurred"
-          alt="error"
-          src="/editor/icons/error.svg"
-        />
-      ) : (
-        <></>
-      )}
       {props.official ? (
         <></>
       ) : (
-        <span
-          className="cursor-pointer whitespace-nowrap rounded-[10px] bg-[var(--editor-ssml)] px-[5px] py-[2px] hover:brightness-90"
-          onClick={addApproval}
+        <button
+          type="button"
+          className={
+            "ml-[4px] inline-flex min-w-[54px] items-center justify-center gap-[4px] whitespace-nowrap rounded-[10px] px-[5px] py-[2px] align-baseline hover:brightness-90 disabled:cursor-wait " +
+            (approvedByCurrentUser
+              ? "bg-[#0089e5] font-bold text-white"
+              : "bg-[var(--editor-ssml)]")
+          }
+          aria-pressed={approvedByCurrentUser}
+          aria-label={
+            approvedByCurrentUser
+              ? `Remove your approval for ${props.name}`
+              : `Approve ${props.name}`
+          }
+          disabled={loading === 1}
+          onClick={requestApprovalToggle}
         >
-          {"👍 " + count}
-        </span>
+          {loading === 1 ? (
+            <span
+              aria-hidden="true"
+              className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+            />
+          ) : loading === -1 ? (
+            <img
+              title="an error occurred"
+              alt="error"
+              src="/editor/icons/error.svg"
+              className="h-4 w-4"
+            />
+          ) : (
+            <span aria-hidden="true">👍</span>
+          )}
+          <span>{count}</span>
+        </button>
       )}
+      <Dialog
+        open={isConfirmingApproval}
+        onOpenChange={setIsConfirmingApproval}
+      >
+        <DialogContent className="max-w-[420px] rounded-[8px] bg-[var(--body-background)] text-left whitespace-normal">
+          <DialogTitle className="text-lg font-bold text-[var(--text-color)]">
+            Approve story?
+          </DialogTitle>
+          <DialogDescription asChild>
+            <p className="text-base leading-relaxed text-[var(--text-color)]">
+              Did you check the story &quot;{props.name}&quot; and think it is
+              ready to be published?
+            </p>
+          </DialogDescription>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              className="rounded-[8px] bg-[var(--editor-ssml)] px-3 py-2 hover:brightness-90"
+              onClick={() => setIsConfirmingApproval(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rounded-[8px] bg-[#0089e5] px-3 py-2 font-bold text-white hover:brightness-90"
+              onClick={() => void toggleApproval()}
+            >
+              Approve
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/editor/(course)/types.ts
+++ b/src/app/editor/(course)/types.ts
@@ -46,6 +46,7 @@ export type StoryListDataProps = {
   public: boolean;
   todo_count: number;
   approvalCount: number;
+  approvedByCurrentUser: boolean;
   author: string;
   author_change: string | null;
 };


### PR DESCRIPTION
## Summary
- Adds per-story approval state for the current editor user in the course story list data.
- Updates the approval control to reflect whether the current user has already approved a story.
- Replaces the one-shot `window.confirm` flow with an explicit confirmation dialog when adding a new approval.
- Keeps the approval button state in sync after toggling, including the displayed count and styling.

## Testing
- Not run
- Concrete check: open the editor story list and verify already-approved stories render as active for the current user.
- Concrete check: click an unapproved story's approval button and confirm the dialog appears before the approval is added.
- Concrete check: click an approved story's button and verify the approval toggles off without the confirmation dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stories now display approval status for the currently logged-in user.

* **Improvements**
  * Approval confirmation interface updated to use a dialog-based flow instead of browser prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->