### PR TITLE
Fix story line direction and mobile haptics

### DIFF
--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -154,10 +154,11 @@ export function HintText({
         ? UNDERLINE_DASHED
         : undefined;
     const color = token.hidden
-      ? "transparent"
+      ? colors.background
       : token.dimmed
         ? colors.disabled
         : (flatStyle.color ?? colors.text);
+    const hiddenTextStyle = token.hidden ? { opacity: 0 } : undefined;
 
     // Every token gets the same box metrics (text + 3px gap + 2px underline
     // window) so underlined and plain words share a baseline. RN draws
@@ -178,7 +179,9 @@ export function HintText({
         }}
         style={{ marginBottom: 2 }}
       >
-        <Text style={[flatStyle, { color, lineHeight: undefined }]}>
+        <Text
+          style={[flatStyle, { color, lineHeight: undefined }, hiddenTextStyle]}
+        >
           {displayText}
         </Text>
         <View style={{ height: 2, marginTop: 3, overflow: "hidden" }}>

--- a/app-mobile/src/story/elements/ArrangeQuestion.tsx
+++ b/app-mobile/src/story/elements/ArrangeQuestion.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
-import * as Haptics from "expo-haptics";
 import { playSoundEffect } from "../soundEffects";
+import { playErrorHaptic, playSelectionHaptic } from "../storyHaptics";
 import { WordChip, type ChipStatus } from "../WordChip";
 import type { StoryElementArrange } from "../types";
 
@@ -54,7 +54,7 @@ export function ArrangeQuestion({
         state.map((value, i) => (i === index ? 1 : value)),
       );
       setPosition(position + 1);
-      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      playSelectionHaptic();
     } else {
       setButtonState((state) =>
         state.map((value, i) => (i === index ? 2 : value)),
@@ -67,7 +67,7 @@ export function ArrangeQuestion({
       }, WRONG_FLASH_DELAY_MS);
       resetTimers.current.add(timer);
       playSoundEffect("wrong");
-      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      playErrorHaptic();
     }
   };
 

--- a/app-mobile/src/story/elements/MatchQuestion.tsx
+++ b/app-mobile/src/story/elements/MatchQuestion.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
-import * as Haptics from "expo-haptics";
 import { playSoundEffect } from "../soundEffects";
+import { playErrorHaptic, playSelectionHaptic } from "../storyHaptics";
 import { WordChip, type ChipStatus } from "../WordChip";
 import { QuestionPrompt } from "./QuestionPrompt";
 import type { StoryElementMatch } from "../types";
@@ -81,12 +81,12 @@ export function MatchQuestion({
       } else if (selectedOther.index === newWord.index) {
         selectedOther.state = "right";
         newWord.state = "right";
-        void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        playSelectionHaptic();
       } else {
         selectedOther.state = "wrong";
         newWord.state = "wrong";
         playSoundEffect("wrong");
-        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+        playErrorHaptic();
       }
       return next;
     });

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -4,6 +4,7 @@ import { Image } from "expo-image";
 import { colors, fontSizes } from "../../theme";
 import { HintText } from "../HintText";
 import { getLanguageTextStyle } from "../languageStyles";
+import { getStoryLineRtl } from "../textDirection";
 import { useLineAudio } from "../useLineAudio";
 import { PlayAudioButton } from "./PlayAudioButton";
 import type { StoryElementLine } from "../types";
@@ -137,6 +138,10 @@ export function TextLine({
 
   if (element.line === undefined) return null;
 
+  const lineRtl = getStoryLineRtl({
+    storyRtl: rtl,
+    lineLang: element.lang,
+  });
   const hideRanges = element.hideRangesForChallenge;
   const textStyle = {
     fontSize: fontSizes.body,
@@ -145,14 +150,14 @@ export function TextLine({
 
   if (element.line.type === "TITLE") {
     return (
-      <View style={[styles.row, rtl && styles.rowRtl]}>
-        <LineBody hasAudio={hasAudio} onPlay={play} rtl={rtl}>
+      <View style={[styles.row, lineRtl && styles.rowRtl]}>
+        <LineBody hasAudio={hasAudio} onPlay={play} rtl={lineRtl}>
           <HintText
             content={element.line.content}
             audioRange={audioRange}
             hideRangesForChallenge={hideRanges}
             unhide={unhide}
-            rtl={rtl}
+            rtl={lineRtl}
             style={[
               styles.title,
               getLanguageTextStyle(element.lang, styles.title),
@@ -165,16 +170,18 @@ export function TextLine({
 
   if (element.line.type === "CHARACTER" && element.line.avatarUrl) {
     return (
-      <View style={[styles.row, styles.characterRow, rtl && styles.rowRtl]}>
+      <View style={[styles.row, styles.characterRow, lineRtl && styles.rowRtl]}>
         <Image
           source={{ uri: element.line.avatarUrl }}
-          style={[styles.avatar, rtl && styles.avatarRtl]}
+          style={[styles.avatar, lineRtl && styles.avatarRtl]}
           contentFit="contain"
         />
         <View
           style={[
             styles.bubbleWrap,
-            rtl ? { paddingRight: TAIL_WIDTH } : { paddingLeft: TAIL_WIDTH },
+            lineRtl
+              ? { paddingRight: TAIL_WIDTH }
+              : { paddingLeft: TAIL_WIDTH },
           ]}
         >
           <View
@@ -186,19 +193,19 @@ export function TextLine({
                   hasAudio,
                 ),
               },
-              rtl && styles.bubbleRtl,
-              rtl
+              lineRtl && styles.bubbleRtl,
+              lineRtl
                 ? { borderTopRightRadius: 0 }
                 : { borderTopLeftRadius: 0 },
             ]}
           >
-            <LineBody hasAudio={hasAudio} onPlay={play} rtl={rtl}>
+            <LineBody hasAudio={hasAudio} onPlay={play} rtl={lineRtl}>
               <HintText
                 content={element.line.content}
                 audioRange={audioRange}
                 hideRangesForChallenge={hideRanges}
                 unhide={unhide}
-                rtl={rtl}
+                rtl={lineRtl}
                 style={[
                   textStyle,
                   getLanguageTextStyle(element.lang, textStyle),
@@ -206,7 +213,7 @@ export function TextLine({
               />
             </LineBody>
           </View>
-          <BubbleTail rtl={rtl} />
+          <BubbleTail rtl={lineRtl} />
         </View>
       </View>
     );
@@ -214,14 +221,14 @@ export function TextLine({
 
   // PROSE (or CHARACTER without avatar)
   return (
-    <View style={[styles.row, rtl && styles.rowRtl]}>
-      <LineBody hasAudio={hasAudio} onPlay={play} rtl={rtl}>
+    <View style={[styles.row, lineRtl && styles.rowRtl]}>
+      <LineBody hasAudio={hasAudio} onPlay={play} rtl={lineRtl}>
         <HintText
           content={element.line.content}
           audioRange={audioRange}
           hideRangesForChallenge={hideRanges}
           unhide={unhide}
-          rtl={rtl}
+          rtl={lineRtl}
           style={[textStyle, getLanguageTextStyle(element.lang, textStyle)]}
         />
       </LineBody>
@@ -270,6 +277,8 @@ const styles = StyleSheet.create({
   },
   body: {
     flexShrink: 1,
+    minWidth: 0,
+    width: "100%",
   },
   bodyPad: {
     paddingLeft: 32,

--- a/app-mobile/src/story/storyHaptics.ts
+++ b/app-mobile/src/story/storyHaptics.ts
@@ -1,0 +1,43 @@
+import * as Haptics from "expo-haptics";
+import { Platform } from "react-native";
+
+function runHaptic(effect: Promise<void>) {
+  void effect.catch(() => {
+    // Haptics are optional feedback; unsupported devices should not affect play.
+  });
+}
+
+export function playSelectionHaptic() {
+  if (Platform.OS === "android") {
+    runHaptic(
+      Haptics.performAndroidHapticsAsync(
+        Haptics.AndroidHaptics.Segment_Frequent_Tick,
+      ),
+    );
+    return;
+  }
+
+  runHaptic(Haptics.selectionAsync());
+}
+
+export function playSuccessHaptic() {
+  if (Platform.OS === "android") {
+    runHaptic(
+      Haptics.performAndroidHapticsAsync(Haptics.AndroidHaptics.Confirm),
+    );
+    return;
+  }
+
+  runHaptic(Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success));
+}
+
+export function playErrorHaptic() {
+  if (Platform.OS === "android") {
+    runHaptic(
+      Haptics.performAndroidHapticsAsync(Haptics.AndroidHaptics.Reject),
+    );
+    return;
+  }
+
+  runHaptic(Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error));
+}

--- a/app-mobile/src/story/textDirection.ts
+++ b/app-mobile/src/story/textDirection.ts
@@ -1,0 +1,9 @@
+export function getStoryLineRtl({
+  storyRtl,
+  lineLang,
+}: {
+  storyRtl: boolean;
+  lineLang?: string;
+}) {
+  return lineLang === "rtl" || (storyRtl && lineLang !== "en");
+}

--- a/app-mobile/src/story/useChoiceButtons.ts
+++ b/app-mobile/src/story/useChoiceButtons.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import * as Haptics from "expo-haptics";
+import { playErrorHaptic, playSuccessHaptic } from "./storyHaptics";
 import { playSoundEffect } from "./soundEffects";
 
 export type ChoiceState = "right" | "false" | "done" | undefined;
@@ -34,13 +34,13 @@ export function useChoiceButtons(
         );
         buttonStateRef.current = nextState;
         setButtonState(nextState);
-        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        playSuccessHaptic();
         callRight();
         return;
       }
 
       playSoundEffect("wrong");
-      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      playErrorHaptic();
       const nextState = state.map((value, i) =>
         i === index ? "false" : value,
       );

--- a/src/components/StoryTextLine/StoryTextLine.tsx
+++ b/src/components/StoryTextLine/StoryTextLine.tsx
@@ -15,6 +15,7 @@ import {
   type EditorProps,
 } from "@/lib/editor/editorHandlers";
 import { cn } from "@/lib/utils";
+import { getStoryLineDirection } from "./text-direction";
 
 function StoryTextLine({
   active,
@@ -52,7 +53,10 @@ function StoryTextLine({
     settings.show_audio,
   );
   const effectiveAudioRange = audioRangeOverride ?? audioRange;
-  const isRtl = settings.rtl || element.lang === "rtl";
+  const isRtl = getStoryLineDirection({
+    storyRtl: settings.rtl,
+    lineLang: element.lang,
+  });
   const showEditorAudioDetails =
     editorShowAudioDetailsOverride ?? settings.show_audio;
   const titleClassName = "m-0 text-[25px] leading-[34px] font-bold";

--- a/src/components/StoryTextLine/text-direction.test.ts
+++ b/src/components/StoryTextLine/text-direction.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getStoryLineDirection } from "./text-direction";
+
+describe("getStoryLineDirection", () => {
+  it("keeps English story lines LTR inside an RTL story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: true, lineLang: "en" }),
+      false,
+    );
+  });
+
+  it("uses RTL for learning language lines inside an RTL story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: true, lineLang: "dv" }),
+      true,
+    );
+  });
+
+  it("allows explicit RTL lines in an LTR story", () => {
+    assert.equal(
+      getStoryLineDirection({ storyRtl: false, lineLang: "rtl" }),
+      true,
+    );
+  });
+});

--- a/src/components/StoryTextLine/text-direction.ts
+++ b/src/components/StoryTextLine/text-direction.ts
@@ -1,0 +1,9 @@
+export function getStoryLineDirection({
+  storyRtl,
+  lineLang,
+}: {
+  storyRtl: boolean;
+  lineLang: string;
+}) {
+  return lineLang === "rtl" || (storyRtl && lineLang !== "en");
+}


### PR DESCRIPTION
## Summary
- Corrects story line direction handling so English lines remain LTR inside RTL stories, while other learning-language lines follow the story direction.
- Reuses the same direction logic in both web and mobile story text rendering to keep layout behavior consistent.
- Replaces direct Expo haptic calls in story interactions with a shared helper that normalizes success, selection, and error feedback across platforms.
- Adjusts hidden hint text rendering so invisible tokens do not affect layout or text color behavior.

## Testing
- Added unit coverage for `getStoryLineDirection` in `src/components/StoryTextLine/text-direction.test.ts`.
- Not run: `pnpm run format`
- Not run: `pnpm run format:check`
- Not run: `pnpm run lint`
- Not run: `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved haptic feedback handling across story interactions, providing consistent selection, success, and error responses with graceful failure handling.
  * Enhanced right-to-left text support by resolving direction per story line (based on both story and line language) to better align layout and speech-bubble rendering.
* **Tests**
  * Added unit test coverage for line direction resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->