### PR TITLE
[codex] Save audio cutter keypoints relative to segments

### DIFF
--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -32,6 +32,7 @@ import type {
   AudioCutterPreparedSegment,
   AudioCutterTranscriptItem,
 } from "@/app/editor/story/[story]/audio-cutter-storage";
+import { getSegmentRelativeKeypointsFromWordMarks } from "@/app/editor/story/[story]/audio-cutter-keypoints";
 import {
   getGraphemeLength,
   getTranscriptWordTokens,
@@ -642,23 +643,6 @@ function getActiveWordMarkIndex(
   return currentTimeSeconds >= (marks[marks.length - 1]?.time ?? 0) / 1000
     ? marks.length - 1
     : -1;
-}
-
-function getKeypointsFromWordMarks(marks: AudioMark[]) {
-  return marks
-    .map((mark) => ({
-      rangeEnd: mark.end,
-      audioStart: mark.time,
-    }))
-    .filter(
-      (point, index, points) =>
-        Number.isFinite(point.rangeEnd) &&
-        Number.isFinite(point.audioStart) &&
-        point.rangeEnd > 0 &&
-        (index === 0 ||
-          point.rangeEnd !== points[index - 1]?.rangeEnd ||
-          point.audioStart !== points[index - 1]?.audioStart),
-    );
 }
 
 function sanitizeDetectionSettings(
@@ -3381,7 +3365,8 @@ export default function AudioCutterDialog({
             itemId: item.id,
             lineIndex: item.lineIndex,
             ssml: item.ssml,
-            keypoints: getKeypointsFromWordMarks(
+            keypoints: getSegmentRelativeKeypointsFromWordMarks(
+              segment,
               wordMarksBySegmentId[segment.id] ?? [],
             ),
           },

--- a/src/app/editor/story/[story]/audio-cutter-keypoints.test.ts
+++ b/src/app/editor/story/[story]/audio-cutter-keypoints.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getSegmentRelativeKeypointsFromWordMarks } from "./audio-cutter-keypoints";
+
+test("getSegmentRelativeKeypointsFromWordMarks saves marks relative to the exported segment", () => {
+  assert.deepEqual(
+    getSegmentRelativeKeypointsFromWordMarks(
+      {
+        start: 132.7,
+        end: 134.393,
+      },
+      [
+        { type: "word", value: "Oh", start: 0, end: 2, time: 132768 },
+        { type: "word", value: "nyd", start: 6, end: 9, time: 132895 },
+        { type: "word", value: "din", start: 14, end: 17, time: 133085 },
+        { type: "word", value: "date", start: 18, end: 22, time: 133276 },
+      ],
+    ),
+    [
+      { rangeEnd: 2, audioStart: 68 },
+      { rangeEnd: 9, audioStart: 195 },
+      { rangeEnd: 17, audioStart: 385 },
+      { rangeEnd: 22, audioStart: 576 },
+    ],
+  );
+});
+
+test("getSegmentRelativeKeypointsFromWordMarks accounts for skipped ranges", () => {
+  assert.deepEqual(
+    getSegmentRelativeKeypointsFromWordMarks(
+      {
+        start: 10,
+        end: 14,
+        skipRanges: [{ start: 11, end: 12 }],
+      },
+      [
+        { type: "word", value: "one", start: 0, end: 3, time: 10000 },
+        { type: "word", value: "two", start: 4, end: 7, time: 10500 },
+        { type: "word", value: "three", start: 8, end: 13, time: 12500 },
+        { type: "word", value: "four", start: 14, end: 18, time: 14000 },
+      ],
+    ),
+    [
+      { rangeEnd: 3, audioStart: 0 },
+      { rangeEnd: 7, audioStart: 500 },
+      { rangeEnd: 13, audioStart: 1500 },
+      { rangeEnd: 18, audioStart: 3000 },
+    ],
+  );
+});

--- a/src/app/editor/story/[story]/audio-cutter-keypoints.ts
+++ b/src/app/editor/story/[story]/audio-cutter-keypoints.ts
@@ -1,0 +1,148 @@
+import type { AudioMark } from "@/app/audio/_lib/audio/types";
+
+export type AudioCutterSegmentTiming = {
+  start: number;
+  end: number;
+  skipRanges?: { start: number; end: number }[];
+};
+
+function sortRanges(ranges: { start: number; end: number }[]) {
+  return [...ranges].sort((a, b) => a.start - b.start || a.end - b.end);
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normalizeRanges(
+  ranges: { start: number; end: number }[] | undefined,
+  bounds: { start: number; end: number },
+) {
+  const normalized: { start: number; end: number }[] = [];
+
+  for (const range of sortRanges(ranges ?? [])) {
+    const start = clamp(range.start, bounds.start, bounds.end);
+    const end = clamp(range.end, start, bounds.end);
+    if (end - start <= 0.001) continue;
+
+    const previous = normalized[normalized.length - 1];
+    if (!previous || start > previous.end) {
+      normalized.push({ start, end });
+      continue;
+    }
+
+    previous.end = Math.max(previous.end, end);
+  }
+
+  return normalized;
+}
+
+function getKeepRanges(
+  bounds: { start: number; end: number },
+  skipRanges: { start: number; end: number }[] | undefined,
+) {
+  const normalizedSkipRanges = normalizeRanges(skipRanges, bounds);
+  if (normalizedSkipRanges.length === 0) return [bounds];
+
+  const keepRanges: { start: number; end: number }[] = [];
+  let cursor = bounds.start;
+
+  for (const skipRange of normalizedSkipRanges) {
+    if (skipRange.start > cursor) {
+      keepRanges.push({
+        start: cursor,
+        end: skipRange.start,
+      });
+    }
+    cursor = Math.max(cursor, skipRange.end);
+  }
+
+  if (cursor < bounds.end) {
+    keepRanges.push({
+      start: cursor,
+      end: bounds.end,
+    });
+  }
+
+  return keepRanges.filter((range) => range.end - range.start > 0.001);
+}
+
+function clampTimeToKeepRanges(
+  timeSeconds: number,
+  keepRanges: { start: number; end: number }[],
+) {
+  if (keepRanges.length === 0) return timeSeconds;
+
+  if (timeSeconds <= keepRanges[0]?.start) {
+    return keepRanges[0]?.start ?? timeSeconds;
+  }
+
+  for (let index = 0; index < keepRanges.length; index += 1) {
+    const range = keepRanges[index];
+    if (!range) continue;
+    if (timeSeconds >= range.start && timeSeconds <= range.end) {
+      return timeSeconds;
+    }
+
+    const nextRange = keepRanges[index + 1];
+    if (!nextRange || timeSeconds >= nextRange.start) continue;
+
+    const previousDistance = Math.abs(timeSeconds - range.end);
+    const nextDistance = Math.abs(nextRange.start - timeSeconds);
+    return previousDistance <= nextDistance ? range.end : nextRange.start;
+  }
+
+  return keepRanges[keepRanges.length - 1]?.end ?? timeSeconds;
+}
+
+function mapAbsoluteTimeToPlayableOffset(
+  keepRanges: { start: number; end: number }[],
+  absoluteTimeSeconds: number,
+) {
+  const clampedTimeSeconds = clampTimeToKeepRanges(
+    absoluteTimeSeconds,
+    keepRanges,
+  );
+  let offsetSeconds = 0;
+
+  for (const range of keepRanges) {
+    const rangeDuration = Math.max(0, range.end - range.start);
+    if (clampedTimeSeconds <= range.end) {
+      return offsetSeconds + Math.max(0, clampedTimeSeconds - range.start);
+    }
+    offsetSeconds += rangeDuration;
+  }
+
+  return offsetSeconds;
+}
+
+export function getSegmentRelativeKeypointsFromWordMarks(
+  segment: AudioCutterSegmentTiming,
+  marks: AudioMark[],
+) {
+  const keepRanges = getKeepRanges(
+    {
+      start: segment.start,
+      end: segment.end,
+    },
+    segment.skipRanges,
+  );
+
+  return marks
+    .map((mark) => ({
+      rangeEnd: mark.end,
+      audioStart: Math.round(
+        mapAbsoluteTimeToPlayableOffset(keepRanges, mark.time / 1000) * 1000,
+      ),
+    }))
+    .filter(
+      (point, index, points) =>
+        Number.isFinite(point.rangeEnd) &&
+        Number.isFinite(point.audioStart) &&
+        point.rangeEnd > 0 &&
+        point.audioStart >= 0 &&
+        (index === 0 ||
+          point.rangeEnd !== points[index - 1]?.rangeEnd ||
+          point.audioStart !== points[index - 1]?.audioStart),
+    );
+}


### PR DESCRIPTION
## Summary
- convert audio cutter word marks from full-recording absolute times to exported-segment-relative keypoints before saving
- handle internal skipped ranges so saved keypoints match the concatenated exported clip timeline
- add regression tests for the bad absolute-timestamp case and skipped ranges

## Root cause
The cutter edits and plays markers against the full uploaded recording, so word mark times are absolute positions in that recording. The exported MP3 segment starts at 0ms, but the save path wrote those absolute mark times directly into story keypoints. That produced short clips with timestamps like 132s, which later broke word highlighting/playback timing.

## Validation
- `pnpm run format`
- `pnpm test`
- `pnpm typecheck`
- `pnpm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for audio segment keypoint computation with skip range handling

* **Refactor**
  * Enhanced audio segment timing calculations with improved offset handling for skip ranges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->