### PR TITLE
Add dynamic sitemap and simplify story reader layout

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,3 +9,5 @@ Disallow: /admin
 # Allow all crawlers
 User-agent: *
 Allow: /
+
+Sitemap: https://duostories.org/sitemap.xml

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,15 +7,38 @@ const SITE_URL = "https://duostories.org";
 
 export const revalidate = 3600;
 
+const EMPTY_DOCS_DATA: Awaited<ReturnType<typeof getDocsData>> = {
+  navigation: [],
+};
+
 function toUrl(path: string) {
   return new URL(path, SITE_URL).toString();
 }
 
+function hasCourseShort(course: unknown): course is { short: string } {
+  return (
+    typeof course === "object" &&
+    course !== null &&
+    "short" in course &&
+    typeof course.short === "string" &&
+    course.short.length > 0
+  );
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [courses, docsData] = await Promise.all([
-    fetchQuery(api.landing.getPublicCourseList, {}),
-    getDocsData(),
-  ]);
+  let courses: Array<{ short: string }> = [];
+  let docsData = EMPTY_DOCS_DATA;
+
+  try {
+    const [fetchedCourses, fetchedDocsData] = await Promise.all([
+      fetchQuery(api.landing.getPublicCourseList, {}),
+      getDocsData(),
+    ]);
+    courses = fetchedCourses.filter(hasCourseShort);
+    docsData = fetchedDocsData;
+  } catch (error) {
+    console.error("Failed to load sitemap data:", error);
+  }
 
   const docsEntries: MetadataRoute.Sitemap = [
     {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,86 @@
+import type { MetadataRoute } from "next";
+import { fetchQuery } from "convex/nextjs";
+import { api } from "@convex/_generated/api";
+import { getDocsData } from "./docs/[[...slug]]/doc_data";
+
+const SITE_URL = "https://duostories.org";
+
+export const revalidate = 3600;
+
+function toUrl(path: string) {
+  return new URL(path, SITE_URL).toString();
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [courses, docsData] = await Promise.all([
+    fetchQuery(api.landing.getPublicCourseList, {}),
+    getDocsData(),
+  ]);
+
+  const docsEntries: MetadataRoute.Sitemap = [
+    {
+      url: toUrl("/docs"),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    ...docsData.navigation.flatMap((group) =>
+      group.pages.map((page) => ({
+        url: toUrl(`/docs/${page.slug}`),
+        changeFrequency: "weekly" as const,
+        priority: 0.6,
+      })),
+    ),
+  ];
+
+  const coursePages = await Promise.all(
+    courses.map(async (course) => ({
+      course,
+      pageData: await fetchQuery(api.landing.getPublicCoursePageData, {
+        short: course.short,
+      }),
+    })),
+  );
+
+  const courseEntries: MetadataRoute.Sitemap = coursePages.map(
+    ({ course }) => ({
+      url: toUrl(`/${course.short}`),
+      changeFrequency: "daily",
+      priority: 0.9,
+    }),
+  );
+
+  const storyEntries: MetadataRoute.Sitemap = coursePages.flatMap(
+    ({ pageData }) =>
+      (pageData?.stories ?? []).map((story) => ({
+        url: toUrl(`/story/${story.id}`),
+        changeFrequency: "weekly" as const,
+        priority: 0.8,
+      })),
+  );
+
+  return [
+    {
+      url: toUrl("/"),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: toUrl("/faq"),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: toUrl("/learn"),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
+      url: toUrl("/privacy_policy"),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    ...docsEntries,
+    ...courseEntries,
+    ...storyEntries,
+  ];
+}


### PR DESCRIPTION
## Summary
- Added dynamic sitemap generation at `src/app/sitemap.ts` so search engines can discover app routes automatically.
- Updated `public/robots.txt` to point crawlers at the generated sitemap.
- Simplified several story-screen components by removing now-unused hint/audio coordination and reducing layout-measurement logic.
- Changed the finished story state to a centered full-screen takeover instead of an inline footer section.

## Testing
- Not run
- Manual verification not performed in this branch
- `src/app/sitemap.ts` added and referenced from `public/robots.txt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic, content-aware sitemap generation that includes public courses, stories, documentation pages, and key site sections to improve search engine discovery.

* **Chores**
  * Updated crawler directives in `robots.txt` to explicitly permit public content and register the site’s sitemap for more reliable indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->