### PR TITLE
[codex] Remove foreground service permissions

### DIFF
--- a/app-mobile/app.json
+++ b/app-mobile/app.json
@@ -18,6 +18,10 @@
     },
     "android": {
       "package": "org.duostories.twa",
+      "blockedPermissions": [
+        "android.permission.FOREGROUND_SERVICE",
+        "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
+      ],
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/android-icon-foreground.png",
@@ -32,7 +36,12 @@
     "plugins": [
       "expo-router",
       "expo-image",
-      "expo-audio",
+      [
+        "expo-audio",
+        {
+          "enableBackgroundPlayback": false
+        }
+      ],
       "expo-secure-store",
       "expo-web-browser",
       "expo-localization",


### PR DESCRIPTION
## Summary

Removes Android foreground-service media playback declarations from the mobile app for the next release.

## What changed

- Configures the `expo-audio` plugin with `enableBackgroundPlayback: false`.
- Adds Android `blockedPermissions` for `android.permission.FOREGROUND_SERVICE` and `android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK`.

## Why

Lock-screen/background autoplay is not reliable enough for this release. Removing these permissions avoids the Google Play foreground-service declaration requirement until we implement a proper continuous/native playback path in a later release.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm --dir app-mobile exec expo config --type introspect --json` confirmed foreground-service permissions are removal nodes and no audio service is generated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app configuration to block two Android foreground service permissions.
  * Adjusted audio plugin settings to disable background playback on mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->