### PR TITLE
[codex] Guard audio keypoint playback timing

### DIFF
--- a/src/components/StoryTextLine/use-audio.hook.test.ts
+++ b/src/components/StoryTextLine/use-audio.hook.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getPlayableKeypoints } from "./use-audio.hook";
+
+test("getPlayableKeypoints removes markers after the audio duration", () => {
+  assert.deepEqual(
+    getPlayableKeypoints(
+      [
+        { rangeEnd: 2, audioStart: 80 },
+        { rangeEnd: 7, audioStart: 596 },
+        { rangeEnd: 30, audioStart: 15312 },
+      ],
+      1.7,
+    ),
+    [
+      { rangeEnd: 2, audioStart: 80 },
+      { rangeEnd: 7, audioStart: 596 },
+    ],
+  );
+});
+
+test("getPlayableKeypoints preserves markers when duration is unavailable", () => {
+  const keypoints = [
+    { rangeEnd: 2, audioStart: 80 },
+    { rangeEnd: 30, audioStart: 15312 },
+  ];
+
+  assert.deepEqual(getPlayableKeypoints(keypoints, Number.NaN), keypoints);
+});

--- a/src/components/StoryTextLine/use-audio.hook.ts
+++ b/src/components/StoryTextLine/use-audio.hook.ts
@@ -13,6 +13,24 @@ declare global {
 
 type UseAudioElement = StoryElementLine | StoryElementHeader;
 
+export function getPlayableKeypoints(
+  keypoints: Audio["keypoints"],
+  durationSeconds: number,
+) {
+  if (!keypoints?.length) return [];
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    return keypoints;
+  }
+
+  const durationMs = durationSeconds * 1000;
+  return keypoints.filter(
+    (keypoint) =>
+      Number.isFinite(keypoint.audioStart) &&
+      keypoint.audioStart >= 0 &&
+      keypoint.audioStart <= durationMs,
+  );
+}
+
 export default function useAudio(
   element: UseAudioElement,
   active: boolean,
@@ -50,30 +68,48 @@ export default function useAudio(
       return;
     }
 
-    const timeouts: NodeJS.Timeout[] = [];
+    const timeouts: number[] = [];
+    let completionTimeout: number | undefined;
+
+    const clearScheduledUpdates = () => {
+      timeouts.forEach(clearTimeout);
+      timeouts.length = 0;
+      if (completionTimeout !== undefined) {
+        clearTimeout(completionTimeout);
+        completionTimeout = undefined;
+      }
+    };
+
+    const completePlayback = () => {
+      clearScheduledUpdates();
+      setAudioRange(9999);
+    };
 
     // Set up keypoint timeouts (if available for word highlighting)
-    audio.keypoints?.forEach((keypoint) => {
-      const timeout = setTimeout(() => {
-        setAudioRange(keypoint.rangeEnd);
-      }, keypoint.audioStart);
-      timeouts.push(timeout);
-    });
+    getPlayableKeypoints(audio.keypoints, audioObject.duration).forEach(
+      (keypoint) => {
+        const timeout = window.setTimeout(() => {
+          setAudioRange(keypoint.rangeEnd);
+        }, keypoint.audioStart);
+        timeouts.push(timeout);
+      },
+    );
 
     // Set up completion timeout
-    const completionTimeout = window.setTimeout(
-      () => {
-        setAudioRange(9999);
-        // Auto-advance logic would go here
-      },
-      audioObject.duration * 1000 - 150,
-    );
+    if (Number.isFinite(audioObject.duration) && audioObject.duration > 0) {
+      completionTimeout = window.setTimeout(
+        completePlayback,
+        Math.max(0, audioObject.duration * 1000 - 150),
+      );
+    }
+
+    audioObject.addEventListener("ended", completePlayback, { once: true });
 
     // Cleanup function
     const cancel = () => {
-      timeouts.forEach(clearTimeout);
-      clearTimeout(completionTimeout);
+      clearScheduledUpdates();
       setAudioRange(99999);
+      audioObject.removeEventListener("ended", completePlayback);
       audioObject.pause();
     };
 


### PR DESCRIPTION
## Summary
- ignore audio keypoints that fall outside the loaded audio duration
- clear scheduled word-highlight timers when playback completes, ends, or is cancelled
- add a focused test for filtering stale keypoints

## Root cause
Some story audio rows contain keypoints whose `audioStart` values are far beyond the actual clip length. The hook scheduled all keypoint timers anyway, so stale timers could fire after playback had already ended and dim/restore words later.

## Validation
- `pnpm exec tsx --test src/components/StoryTextLine/use-audio.hook.test.ts`
- `pnpm typecheck`
- `pnpm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio playback synchronization to properly handle edge cases with missing duration and invalid keypoints.
  * Improved audio completion detection and timeout management for more reliable word highlighting during playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->