### PR TITLE
[codex] Virtualize mobile SVG-heavy lists

### DIFF
--- a/app-mobile/app/(tabs)/courses.tsx
+++ b/app-mobile/app/(tabs)/courses.tsx
@@ -3,10 +3,10 @@ import {
   ActionSheetIOS,
   ActivityIndicator,
   Alert,
+  FlatList,
   Modal,
   Platform,
   Pressable,
-  ScrollView,
   StyleSheet,
   View,
 } from "react-native";
@@ -218,6 +218,112 @@ export default function CoursesTab() {
     [confirmDeleteCourseProgress, progressByShort, removeCourse],
   );
 
+  const renderCourse = React.useCallback(
+    ({ item: course }: { item: CourseItem }) => {
+      const completed = Math.min(
+        course.count,
+        progressByShort[course.short]?.completedCount ?? 0,
+      );
+      const selected = course.short === courseShort;
+      const canRemoveCourse = completed === 0;
+
+      return (
+        <Pressable
+          accessibilityRole="button"
+          disabled={isOffline}
+          onPress={() => {
+            captureMobileEventLater("mobile_course_selected", {
+              course_short: course.short,
+              course_name: course.name,
+              from_language: course.fromLanguageName,
+            });
+            void setCourseShort(course.short).then(() =>
+              router.navigate("/(tabs)"),
+            );
+          }}
+          style={({ pressed }) => [
+            styles.card,
+            selected && styles.cardSelected,
+            isOffline && styles.cardDisabled,
+            pressed && !isOffline && { opacity: 0.75 },
+          ]}
+        >
+          <View style={styles.cardContent}>
+            <Flag
+              iso={course.learningLanguage.short}
+              flag={course.learningLanguage.flag}
+              flag_file={course.learningLanguage.flag_file}
+              width={48}
+            />
+            <View style={styles.cardBody}>
+              <View style={styles.cardTop}>
+                <View style={styles.cardTitleWrap}>
+                  <Text style={styles.courseName}>{course.name}</Text>
+                  <Text style={styles.courseMeta}>
+                    From {course.fromLanguageName}
+                  </Text>
+                </View>
+                {(selected || completed > 0 || canRemoveCourse) && (
+                  <View style={styles.cardActions}>
+                    {selected && (
+                      <Text style={styles.currentBadge}>Current</Text>
+                    )}
+                    {(completed > 0 || canRemoveCourse) && (
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel={`Open actions for ${course.name}`}
+                        hitSlop={10}
+                        onPress={(event) => {
+                          event.stopPropagation();
+                          openCourseActions(course);
+                        }}
+                        style={({ pressed }) => [
+                          styles.cardActionButton,
+                          pressed && { opacity: 0.6 },
+                        ]}
+                      >
+                        <Ionicons
+                          name="ellipsis-horizontal"
+                          size={22}
+                          color={colors.textDim}
+                        />
+                      </Pressable>
+                    )}
+                  </View>
+                )}
+              </View>
+              <View style={styles.progressTrack}>
+                <View
+                  style={[
+                    styles.progressFill,
+                    {
+                      width: `${
+                        course.count > 0
+                          ? Math.min(100, (completed / course.count) * 100)
+                          : 0
+                      }%`,
+                    },
+                  ]}
+                />
+              </View>
+              <Text style={styles.progressText}>
+                {completed} / {course.count} stories completed
+              </Text>
+            </View>
+          </View>
+        </Pressable>
+      );
+    },
+    [
+      courseShort,
+      isOffline,
+      openCourseActions,
+      progressByShort,
+      router,
+      setCourseShort,
+    ],
+  );
+
   return (
     <SafeAreaView style={styles.root} edges={["top"]}>
       <View style={styles.header}>
@@ -257,109 +363,22 @@ export default function CoursesTab() {
           />
         </View>
       ) : (
-        <ScrollView contentContainerStyle={styles.listContent}>
-          {isOffline ? (
-            <OfflineNotice detail="Connect to the internet to switch or add courses." />
-          ) : null}
-          {courses.map((course) => {
-            const completed = Math.min(
-              course.count,
-              progressByShort[course.short]?.completedCount ?? 0,
-            );
-            const selected = course.short === courseShort;
-            const canRemoveCourse = completed === 0;
-            return (
-              <Pressable
-                key={course.short}
-                accessibilityRole="button"
-                disabled={isOffline}
-                onPress={() => {
-                  captureMobileEventLater("mobile_course_selected", {
-                    course_short: course.short,
-                    course_name: course.name,
-                    from_language: course.fromLanguageName,
-                  });
-                  void setCourseShort(course.short).then(() =>
-                    router.navigate("/(tabs)"),
-                  );
-                }}
-                style={({ pressed }) => [
-                  styles.card,
-                  selected && styles.cardSelected,
-                  isOffline && styles.cardDisabled,
-                  pressed && !isOffline && { opacity: 0.75 },
-                ]}
-              >
-                <View style={styles.cardContent}>
-                  <Flag
-                    iso={course.learningLanguage.short}
-                    flag={course.learningLanguage.flag}
-                    flag_file={course.learningLanguage.flag_file}
-                    width={48}
-                  />
-                  <View style={styles.cardBody}>
-                    <View style={styles.cardTop}>
-                      <View style={styles.cardTitleWrap}>
-                        <Text style={styles.courseName}>{course.name}</Text>
-                        <Text style={styles.courseMeta}>
-                          From {course.fromLanguageName}
-                        </Text>
-                      </View>
-                      {(selected || completed > 0 || canRemoveCourse) && (
-                        <View style={styles.cardActions}>
-                          {selected && (
-                            <Text style={styles.currentBadge}>Current</Text>
-                          )}
-                          {(completed > 0 || canRemoveCourse) && (
-                            <Pressable
-                              accessibilityRole="button"
-                              accessibilityLabel={`Open actions for ${course.name}`}
-                              hitSlop={10}
-                              onPress={(event) => {
-                                event.stopPropagation();
-                                openCourseActions(course);
-                              }}
-                              style={({ pressed }) => [
-                                styles.cardActionButton,
-                                pressed && { opacity: 0.6 },
-                              ]}
-                            >
-                              <Ionicons
-                                name="ellipsis-horizontal"
-                                size={22}
-                                color={colors.textDim}
-                              />
-                            </Pressable>
-                          )}
-                        </View>
-                      )}
-                    </View>
-                    <View style={styles.progressTrack}>
-                      <View
-                        style={[
-                          styles.progressFill,
-                          {
-                            width: `${
-                              course.count > 0
-                                ? Math.min(
-                                    100,
-                                    (completed / course.count) * 100,
-                                  )
-                                : 0
-                            }%`,
-                          },
-                        ]}
-                      />
-                    </View>
-                    <Text style={styles.progressText}>
-                      {completed} / {course.count} stories completed
-                    </Text>
-                  </View>
-                </View>
-              </Pressable>
-            );
-          })}
-        </ScrollView>
+        <FlatList
+          data={courses}
+          keyExtractor={(course) => course.short}
+          renderItem={renderCourse}
+          contentContainerStyle={styles.listContent}
+          ListHeaderComponent={
+            isOffline ? (
+              <OfflineNotice detail="Connect to the internet to switch or add courses." />
+            ) : null
+          }
+          initialNumToRender={6}
+          maxToRenderPerBatch={4}
+          removeClippedSubviews={Platform.OS === "android"}
+          updateCellsBatchingPeriod={80}
+          windowSize={5}
+        />
       )}
       <Modal
         visible={Platform.OS !== "ios" && Boolean(actionCourse)}

--- a/app-mobile/app/(tabs)/index.tsx
+++ b/app-mobile/app/(tabs)/index.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import {
   ActivityIndicator,
-  ScrollView,
+  FlatList,
+  Platform,
   StyleSheet,
   Switch,
   View,
@@ -26,6 +27,8 @@ import { OfflineNotice } from "../../src/components/OfflineNotice";
 import { Text } from "../../src/components/Text";
 import { colors } from "../../src/theme";
 
+type StorySet = { setId: number; stories: StoryListItem[] };
+
 /** Learn tab: the current course's stories, grouped by set. */
 export default function LearnTab() {
   const router = useRouter();
@@ -48,6 +51,61 @@ export default function LearnTab() {
     if (!serverDoneIds) return null;
     return new Set(serverDoneIds);
   }, [serverDoneIds]);
+  const stories = React.useMemo(
+    () => (course && course !== null ? (course.stories as StoryListItem[]) : []),
+    [course],
+  );
+  const isStoryDone = React.useCallback(
+    (storyId: number) =>
+      session?.session
+        ? Boolean(serverDoneSet?.has(storyId))
+        : Boolean(doneMap[String(storyId)]),
+    [doneMap, serverDoneSet, session?.session],
+  );
+  const doneCount = React.useMemo(
+    () => stories.filter((story) => isStoryDone(story.id)).length,
+    [isStoryDone, stories],
+  );
+  const isServerProgressPending =
+    Boolean(session?.session) && serverDoneIds === undefined && !isOffline;
+  const sets = React.useMemo(() => {
+    const grouped: StorySet[] = [];
+    for (const story of stories) {
+      const last = grouped[grouped.length - 1];
+      if (last && last.setId === story.set_id) last.stories.push(story);
+      else grouped.push({ setId: story.set_id, stories: [story] });
+    }
+    return grouped;
+  }, [stories]);
+  const renderStorySet = React.useCallback(
+    ({ item }: { item: StorySet }) => (
+      <View style={styles.set}>
+        <Text style={styles.setTitle}>Set {item.setId}</Text>
+        <View style={styles.setGrid}>
+          {item.stories.map((story) => (
+            <StoryButton
+              key={story.id}
+              story={story}
+              done={isStoryDone(story.id)}
+              listeningMode={listening}
+              disabled={isOffline}
+              onPress={() => {
+                captureMobileEventLater("story_opened", {
+                  story_id: story.id,
+                  course_short: courseShort,
+                  listening_mode: listening,
+                });
+                router.push(
+                  `/story/${story.id}?listening=${listening ? "1" : "0"}`,
+                );
+              }}
+            />
+          ))}
+        </View>
+      </View>
+    ),
+    [courseShort, isOffline, isStoryDone, listening, router],
+  );
 
   // Reload local progress whenever the tab regains focus (e.g. after a story).
   useFocusEffect(
@@ -117,23 +175,6 @@ export default function LearnTab() {
     );
   }
 
-  const stories = course.stories as StoryListItem[];
-  const isStoryDone = (storyId: number) =>
-    session?.session
-      ? Boolean(serverDoneSet?.has(storyId))
-      : Boolean(doneMap[String(storyId)]);
-  const doneCount = stories.filter((story) => isStoryDone(story.id)).length;
-  const isServerProgressPending =
-    Boolean(session?.session) && serverDoneIds === undefined && !isOffline;
-
-  // Stories arrive sorted by (set_id, set_index); group them into sets.
-  const sets: { setId: number; stories: StoryListItem[] }[] = [];
-  for (const story of stories) {
-    const last = sets[sets.length - 1];
-    if (last && last.setId === story.set_id) last.stories.push(story);
-    else sets.push({ setId: story.set_id, stories: [story] });
-  }
-
   return (
     <SafeAreaView style={styles.root} edges={["top"]}>
       <View style={styles.header}>
@@ -172,41 +213,25 @@ export default function LearnTab() {
         </View>
       </View>
 
-      <ScrollView contentContainerStyle={styles.scrollContent}>
-        {isOffline ? (
-          <View style={styles.offlineWrap}>
-            <OfflineNotice detail="Connect to the internet to open stories." />
-          </View>
-        ) : null}
-
-        {sets.map((set) => (
-          <View key={set.setId} style={styles.set}>
-            <Text style={styles.setTitle}>Set {set.setId}</Text>
-            <View style={styles.setGrid}>
-              {set.stories.map((story) => (
-                <StoryButton
-                  key={story.id}
-                  story={story}
-                  done={isStoryDone(story.id)}
-                  listeningMode={listening}
-                  disabled={isOffline}
-                  onPress={() => {
-                    captureMobileEventLater("story_opened", {
-                      story_id: story.id,
-                      course_short: courseShort,
-                      listening_mode: listening,
-                    });
-                    router.push(
-                      `/story/${story.id}?listening=${listening ? "1" : "0"}`,
-                    );
-                  }}
-                />
-              ))}
+      <FlatList
+        data={sets}
+        keyExtractor={(set) => String(set.setId)}
+        renderItem={renderStorySet}
+        contentContainerStyle={styles.scrollContent}
+        ListHeaderComponent={
+          isOffline ? (
+            <View style={styles.offlineWrap}>
+              <OfflineNotice detail="Connect to the internet to open stories." />
             </View>
-          </View>
-        ))}
-        <View style={{ height: 40 }} />
-      </ScrollView>
+          ) : null
+        }
+        ListFooterComponent={<View style={styles.listFooter} />}
+        initialNumToRender={3}
+        maxToRenderPerBatch={3}
+        removeClippedSubviews={Platform.OS === "android"}
+        updateCellsBatchingPeriod={80}
+        windowSize={5}
+      />
     </SafeAreaView>
   );
 }
@@ -314,5 +339,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     justifyContent: "center",
+  },
+  listFooter: {
+    height: 40,
   },
 });


### PR DESCRIPTION
## Summary

- Virtualizes the mobile Courses tab list with FlatList so offscreen flag SVGs are not mounted/drawn.
- Virtualizes the mobile Learn tab by story set so offscreen story artwork SVGs are not mounted/drawn.
- Keeps existing card/set UI and offline notices intact while reducing native SVG draw pressure.

## Why

Play Console reported a user-perceived ANR in react-native-svg/Fabric during native drawing. The affected screens can render many SVG-backed flags and story icons in plain ScrollViews. Virtualizing these lists lowers the number of mounted SVG views and should reduce the chance of Android input dispatch timing out during heavy draw work.

## Validation

- pnpm run format
- pnpm run lint
- git diff --check

## Notes

- pnpm typecheck is currently blocked by existing dependency resolution errors in Convex/auth files: missing jose and @better-auth/expo from the root typecheck path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling and loading behavior on the Courses and Learn tabs for smoother browsing.
  * Kept offline messaging visible while making list rendering more reliable.
  * Preserved course actions and current-course indicators when interacting with the list.

* **Performance**
  * Updated both tabs to use more efficient list rendering, which should help with responsiveness on longer course and story lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->