### PR TITLE
[codex] fix mobile story line direction

### DIFF
--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -154,10 +154,11 @@ export function HintText({
         ? UNDERLINE_DASHED
         : undefined;
     const color = token.hidden
-      ? "transparent"
+      ? colors.background
       : token.dimmed
         ? colors.disabled
         : (flatStyle.color ?? colors.text);
+    const hiddenTextStyle = token.hidden ? { opacity: 0 } : undefined;
 
     // Every token gets the same box metrics (text + 3px gap + 2px underline
     // window) so underlined and plain words share a baseline. RN draws
@@ -178,7 +179,9 @@ export function HintText({
         }}
         style={{ marginBottom: 2 }}
       >
-        <Text style={[flatStyle, { color, lineHeight: undefined }]}>
+        <Text
+          style={[flatStyle, { color, lineHeight: undefined }, hiddenTextStyle]}
+        >
           {displayText}
         </Text>
         <View style={{ height: 2, marginTop: 3, overflow: "hidden" }}>

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -4,6 +4,7 @@ import { Image } from "expo-image";
 import { colors, fontSizes } from "../../theme";
 import { HintText } from "../HintText";
 import { getLanguageTextStyle } from "../languageStyles";
+import { getStoryLineRtl } from "../textDirection";
 import { useLineAudio } from "../useLineAudio";
 import { PlayAudioButton } from "./PlayAudioButton";
 import type { StoryElementLine } from "../types";
@@ -137,6 +138,10 @@ export function TextLine({
 
   if (element.line === undefined) return null;
 
+  const lineRtl = getStoryLineRtl({
+    storyRtl: rtl,
+    lineLang: element.lang,
+  });
   const hideRanges = element.hideRangesForChallenge;
   const textStyle = {
     fontSize: fontSizes.body,
@@ -145,14 +150,14 @@ export function TextLine({
 
   if (element.line.type === "TITLE") {
     return (
-      <View style={[styles.row, rtl && styles.rowRtl]}>
-        <LineBody hasAudio={hasAudio} onPlay={play} rtl={rtl}>
+      <View style={[styles.row, lineRtl && styles.rowRtl]}>
+        <LineBody hasAudio={hasAudio} onPlay={play} rtl={lineRtl}>
           <HintText
             content={element.line.content}
             audioRange={audioRange}
             hideRangesForChallenge={hideRanges}
             unhide={unhide}
-            rtl={rtl}
+            rtl={lineRtl}
             style={[
               styles.title,
               getLanguageTextStyle(element.lang, styles.title),
@@ -165,16 +170,18 @@ export function TextLine({
 
   if (element.line.type === "CHARACTER" && element.line.avatarUrl) {
     return (
-      <View style={[styles.row, styles.characterRow, rtl && styles.rowRtl]}>
+      <View style={[styles.row, styles.characterRow, lineRtl && styles.rowRtl]}>
         <Image
           source={{ uri: element.line.avatarUrl }}
-          style={[styles.avatar, rtl && styles.avatarRtl]}
+          style={[styles.avatar, lineRtl && styles.avatarRtl]}
           contentFit="contain"
         />
         <View
           style={[
             styles.bubbleWrap,
-            rtl ? { paddingRight: TAIL_WIDTH } : { paddingLeft: TAIL_WIDTH },
+            lineRtl
+              ? { paddingRight: TAIL_WIDTH }
+              : { paddingLeft: TAIL_WIDTH },
           ]}
         >
           <View
@@ -186,19 +193,19 @@ export function TextLine({
                   hasAudio,
                 ),
               },
-              rtl && styles.bubbleRtl,
-              rtl
+              lineRtl && styles.bubbleRtl,
+              lineRtl
                 ? { borderTopRightRadius: 0 }
                 : { borderTopLeftRadius: 0 },
             ]}
           >
-            <LineBody hasAudio={hasAudio} onPlay={play} rtl={rtl}>
+            <LineBody hasAudio={hasAudio} onPlay={play} rtl={lineRtl}>
               <HintText
                 content={element.line.content}
                 audioRange={audioRange}
                 hideRangesForChallenge={hideRanges}
                 unhide={unhide}
-                rtl={rtl}
+                rtl={lineRtl}
                 style={[
                   textStyle,
                   getLanguageTextStyle(element.lang, textStyle),
@@ -206,7 +213,7 @@ export function TextLine({
               />
             </LineBody>
           </View>
-          <BubbleTail rtl={rtl} />
+          <BubbleTail rtl={lineRtl} />
         </View>
       </View>
     );
@@ -214,14 +221,14 @@ export function TextLine({
 
   // PROSE (or CHARACTER without avatar)
   return (
-    <View style={[styles.row, rtl && styles.rowRtl]}>
-      <LineBody hasAudio={hasAudio} onPlay={play} rtl={rtl}>
+    <View style={[styles.row, lineRtl && styles.rowRtl]}>
+      <LineBody hasAudio={hasAudio} onPlay={play} rtl={lineRtl}>
         <HintText
           content={element.line.content}
           audioRange={audioRange}
           hideRangesForChallenge={hideRanges}
           unhide={unhide}
-          rtl={rtl}
+          rtl={lineRtl}
           style={[textStyle, getLanguageTextStyle(element.lang, textStyle)]}
         />
       </LineBody>

--- a/app-mobile/src/story/textDirection.ts
+++ b/app-mobile/src/story/textDirection.ts
@@ -1,0 +1,9 @@
+export function getStoryLineRtl({
+  storyRtl,
+  lineLang,
+}: {
+  storyRtl: boolean;
+  lineLang?: string;
+}) {
+  return lineLang === "rtl" || (storyRtl && lineLang !== "en");
+}

--- a/src/components/StoryTextLine/StoryTextLine.tsx
+++ b/src/components/StoryTextLine/StoryTextLine.tsx
@@ -15,6 +15,7 @@ import {
   type EditorProps,
 } from "@/lib/editor/editorHandlers";
 import { cn } from "@/lib/utils";
+import { getStoryLineDirection } from "./text-direction";
 
 function StoryTextLine({
   active,
@@ -52,7 +53,10 @@ function StoryTextLine({
     settings.show_audio,
   );
   const effectiveAudioRange = audioRangeOverride ?? audioRange;
-  const isRtl = settings.rtl || element.lang === "rtl";
+  const isRtl = getStoryLineDirection({
+    storyRtl: settings.rtl,
+    lineLang: element.lang,
+  });
   const showEditorAudioDetails =
     editorShowAudioDetailsOverride ?? settings.show_audio;
   const titleClassName = "m-0 text-[25px] leading-[34px] font-bold";

--- a/src/components/StoryTextLine/text-direction.test.ts
+++ b/src/components/StoryTextLine/text-direction.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getStoryLineDirection } from "./text-direction";
+
+describe("getStoryLineDirection", () => {
+  it("keeps English story lines LTR inside an RTL story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: true, lineLang: "en" }),
+      false,
+    );
+  });
+
+  it("uses RTL for learning language lines inside an RTL story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: true, lineLang: "dv" }),
+      true,
+    );
+  });
+
+  it("allows explicit RTL lines in an LTR story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: false, lineLang: "rtl" }),
+      true,
+    );
+  });
+});

--- a/src/components/StoryTextLine/text-direction.ts
+++ b/src/components/StoryTextLine/text-direction.ts
@@ -1,0 +1,9 @@
+export function getStoryLineDirection({
+  storyRtl,
+  lineLang,
+}: {
+  storyRtl: boolean;
+  lineLang: string;
+}) {
+  return lineLang === "rtl" || (storyRtl && lineLang !== "en");
+}


### PR DESCRIPTION
## What changed

- Added a mobile story-line direction helper that keeps explicit English lines LTR inside RTL stories.
- Updated the React Native story line renderer so row order, avatar mirroring, bubble tail side, audio button position, and hinted text wrapping use the effective line direction instead of only the course direction.
- Gave mobile line bodies a stable width so iOS measures wrapped hinted text height correctly inside speech bubbles.
- Centered mobile hint popups above the measured hinted word and anchored popup bottoms above the word so multi-line translations grow upward.
- Updated hidden challenge text rendering so Android hides the answer text while keeping the underline placeholder visible.
- Centralized mobile question haptics and switched Android question feedback to `performAndroidHapticsAsync` instead of the Vibrator-backed `notificationAsync` / `impactAsync` paths.

## Why

Dhivehi stories can include English lines. The mobile renderer was using the course-level RTL setting for all speech bubble layout, so English lines in an RTL story kept RTL bubble chrome even though their text should read LTR.

React Native/Yoga does not measure wrapped tokenized text the same way browsers do. On iOS, `HintText` could paint on two lines after the bubble had already measured itself as one line tall. Giving the line body a definite width makes wrapping part of the measured layout.

Mobile hint popups were centered on the tap coordinate and positioned with a fixed top offset. The popup now uses the measured token center and measured popup height, so it stays centered above the word and taller translations grow upward.

Android also did not reliably hide challenge text when the mobile renderer used `color: transparent`; the hidden range calculation was working, but the answer text remained visible above the placeholder underline.

Android haptics were using Expo APIs that simulate iOS feedback with the Android Vibrator API. That can feel much stronger on some devices, especially for repeated question interactions. Android now uses native haptic feedback types instead.

## Validation

- `pnpm --dir app-mobile typecheck`
- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm test`