### PR TITLE
Simplify story reader hint and audio handling

### DIFF
--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -164,7 +164,6 @@ function StoryLineHints({
     end2: number,
   ) {
     if (start2 === end2) return false;
-    if (start2 === undefined || end2 === undefined) return false;
     if (start1 <= start2 && start2 < end1) return true;
     return start2 <= start1 && start1 < end2;
   }
@@ -206,7 +205,7 @@ function StoryLineHints({
   }
 
   function buildHintRenderState(hint: ContentWithHints["hintMap"][number]) {
-    const isHidden = getHintHiddenState(hint.rangeFrom, hint.rangeTo);
+    const isHidden = getHintHiddenState(hint.rangeFrom, hint.rangeTo + 1);
     const hintTranslation = visibleContent.hints?.[hint.hintIndex];
     const hintPronunciation =
       visibleContent.hints_pronunciation?.[hint.hintIndex];
@@ -236,6 +235,7 @@ function StoryLineHints({
     const wasHidden = wasHiddenForChallenge(start, end);
     const isHidden = getHiddenState(start, end);
     const segmentText = visibleContent.text.substring(start, end);
+    const segmentLines = segmentText.split("\n");
     const style: CSSProperties = {};
     if (audioRange && audioRange < start) style.opacity = 0.5;
     if (wasHidden && !isHidden) {
@@ -259,11 +259,14 @@ function StoryLineHints({
         data-hidden={isHidden}
         data-revealed={wasHidden && !isHidden ? true : undefined}
       >
-        {segmentText}
+        {segmentLines.map((line, index) => (
+          <React.Fragment key={`${start} ${end} ${index}`}>
+            {index > 0 ? <br /> : null}
+            {line}
+          </React.Fragment>
+        ))}
       </span>,
     ];
-    if (segmentText.includes("\n"))
-      returns.push(<br key={start + " " + end + " br"} />);
     return returns;
   }
 

--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -3,8 +3,8 @@ import { ContentWithHints } from "@/components/editor/story/syntax_parser_types"
 import type { EditorStateType } from "@/app/editor/story/[story]/editor_state";
 import { cn } from "@/lib/utils";
 
-type Range = { start: number; end: number };
 type HiddenState = boolean | undefined | "editor";
+type InlineHintStyle = CSSProperties | undefined;
 
 const underlineBaseStyle: CSSProperties = {
   backgroundPosition: "0 100%",
@@ -47,6 +47,16 @@ const tooltipArrowStyle: CSSProperties = {
 function splitTextTokens(text: string) {
   if (!text) return [];
   return text.split(/([\s\\¡!"#$%&*,./:;<=>¿?@^_`{|}]+)/);
+}
+
+function getVisibleContent(content: ContentWithHints, showHints: boolean) {
+  if (showHints) return content;
+  return {
+    ...content,
+    hintMap: [],
+    hints: undefined,
+    hints_pronunciation: undefined,
+  };
 }
 
 function Tooltip({
@@ -130,15 +140,7 @@ function StoryLineHints({
   unhide?: number;
   editorState?: EditorStateType;
 }) {
-  if (!content) return <>Empty</>;
-  const visibleContent = showHints
-    ? content
-    : {
-        ...content,
-        hintMap: [],
-        hints: undefined,
-        hints_pronunciation: undefined,
-      };
+  const visibleContent = getVisibleContent(content, showHints);
   let hideRangesForChallengeEntry = hideRangesForChallenge
     ? hideRangesForChallenge[0]
     : hideRangesForChallenge;
@@ -174,7 +176,7 @@ function StoryLineHints({
   }
 
   function getHiddenState(start: number, end: number): HiddenState {
-    let is_hidden: HiddenState =
+    let isHidden: HiddenState =
       hideRangesForChallengeEntry !== undefined &&
       overlaps(
         start,
@@ -184,19 +186,62 @@ function StoryLineHints({
       )
         ? true
         : undefined;
-    if (is_hidden && editor) is_hidden = "editor";
-    return is_hidden;
+    if (isHidden && editor) isHidden = "editor";
+    return isHidden;
+  }
+
+  function getHintHiddenState(start: number, end: number): boolean | undefined {
+    const hiddenState = getHiddenState(start, end);
+    return hiddenState ? true : undefined;
+  }
+
+  function getInlineHintUnderlineStyle(
+    hasTranslationHint: boolean,
+    isHidden: boolean | undefined,
+    wasHidden: boolean | undefined,
+  ): InlineHintStyle {
+    return !showTrans && hasTranslationHint && !isHidden && !wasHidden
+      ? tooltipContainerStyle
+      : undefined;
+  }
+
+  function buildHintRenderState(hint: ContentWithHints["hintMap"][number]) {
+    const isHidden = getHintHiddenState(hint.rangeFrom, hint.rangeTo);
+    const hintTranslation = visibleContent.hints?.[hint.hintIndex];
+    const hintPronunciation =
+      visibleContent.hints_pronunciation?.[hint.hintIndex];
+    const hasAnyHint = Boolean(hintTranslation || hintPronunciation);
+    const hasTranslationHint = Boolean(hintTranslation);
+    const isInteractive = !isHidden && !showTrans && hasTranslationHint;
+    const wasHidden = wasHiddenForChallenge(hint.rangeFrom, hint.rangeTo + 1);
+    const inlineUnderlineStyle = getInlineHintUnderlineStyle(
+      hasTranslationHint,
+      isHidden,
+      wasHidden,
+    );
+
+    return {
+      hasAnyHint,
+      hasTranslationHint,
+      hintPronunciation,
+      hintTranslation,
+      inlineUnderlineStyle,
+      isHidden,
+      isInteractive,
+      wasHidden,
+    };
   }
 
   function renderTextSegment(start: number, end: number) {
-    const was_hidden_for_challenge = wasHiddenForChallenge(start, end);
-    const is_hidden = getHiddenState(start, end);
+    const wasHidden = wasHiddenForChallenge(start, end);
+    const isHidden = getHiddenState(start, end);
+    const segmentText = visibleContent.text.substring(start, end);
     const style: CSSProperties = {};
     if (audioRange && audioRange < start) style.opacity = 0.5;
-    if (was_hidden_for_challenge && !is_hidden) {
+    if (wasHidden && !isHidden) {
       Object.assign(style, revealedUnderlineStyle);
     }
-    if (is_hidden) {
+    if (isHidden) {
       Object.assign(style, hiddenUnderlineStyle);
     }
 
@@ -204,31 +249,27 @@ function StoryLineHints({
       <span
         className={cn(
           "select-text",
-          is_hidden === true && "select-none text-[var(--body-background)]",
-          is_hidden === "editor" && "opacity-70",
+          isHidden === true && "select-none text-[var(--body-background)]",
+          isHidden === "editor" && "opacity-70",
         )}
         key={start + " " + end}
         style={
-          was_hidden_for_challenge || is_hidden
-            ? { ...underlineBaseStyle, ...style }
-            : style
+          wasHidden || isHidden ? { ...underlineBaseStyle, ...style } : style
         }
-        data-hidden={is_hidden}
-        data-revealed={
-          was_hidden_for_challenge && !is_hidden ? true : undefined
-        }
+        data-hidden={isHidden}
+        data-revealed={wasHidden && !isHidden ? true : undefined}
       >
-        {visibleContent.text.substring(start, end)}
+        {segmentText}
       </span>,
     ];
-    if (visibleContent.text.substring(start, end).indexOf("\n") !== -1)
+    if (segmentText.includes("\n"))
       returns.push(<br key={start + " " + end + " br"} />);
-    // add the span and optionally add a line break
     return returns;
   }
 
   function renderSplitText(start: number, end: number) {
-    let parts = splitTextTokens(visibleContent.text.substring(start, end));
+    const text = visibleContent.text.substring(start, end);
+    let parts = splitTextTokens(text);
     if (parts[0] === "") parts.splice(0, 1);
     if (parts[parts.length - 1] === "") parts.pop();
 
@@ -245,9 +286,9 @@ function StoryLineHints({
   }
 
   function renderPronunciation(
-    hint_pronunciation: string,
-    is_hidden: boolean | undefined,
-    inlineHintUnderlineStyle: CSSProperties | undefined,
+    hintPronunciation: string,
+    isHidden: boolean | undefined,
+    inlineHintUnderlineStyle: InlineHintStyle,
     children: React.ReactNode,
   ) {
     return (
@@ -256,9 +297,9 @@ function StoryLineHints({
         <span
           className={cn(
             "pointer-events-none invisible absolute bottom-[calc(100%-6px)] left-1/2 whitespace-nowrap text-[0.62em] leading-none opacity-0 transition-opacity duration-200",
-            !is_hidden &&
+            !isHidden &&
               "group-hover/tooltip:visible group-hover/tooltip:opacity-95",
-            !is_hidden &&
+            !isHidden &&
               "group-focus-within/tooltip:visible group-focus-within/tooltip:opacity-95",
             showTrans &&
               "group-hover/editorhint:visible group-hover/editorhint:opacity-95",
@@ -269,27 +310,27 @@ function StoryLineHints({
           )}
           style={{ transform: "translateX(-50%)" }}
         >
-          {hint_pronunciation}
+          {hintPronunciation}
         </span>
       </span>
     );
   }
 
   function renderTooltip(
-    hint_translation: string,
-    hint_pronunciation: string | undefined,
+    hintTranslation: string,
+    hintPronunciation: string | undefined,
     hintTextClassName: string,
   ) {
     return (
       <span
         className={cn(
           "bottom-full left-1/2 z-10 mb-1 rounded-[14px] border-2 px-[17px] pt-[7px] pb-[6px] text-center text-[19px]",
-          hint_pronunciation && "bottom-[calc(115%+4px)] mb-2",
+          hintPronunciation && "bottom-[calc(115%+4px)] mb-2",
           hintTextClassName,
         )}
         data-hint-tooltip
         style={
-          hint_pronunciation
+          hintPronunciation
             ? {
                 ...tooltipContentWithPronunciationStyle,
                 transform: "translateX(-50%)",
@@ -300,7 +341,7 @@ function StoryLineHints({
               }
         }
       >
-        <span>{hint_translation}</span>
+        <span>{hintTranslation}</span>
         <span
           aria-hidden={true}
           className="absolute top-full left-1/2 z-10 mt-[-6px] ml-[-5px] h-[10px] w-[10px] rotate-[-45deg] border-2"
@@ -311,59 +352,40 @@ function StoryLineHints({
   }
 
   let elements = [];
-  let text_pos = 0;
+  let textPos = 0;
   for (let hint of visibleContent.hintMap) {
-    if (hint.rangeFrom > text_pos) {
-      elements.push(renderSplitText(text_pos, hint.rangeFrom));
+    if (hint.rangeFrom > textPos) {
+      elements.push(renderSplitText(textPos, hint.rangeFrom));
     }
 
-    let is_hidden: boolean | undefined =
-      hideRangesForChallengeEntry !== undefined &&
-      overlaps(
-        hint.rangeFrom,
-        hint.rangeTo,
-        hideRangesForChallengeEntry.start,
-        hideRangesForChallengeEntry.end,
-      )
-        ? true
-        : undefined;
-    if (editor) is_hidden = false;
-    const hint_translation = visibleContent.hints?.[hint.hintIndex];
-    const hint_pronunciation =
-      visibleContent.hints_pronunciation?.[hint.hintIndex];
-    const has_any_hint = Boolean(hint_translation || hint_pronunciation);
-    const has_translation_hint = Boolean(hint_translation);
-    const isInteractive = !is_hidden && !showTrans && has_translation_hint;
-    const was_hidden_for_challenge = wasHiddenForChallenge(
-      hint.rangeFrom,
-      hint.rangeTo + 1,
-    );
-    const inlineHintUnderlineStyle =
-      !showTrans &&
-      has_translation_hint &&
-      !is_hidden &&
-      !was_hidden_for_challenge
-        ? tooltipContainerStyle
-        : undefined;
-
+    const {
+      hasAnyHint,
+      hasTranslationHint,
+      hintPronunciation,
+      hintTranslation,
+      inlineUnderlineStyle,
+      isHidden,
+      isInteractive,
+      wasHidden,
+    } = buildHintRenderState(hint);
     const hintText = renderSplitText(hint.rangeFrom, hint.rangeTo + 1);
-    const word_content = hint_pronunciation ? (
+    const wordContent = hintPronunciation ? (
       renderPronunciation(
-        hint_pronunciation,
-        is_hidden,
-        inlineHintUnderlineStyle,
+        hintPronunciation,
+        isHidden,
+        inlineUnderlineStyle,
         hintText,
       )
     ) : (
-      <span style={inlineHintUnderlineStyle}>{hintText}</span>
+      <span style={inlineUnderlineStyle}>{hintText}</span>
     );
-    const hintContainerClassName = is_hidden
+    const hintContainerClassName = isHidden
       ? ""
       : showTrans
-        ? has_any_hint
+        ? hasAnyHint
           ? "group/editorhint inline-flex grow flex-col"
           : ""
-        : has_translation_hint
+        : hasTranslationHint
           ? cn(
               "group/tooltip relative inline-block align-baseline",
               "focus:outline-none focus-visible:rounded focus-visible:outline-2 focus-visible:outline-offset-2",
@@ -381,40 +403,38 @@ function StoryLineHints({
         key={`${hint.rangeFrom} ${hint.rangeTo + 1}`}
         className={cn(
           "select-text",
-          showTrans && has_any_hint && "border-s border-[#bfbfbf] ps-[5px]",
+          showTrans && hasAnyHint && "border-s border-[#bfbfbf] ps-[5px]",
           hintContainerClassName,
         )}
         interactive={isInteractive}
-        data-revealed={
-          was_hidden_for_challenge && !is_hidden ? true : undefined
-        }
+        data-revealed={wasHidden && !isHidden ? true : undefined}
       >
-        {word_content}
+        {wordContent}
         {showTrans ? (
-          has_any_hint ? (
+          hasAnyHint ? (
             <span
               className={cn(
                 "ms-[-4px] bg-[var(--editor-hints-background)] ps-[6px] text-[0.9em]",
                 hintTextClassName,
               )}
             >
-              {hint_translation ? <span>{hint_translation}</span> : null}
-              {hint_pronunciation ? (
+              {hintTranslation ? <span>{hintTranslation}</span> : null}
+              {hintPronunciation ? (
                 <span className="mt-0.5 block opacity-90">
-                  {hint_pronunciation}
+                  {hintPronunciation}
                 </span>
               ) : null}
             </span>
           ) : null
-        ) : has_translation_hint ? (
-          renderTooltip(hint_translation, hint_pronunciation, hintTextClassName)
+        ) : hasTranslationHint ? (
+          renderTooltip(hintTranslation!, hintPronunciation, hintTextClassName)
         ) : null}
       </Tooltip>,
     );
-    text_pos = hint.rangeTo + 1;
+    textPos = hint.rangeTo + 1;
   }
-  if (text_pos < visibleContent.text.length) {
-    elements.push(renderSplitText(text_pos, visibleContent.text.length));
+  if (textPos < visibleContent.text.length) {
+    elements.push(renderSplitText(textPos, visibleContent.text.length));
   }
 
   return elements;

--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -3,6 +3,9 @@ import { ContentWithHints } from "@/components/editor/story/syntax_parser_types"
 import type { EditorStateType } from "@/app/editor/story/[story]/editor_state";
 import { cn } from "@/lib/utils";
 
+type Range = { start: number; end: number };
+type HiddenState = boolean | undefined | "editor";
+
 const underlineBaseStyle: CSSProperties = {
   backgroundPosition: "0 100%",
   backgroundRepeat: "repeat-x",
@@ -18,16 +21,6 @@ const hiddenUnderlineStyle: CSSProperties = {
   backgroundImage:
     "linear-gradient(to right, var(--underline-solid) 60%, var(--underline-solid) 60%)",
 };
-const editorHintContainerStyle: CSSProperties = {
-  borderInlineStart: "1px solid #bfbfbf",
-  paddingInlineStart: "5px",
-};
-const editorHintTextStyle: CSSProperties = {
-  marginInlineStart: "-4px",
-  paddingInlineStart: "6px",
-  backgroundColor: "var(--editor-hints-background)",
-  fontSize: "0.9em",
-};
 const tooltipContainerStyle = {
   ...underlineBaseStyle,
   "--story-hint-underline": "var(--underline-dashed)",
@@ -37,55 +30,23 @@ const tooltipContainerStyle = {
   outlineColor: "var(--tooltip-border)",
 } as CSSProperties;
 const tooltipContentStyle: CSSProperties = {
-  bottom: "100%",
-  left: "50%",
-  zIndex: 10,
-  marginBottom: "4px",
-  transform: "translateX(-50%)",
-  borderRadius: "14px",
-  borderWidth: "2px",
-  borderStyle: "solid",
   borderColor: "var(--tooltip-border)",
   backgroundColor: "var(--tooltip-backgroud)",
-  padding: "7px 17px 6px",
-  fontSize: "19px",
   color: "var(--tooltip-color)",
 };
 const tooltipContentWithPronunciationStyle: CSSProperties = {
   ...tooltipContentStyle,
   bottom: "calc(115% + 4px)",
-  marginBottom: "8px",
 };
 const tooltipArrowStyle: CSSProperties = {
-  position: "absolute",
-  top: "100%",
-  left: "50%",
-  zIndex: 10,
-  marginTop: "-6px",
-  marginLeft: "-5px",
-  width: "10px",
-  height: "10px",
-  transform: "rotate(-45deg)",
-  borderWidth: "2px",
-  borderStyle: "solid",
   borderColor:
     "transparent transparent var(--tooltip-border) var(--tooltip-border)",
   backgroundColor: "var(--tooltip-backgroud)",
 };
-const pronunciationStyle: CSSProperties = {
-  bottom: "calc(100% - 6px)",
-  left: "50%",
-  transform: "translateX(-50%)",
-  fontSize: "0.62em",
-};
 
-function splitTextTokens(text: string, keep_tilde = true) {
+function splitTextTokens(text: string) {
   if (!text) return [];
-  if (keep_tilde)
-    //return text.split(/([\s\u2000-\u206F\u2E00-\u2E7F\\¡!"#$%&*,.\/:;<=>¿?@^_`{|}]+)/)
-    return text.split(/([\s\\¡!"#$%&*,./:;<=>¿?@^_`{|}]+)/);
-  //return text.split(/([\s\u2000-\u206F\u2E00-\u2E7F\\¡!"#$%&*,.\/:;<=>¿?@^_`{|}~]+)/)
-  else return text.split(/([\s\\¡!"#$%&*,./:;<=>¿?@^_`{|}~]+)/);
+  return text.split(/([\s\\¡!"#$%&*,./:;<=>¿?@^_`{|}]+)/);
 }
 
 function Tooltip({
@@ -194,7 +155,7 @@ function StoryLineHints({
 
   const showTrans = showTranslationsInline ?? false;
 
-  function getOverlap(
+  function overlaps(
     start1: number,
     end1: number,
     start2: number,
@@ -206,13 +167,16 @@ function StoryLineHints({
     return start2 <= start1 && start1 < end2;
   }
 
-  function addWord2(start: number, end: number) {
-    const was_hidden_for_challenge = hideRangesForChallenge?.some((range) =>
-      getOverlap(start, end, range.start, range.end),
+  function wasHiddenForChallenge(start: number, end: number) {
+    return hideRangesForChallenge?.some((range) =>
+      overlaps(start, end, range.start, range.end),
     );
-    let is_hidden: boolean | undefined | "editor" =
+  }
+
+  function getHiddenState(start: number, end: number): HiddenState {
+    let is_hidden: HiddenState =
       hideRangesForChallengeEntry !== undefined &&
-      getOverlap(
+      overlaps(
         start,
         end,
         hideRangesForChallengeEntry.start,
@@ -221,10 +185,13 @@ function StoryLineHints({
         ? true
         : undefined;
     if (is_hidden && editor) is_hidden = "editor";
+    return is_hidden;
+  }
+
+  function renderTextSegment(start: number, end: number) {
+    const was_hidden_for_challenge = wasHiddenForChallenge(start, end);
+    const is_hidden = getHiddenState(start, end);
     const style: CSSProperties = {};
-    //TODO
-    //if(is_hidden && window.view)
-    //    style.color = "#afafaf";
     if (audioRange && audioRange < start) style.opacity = 0.5;
     if (was_hidden_for_challenge && !is_hidden) {
       Object.assign(style, revealedUnderlineStyle);
@@ -260,38 +227,99 @@ function StoryLineHints({
     return returns;
   }
 
-  function addSplitWord(start: number, end: number) {
+  function renderSplitText(start: number, end: number) {
     let parts = splitTextTokens(visibleContent.text.substring(start, end));
     if (parts[0] === "") parts.splice(0, 1);
     if (parts[parts.length - 1] === "") parts.pop();
 
     if (parts.length === 1) {
-      return addWord2(start, end);
-      //addWord(dom, start, end);
-      //return dom;
+      return renderTextSegment(start, end);
     }
     let elements = [];
     for (let p of parts) {
-      for (let w of addWord2(start, start + p.length)) elements.push(w);
+      for (let w of renderTextSegment(start, start + p.length))
+        elements.push(w);
       start += p.length;
     }
-    // <span className="word">{content.text.substring(text_pos, hint.rangeFrom)}</span>
     return elements;
+  }
+
+  function renderPronunciation(
+    hint_pronunciation: string,
+    is_hidden: boolean | undefined,
+    inlineHintUnderlineStyle: CSSProperties | undefined,
+    children: React.ReactNode,
+  ) {
+    return (
+      <span className="group/pronunciation relative inline-block">
+        <span style={inlineHintUnderlineStyle}>{children}</span>
+        <span
+          className={cn(
+            "pointer-events-none invisible absolute bottom-[calc(100%-6px)] left-1/2 whitespace-nowrap text-[0.62em] leading-none opacity-0 transition-opacity duration-200",
+            !is_hidden &&
+              "group-hover/tooltip:visible group-hover/tooltip:opacity-95",
+            !is_hidden &&
+              "group-focus-within/tooltip:visible group-focus-within/tooltip:opacity-95",
+            showTrans &&
+              "group-hover/editorhint:visible group-hover/editorhint:opacity-95",
+            showTrans &&
+              "group-focus-within/editorhint:visible group-focus-within/editorhint:opacity-95",
+            "group-hover/pronunciation:visible group-hover/pronunciation:opacity-95",
+            "group-focus-within/pronunciation:visible group-focus-within/pronunciation:opacity-95",
+          )}
+          style={{ transform: "translateX(-50%)" }}
+        >
+          {hint_pronunciation}
+        </span>
+      </span>
+    );
+  }
+
+  function renderTooltip(
+    hint_translation: string,
+    hint_pronunciation: string | undefined,
+    hintTextClassName: string,
+  ) {
+    return (
+      <span
+        className={cn(
+          "bottom-full left-1/2 z-10 mb-1 rounded-[14px] border-2 px-[17px] pt-[7px] pb-[6px] text-center text-[19px]",
+          hint_pronunciation && "bottom-[calc(115%+4px)] mb-2",
+          hintTextClassName,
+        )}
+        data-hint-tooltip
+        style={
+          hint_pronunciation
+            ? {
+                ...tooltipContentWithPronunciationStyle,
+                transform: "translateX(-50%)",
+              }
+            : {
+                ...tooltipContentStyle,
+                transform: "translateX(-50%)",
+              }
+        }
+      >
+        <span>{hint_translation}</span>
+        <span
+          aria-hidden={true}
+          className="absolute top-full left-1/2 z-10 mt-[-6px] ml-[-5px] h-[10px] w-[10px] rotate-[-45deg] border-2"
+          style={tooltipArrowStyle}
+        />
+      </span>
+    );
   }
 
   let elements = [];
   let text_pos = 0;
-  // iterate over all hints
   for (let hint of visibleContent.hintMap) {
-    // add the text since the last hint
-    if (hint.rangeFrom > text_pos)
-      elements.push(addSplitWord(text_pos, hint.rangeFrom));
-    //addSplitWord(dom.append("span").attr("class", "word"), text_pos, hint.rangeFrom);
+    if (hint.rangeFrom > text_pos) {
+      elements.push(renderSplitText(text_pos, hint.rangeFrom));
+    }
 
-    // add the text with the hint
-    let is_hidden =
+    let is_hidden: boolean | undefined =
       hideRangesForChallengeEntry !== undefined &&
-      getOverlap(
+      overlaps(
         hint.rangeFrom,
         hint.rangeTo,
         hideRangesForChallengeEntry.start,
@@ -306,8 +334,9 @@ function StoryLineHints({
     const has_any_hint = Boolean(hint_translation || hint_pronunciation);
     const has_translation_hint = Boolean(hint_translation);
     const isInteractive = !is_hidden && !showTrans && has_translation_hint;
-    const was_hidden_for_challenge = hideRangesForChallenge?.some((range) =>
-      getOverlap(hint.rangeFrom, hint.rangeTo + 1, range.start, range.end),
+    const was_hidden_for_challenge = wasHiddenForChallenge(
+      hint.rangeFrom,
+      hint.rangeTo + 1,
     );
     const inlineHintUnderlineStyle =
       !showTrans &&
@@ -317,34 +346,16 @@ function StoryLineHints({
         ? tooltipContainerStyle
         : undefined;
 
+    const hintText = renderSplitText(hint.rangeFrom, hint.rangeTo + 1);
     const word_content = hint_pronunciation ? (
-      <span className="group/pronunciation relative inline-block">
-        <span style={inlineHintUnderlineStyle}>
-          {addSplitWord(hint.rangeFrom, hint.rangeTo + 1)}
-        </span>
-        <span
-          className={cn(
-            "pointer-events-none invisible absolute whitespace-nowrap leading-none opacity-0 transition-opacity duration-200",
-            !is_hidden &&
-              "group-hover/tooltip:visible group-hover/tooltip:opacity-95",
-            !is_hidden &&
-              "group-focus-within/tooltip:visible group-focus-within/tooltip:opacity-95",
-            showTrans &&
-              "group-hover/editorhint:visible group-hover/editorhint:opacity-95",
-            showTrans &&
-              "group-focus-within/editorhint:visible group-focus-within/editorhint:opacity-95",
-            "group-hover/pronunciation:visible group-hover/pronunciation:opacity-95",
-            "group-focus-within/pronunciation:visible group-focus-within/pronunciation:opacity-95",
-          )}
-          style={pronunciationStyle}
-        >
-          {hint_pronunciation}
-        </span>
-      </span>
+      renderPronunciation(
+        hint_pronunciation,
+        is_hidden,
+        inlineHintUnderlineStyle,
+        hintText,
+      )
     ) : (
-      <span style={inlineHintUnderlineStyle}>
-        {addSplitWord(hint.rangeFrom, hint.rangeTo + 1)}
-      </span>
+      <span style={inlineHintUnderlineStyle}>{hintText}</span>
     );
     const hintContainerClassName = is_hidden
       ? ""
@@ -364,21 +375,16 @@ function StoryLineHints({
           "pointer-events-none invisible absolute block w-auto whitespace-nowrap text-center font-normal not-italic opacity-0 transition-opacity duration-300 group-hover/tooltip:visible group-hover/tooltip:opacity-100 group-focus-within/tooltip:visible group-focus-within/tooltip:opacity-100",
           visibleContent.lang_hints,
         );
-    const hintHasChallengeUnderline =
-      Boolean(was_hidden_for_challenge) || Boolean(is_hidden);
-    const hintContainerStyle =
-      showTrans && has_any_hint ? editorHintContainerStyle : undefined;
-    const tooltipStyle =
-      hint_translation && hint_pronunciation
-        ? tooltipContentWithPronunciationStyle
-        : tooltipContentStyle;
 
     elements.push(
       <Tooltip
         key={`${hint.rangeFrom} ${hint.rangeTo + 1}`}
-        className={cn("select-text", hintContainerClassName)}
+        className={cn(
+          "select-text",
+          showTrans && has_any_hint && "border-s border-[#bfbfbf] ps-[5px]",
+          hintContainerClassName,
+        )}
         interactive={isInteractive}
-        style={hintContainerStyle}
         data-revealed={
           was_hidden_for_challenge && !is_hidden ? true : undefined
         }
@@ -386,7 +392,12 @@ function StoryLineHints({
         {word_content}
         {showTrans ? (
           has_any_hint ? (
-            <span className={hintTextClassName} style={editorHintTextStyle}>
+            <span
+              className={cn(
+                "ms-[-4px] bg-[var(--editor-hints-background)] ps-[6px] text-[0.9em]",
+                hintTextClassName,
+              )}
+            >
               {hint_translation ? <span>{hint_translation}</span> : null}
               {hint_pronunciation ? (
                 <span className="mt-0.5 block opacity-90">
@@ -396,26 +407,15 @@ function StoryLineHints({
             </span>
           ) : null
         ) : has_translation_hint ? (
-          <span
-            className={hintTextClassName}
-            data-hint-tooltip
-            style={tooltipStyle}
-          >
-            <span>{hint_translation}</span>
-            <span aria-hidden={true} style={tooltipArrowStyle} />
-          </span>
+          renderTooltip(hint_translation, hint_pronunciation, hintTextClassName)
         ) : null}
       </Tooltip>,
     );
-    //addSplitWord(dom.append("span").attr("class", "word tooltip"), hint.rangeFrom, hint.rangeTo+1)
-    //    .append("span").attr("class", "tooltiptext").text(content.hints[hint.hintIndex]);
-    // advance the position
     text_pos = hint.rangeTo + 1;
   }
-  // add the text after the last hint
-  if (text_pos < visibleContent.text.length)
-    elements.push(addSplitWord(text_pos, visibleContent.text.length));
-  //            addSplitWord(dom.append("span").attr("class", "word"), text_pos, content.text.length);
+  if (text_pos < visibleContent.text.length) {
+    elements.push(renderSplitText(text_pos, visibleContent.text.length));
+  }
 
   return elements;
 }


### PR DESCRIPTION
## Summary
- Simplified story quit behavior so closing the reader always confirms before leaving.
- Refactored hint rendering to remove the shared lookup/audio pause plumbing and align mobile hint layout more closely with the web reader.
- Streamlined story line and header audio playback by removing manual replay coordination and several layout-measurement workarounds.
- Updated the finished-story state to render as a full-screen takeover instead of an inline transcript block.

## Testing
- Not run
- Expected checks: `pnpm run format`
- Expected checks: `pnpm run lint`
- Expected checks: `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized story hint rendering to use a more robust text tokenization and segment-based approach, improving maintainability.
* **UI Improvements**
  * Updated hint underline and tooltip behavior/positioning (including pronunciation hints), with visibility now driven by the current hint state (e.g., revealed vs hidden) and available translation/pronunciation info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->