### PR TITLE
Fix RTL story line direction for mixed-language bubbles

### DIFF
--- a/src/components/StoryTextLine/StoryTextLine.tsx
+++ b/src/components/StoryTextLine/StoryTextLine.tsx
@@ -15,6 +15,7 @@ import {
   type EditorProps,
 } from "@/lib/editor/editorHandlers";
 import { cn } from "@/lib/utils";
+import { getStoryLineDirection } from "./text-direction";
 
 function StoryTextLine({
   active,
@@ -52,7 +53,10 @@ function StoryTextLine({
     settings.show_audio,
   );
   const effectiveAudioRange = audioRangeOverride ?? audioRange;
-  const isRtl = settings.rtl || element.lang === "rtl";
+  const isRtl = getStoryLineDirection({
+    storyRtl: settings.rtl,
+    lineLang: element.lang,
+  });
   const showEditorAudioDetails =
     editorShowAudioDetailsOverride ?? settings.show_audio;
   const titleClassName = "m-0 text-[25px] leading-[34px] font-bold";

--- a/src/components/StoryTextLine/text-direction.test.ts
+++ b/src/components/StoryTextLine/text-direction.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getStoryLineDirection } from "./text-direction";
+
+describe("getStoryLineDirection", () => {
+  it("keeps English story lines LTR inside an RTL story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: true, lineLang: "en" }),
+      false,
+    );
+  });
+
+  it("uses RTL for learning language lines inside an RTL story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: true, lineLang: "dv" }),
+      true,
+    );
+  });
+
+  it("allows explicit RTL lines in an LTR story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: false, lineLang: "rtl" }),
+      true,
+    );
+  });
+});

--- a/src/components/StoryTextLine/text-direction.ts
+++ b/src/components/StoryTextLine/text-direction.ts
@@ -1,0 +1,9 @@
+export function getStoryLineDirection({
+  storyRtl,
+  lineLang,
+}: {
+  storyRtl: boolean;
+  lineLang: string;
+}) {
+  return lineLang === "rtl" || (storyRtl && lineLang !== "en");
+}


### PR DESCRIPTION
## Summary
- Introduce `getStoryLineDirection` to determine bubble text direction from story RTL state and line language.
- Keep English lines LTR inside RTL stories, while still allowing RTL lines where appropriate.
- Add unit coverage for the key direction cases.

## Testing
- Not run (not requested).
- Added `node:test` coverage for English-in-RTL, RTL-in-RTL, and explicit RTL-in-LTR scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced right-to-left text direction detection for multilingual content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->