### PR TITLE
[codex] Harden mobile password input

### DIFF
--- a/app-mobile/app/auth.tsx
+++ b/app-mobile/app/auth.tsx
@@ -336,7 +336,10 @@ export default function AuthScreen() {
               onChangeText={setPassword}
               placeholder="Password"
               placeholderTextColor={colors.disabled}
+              autoCapitalize="none"
+              autoCorrect={false}
               secureTextEntry
+              spellCheck={false}
               textContentType={isRegister ? "newPassword" : "password"}
               returnKeyType="done"
               onSubmitEditing={() => void submit()}


### PR DESCRIPTION
## Summary

Adds explicit credential-field settings to the Expo mobile password input so iOS and keyboard integrations do not apply capitalization, autocorrection, or spellcheck to password entry.

## Why

A TestFlight user reported valid credentials failing after a password reset. The username in the report was plain ASCII and the app already trims usernames before sign-in, so username special characters are unlikely for that case. This change hardens the password field against subtle mobile text transformations while preserving existing auth behavior.

## Impact

Users should see the same sign-in UI, with password entry treated more explicitly as raw credential input on mobile.

## Validation

- `pnpm run format` passed in the original checkout
- `pnpm run lint` passed in the original checkout
- `pnpm --dir app-mobile typecheck` passed in the original checkout after installing mobile dependencies
- `pnpm typecheck` was run and failed on an existing unrelated `tmp/find-danish-audio-drift.ts` error

Note: I created this PR from a clean worktree off `origin/main` to avoid unrelated local story/script changes. Re-running root dependency install in that clean worktree hit a pnpm store write error fetching `postcss`, so the successful validation above came from the original checkout with the same auth-screen diff applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled spell checking in the password field for a smoother, more secure sign-in experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->