### PR TITLE
[codex] Add stitched story audio playback

### DIFF
--- a/app-mobile/src/story/Part.tsx
+++ b/app-mobile/src/story/Part.tsx
@@ -29,6 +29,7 @@ export type PartSettings = {
   rtl: boolean;
   audioAutoPlay: boolean;
   audioReplayKey: number;
+  audioRangeOverride?: number;
   onManualAudioPlay?: () => void;
 };
 
@@ -52,6 +53,7 @@ function HeaderPart({ parts, active, setButtonStatus, settings }: PartProps) {
         rtl={settings.rtl}
         autoPlay={settings.audioAutoPlay}
         replayKey={settings.audioReplayKey}
+        audioRangeOverride={settings.audioRangeOverride}
         onManualAudioPlay={settings.onManualAudioPlay}
       />
     </FadeIn>
@@ -72,6 +74,7 @@ function LinePart({ parts, active, setButtonStatus, settings }: PartProps) {
         rtl={settings.rtl}
         autoPlay={settings.audioAutoPlay}
         replayKey={settings.audioReplayKey}
+        audioRangeOverride={settings.audioRangeOverride}
         onManualAudioPlay={settings.onManualAudioPlay}
       />
     </FadeIn>
@@ -113,6 +116,7 @@ function MultipleChoicePart({
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -142,6 +146,7 @@ function MultipleChoicePart({
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -181,6 +186,7 @@ function ContinuationPart({
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -202,6 +208,7 @@ function ContinuationPart({
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -244,6 +251,7 @@ function SelectPhrasesPart({
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -265,6 +273,7 @@ function SelectPhrasesPart({
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -302,6 +311,7 @@ function ArrangePart({ parts, setButtonStatus, active, settings }: PartProps) {
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -323,6 +333,7 @@ function ArrangePart({ parts, setButtonStatus, active, settings }: PartProps) {
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -370,6 +381,7 @@ function PointToPhrasePart({
           rtl={settings.rtl}
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
+          audioRangeOverride={settings.audioRangeOverride}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>

--- a/app-mobile/src/story/Part.tsx
+++ b/app-mobile/src/story/Part.tsx
@@ -398,6 +398,7 @@ function PointToPhrasePart({
             rtl={settings.rtl}
             autoPlay={settings.audioAutoPlay}
             replayKey={settings.audioReplayKey}
+            audioRangeOverride={settings.audioRangeOverride}
             onManualAudioPlay={settings.onManualAudioPlay}
           />
         </FadeIn>

--- a/app-mobile/src/story/Reader.tsx
+++ b/app-mobile/src/story/Reader.tsx
@@ -19,6 +19,7 @@ import { Part } from "./Part";
 import { Footer, type NextStoryPreview } from "./Footer";
 import { HintLookupContext } from "./HintPopup";
 import { SmartImage } from "../components/SmartImage";
+import { useStitchedListeningAudio } from "./useStitchedListeningAudio";
 import type { StoryData } from "./types";
 
 const noop = () => {};
@@ -136,6 +137,34 @@ export function Reader({
     storyProgress,
   ]);
 
+  const handleStitchedPartChange = React.useCallback(
+    (partIndex: number) => {
+      const nextPart = partsList[partIndex];
+      if (!nextPart) return;
+      requestScrollToNewContent();
+      setPartProgress(0);
+      setStoryProgress(partIndex);
+      setButtonStatus(getInitialButtonStatus(nextPart, hideQuestions));
+    },
+    [hideQuestions, partsList, requestScrollToNewContent],
+  );
+
+  const handleStitchedFinished = React.useCallback(() => {
+    requestScrollToNewContent();
+    setPartProgress(0);
+    setStoryProgress(partsList.length);
+    setButtonStatus("finished");
+  }, [partsList.length, requestScrollToNewContent]);
+
+  const stitchedAudio = useStitchedListeningAudio({
+    enabled: listening,
+    story,
+    paused: listeningPaused,
+    onPartChange: handleStitchedPartChange,
+    onFinished: handleStitchedFinished,
+  });
+  const useStitchedAudio = listening && stitchedAudio.isReady;
+
   const pauseListening = React.useCallback(() => {
     stopAudio(false);
     setListeningPaused(true);
@@ -154,24 +183,30 @@ export function Reader({
   const replayListening = React.useCallback(() => {
     stopAudio();
     setListeningPaused(false);
+    if (useStitchedAudio) {
+      stitchedAudio.replay();
+      return;
+    }
     setAudioReplayKey((key) => key + 1);
-  }, []);
+  }, [stitchedAudio, useStitchedAudio]);
 
   const skipListening = React.useCallback(() => {
     stopAudio();
     setListeningPaused(false);
+    if (useStitchedAudio && stitchedAudio.skipToNext()) return;
     void next();
-  }, [next]);
+  }, [next, stitchedAudio, useStitchedAudio]);
 
   const handleManualAudioPlay = React.useCallback(
     (partIndex: number) => {
       if (!listening) return;
-      setListeningPaused(false);
+      if (useStitchedAudio) setListeningPaused(true);
+      else setListeningPaused(false);
       setPartProgress(0);
       setStoryProgress(partIndex);
       setButtonStatus(getInitialButtonStatus(partsList[partIndex], hideQuestions));
     },
-    [hideQuestions, listening, partsList],
+    [hideQuestions, listening, partsList, useStitchedAudio],
   );
 
   // Record completion exactly once when the end is reached.
@@ -192,7 +227,7 @@ export function Reader({
   const listeningPausedRef = React.useRef(listeningPaused);
   listeningPausedRef.current = listeningPaused;
   React.useEffect(() => {
-    if (!listening) return;
+    if (!listening || useStitchedAudio) return;
     return onAnyAudioDone(() => {
       setTimeout(() => {
         if (
@@ -203,7 +238,7 @@ export function Reader({
         }
       }, 500);
     });
-  }, [listening]);
+  }, [listening, useStitchedAudio]);
 
   // Keep the newest line in view only after an intentional reveal. Text and
   // bubble measurement can also change content size; those layout passes should
@@ -274,8 +309,10 @@ export function Reader({
                 settings={{
                   hideQuestions,
                   rtl: story.learning_language_rtl,
-                  audioAutoPlay: !listeningPaused,
+                  audioAutoPlay: !listeningPaused && !useStitchedAudio,
                   audioReplayKey,
+                  audioRangeOverride:
+                    useStitchedAudio && active ? stitchedAudio.audioRange : undefined,
                   onManualAudioPlay: () => handleManualAudioPlay(index),
                 }}
               />

--- a/app-mobile/src/story/Reader.tsx
+++ b/app-mobile/src/story/Reader.tsx
@@ -164,6 +164,8 @@ export function Reader({
     onFinished: handleStitchedFinished,
   });
   const useStitchedAudio = listening && stitchedAudio.isReady;
+  const stitchedAudioRangeOverride =
+    useStitchedAudio && !listeningPaused ? stitchedAudio.audioRange : undefined;
 
   const pauseListening = React.useCallback(() => {
     stopAudio(false);
@@ -311,8 +313,9 @@ export function Reader({
                   rtl: story.learning_language_rtl,
                   audioAutoPlay: !listeningPaused && !useStitchedAudio,
                   audioReplayKey,
-                  audioRangeOverride:
-                    useStitchedAudio && active ? stitchedAudio.audioRange : undefined,
+                  audioRangeOverride: active
+                    ? stitchedAudioRangeOverride
+                    : undefined,
                   onManualAudioPlay: () => handleManualAudioPlay(index),
                 }}
               />

--- a/app-mobile/src/story/elements/Header.tsx
+++ b/app-mobile/src/story/elements/Header.tsx
@@ -14,6 +14,7 @@ export function Header({
   rtl,
   autoPlay = true,
   replayKey = 0,
+  audioRangeOverride,
   onManualAudioPlay,
 }: {
   element: StoryElementHeader;
@@ -21,25 +22,27 @@ export function Header({
   rtl: boolean;
   autoPlay?: boolean;
   replayKey?: number;
+  audioRangeOverride?: number;
   onManualAudioPlay?: () => void;
 }) {
   const audio = element.learningLanguageTitleContent?.audio;
-  const { audioRange, play, hasAudio } = useLineAudio(
+  const lineAudio = useLineAudio(
     audio,
     active,
     autoPlay,
     replayKey,
   );
+  const audioRange = audioRangeOverride ?? lineAudio.audioRange;
   const handlePlay = React.useCallback(() => {
     onManualAudioPlay?.();
-    play();
-  }, [onManualAudioPlay, play]);
+    lineAudio.play();
+  }, [lineAudio, onManualAudioPlay]);
 
   return (
     <View style={styles.root}>
       <SmartImage uri={element.illustrationUrl} width={175} height={175} />
       <View style={[styles.titleRow, rtl && styles.titleRowRtl]}>
-        {hasAudio && <PlayAudioButton onPress={handlePlay} rtl={rtl} />}
+        {lineAudio.hasAudio && <PlayAudioButton onPress={handlePlay} rtl={rtl} />}
         <HintText
           content={element.learningLanguageTitleContent}
           audioRange={audioRange}

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -119,6 +119,7 @@ export function TextLine({
   rtl,
   autoPlay = true,
   replayKey = 0,
+  audioRangeOverride,
   onManualAudioPlay,
 }: {
   element: StoryElementLine;
@@ -127,19 +128,21 @@ export function TextLine({
   rtl: boolean;
   autoPlay?: boolean;
   replayKey?: number;
+  audioRangeOverride?: number;
   onManualAudioPlay?: () => void;
 }) {
   const audio = element.line?.content?.audio;
-  const { audioRange, play, hasAudio } = useLineAudio(
+  const lineAudio = useLineAudio(
     audio,
     active,
     autoPlay,
     replayKey,
   );
+  const audioRange = audioRangeOverride ?? lineAudio.audioRange;
   const handlePlay = React.useCallback(() => {
     onManualAudioPlay?.();
-    play();
-  }, [onManualAudioPlay, play]);
+    lineAudio.play();
+  }, [lineAudio, onManualAudioPlay]);
 
   const lineRtl = getStoryLineRtl({
     storyRtl: rtl,
@@ -156,7 +159,7 @@ export function TextLine({
   if (element.line.type === "TITLE") {
     return (
       <View style={[styles.row, lineRtl && styles.rowRtl]}>
-        <LineBody hasAudio={hasAudio} onPlay={handlePlay} rtl={lineRtl}>
+        <LineBody hasAudio={lineAudio.hasAudio} onPlay={handlePlay} rtl={lineRtl}>
           <HintText
             content={element.line.content}
             audioRange={audioRange}
@@ -213,7 +216,7 @@ export function TextLine({
                 rtl={lineRtl}
                 containerStyle={lineRtl ? styles.rtlBubbleText : undefined}
                 leadingElement={
-                  hasAudio ? (
+                  lineAudio.hasAudio ? (
                     <PlayAudioButton onPress={handlePlay} rtl={lineRtl} />
                   ) : undefined
                 }
@@ -233,7 +236,7 @@ export function TextLine({
   // PROSE (or CHARACTER without avatar)
   return (
     <View style={[styles.row, lineRtl && styles.rowRtl]}>
-      <LineBody hasAudio={hasAudio} onPlay={handlePlay} rtl={lineRtl}>
+      <LineBody hasAudio={lineAudio.hasAudio} onPlay={handlePlay} rtl={lineRtl}>
         <HintText
           content={element.line.content}
           audioRange={audioRange}

--- a/app-mobile/src/story/useStitchedListeningAudio.ts
+++ b/app-mobile/src/story/useStitchedListeningAudio.ts
@@ -1,0 +1,311 @@
+import React from "react";
+import { createAudioPlayer } from "expo-audio";
+import type { AudioPlayer } from "expo-audio";
+import { stopAudio } from "./audio";
+import type { StoryData } from "./types";
+
+const STATUS_UPDATE_INTERVAL_MS = 50;
+const FETCH_TIMEOUT_MS = 2500;
+const PLAYBACK_START_TIMEOUT_MS = 3000;
+
+type StitchedAudioStatus = "disabled" | "loading" | "ready" | "unavailable";
+
+type StitchedSegment = {
+  partIndex: number;
+  startMs: number;
+  endMs: number;
+  keypoints?: { rangeEnd: number; startMs: number }[];
+};
+
+type StitchedManifest = {
+  storyId: number;
+  audio: { filename: string };
+  durationMs: number;
+  segments: StitchedSegment[];
+};
+
+type CourseSummary = {
+  results: {
+    storyId: number;
+    status: string;
+    outputDir?: string;
+  }[];
+};
+
+type ResolvedManifest = {
+  manifest: StitchedManifest;
+  audioUrl: string;
+};
+
+const rootUrl = process.env.EXPO_PUBLIC_STITCHED_AUDIO_ROOT_URL?.replace(
+  /\/+$/,
+  "",
+);
+
+function trimLeadingTmp(path: string) {
+  return path.replace(/^tmp\//, "");
+}
+
+function joinUrl(...parts: string[]) {
+  return parts
+    .map((part, index) =>
+      index === 0 ? part.replace(/\/+$/, "") : part.replace(/^\/+|\/+$/g, ""),
+    )
+    .filter(Boolean)
+    .join("/");
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}: ${response.status}`);
+    }
+    return (await response.json()) as T;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function resolveManifest(story: StoryData): Promise<ResolvedManifest | null> {
+  if (!rootUrl) return null;
+
+  const summaryCandidates = [
+    {
+      url: joinUrl(rootUrl, "story-audio", "courses", story.course_short, "summary.json"),
+      stripTmp: true,
+    },
+    {
+      url: joinUrl(
+        rootUrl,
+        "tmp",
+        "story-audio",
+        "courses",
+        story.course_short,
+        "summary.json",
+      ),
+      stripTmp: false,
+    },
+  ];
+
+  for (const candidate of summaryCandidates) {
+    try {
+      const summary = await fetchJson<CourseSummary>(candidate.url);
+      const result = summary.results.find(
+        (item) => item.storyId === story.id && item.status === "ok" && item.outputDir,
+      );
+      if (!result?.outputDir) return null;
+
+      const outputDir = candidate.stripTmp
+        ? trimLeadingTmp(result.outputDir)
+        : result.outputDir;
+      const manifestUrl = joinUrl(rootUrl, outputDir, "joined.audio.json");
+      const manifest = await fetchJson<StitchedManifest>(manifestUrl);
+      return {
+        manifest,
+        audioUrl: joinUrl(rootUrl, outputDir, manifest.audio.filename),
+      };
+    } catch {
+      // Try the next root layout. This is a temporary local-hosting path.
+    }
+  }
+
+  return null;
+}
+
+function getActiveSegment(
+  segments: StitchedSegment[],
+  currentTimeMs: number,
+): StitchedSegment | undefined {
+  let active: StitchedSegment | undefined;
+  for (const segment of segments) {
+    if (segment.startMs <= currentTimeMs) active = segment;
+    else break;
+  }
+  return active;
+}
+
+function getAudioRange(
+  segment: StitchedSegment | undefined,
+  currentTimeMs: number,
+): number | undefined {
+  if (!segment?.keypoints?.length) return undefined;
+
+  let rangeEnd: number | undefined;
+  let latestStart = Number.NEGATIVE_INFINITY;
+  for (const keypoint of segment.keypoints) {
+    if (keypoint.startMs <= currentTimeMs && keypoint.startMs >= latestStart) {
+      latestStart = keypoint.startMs;
+      rangeEnd = keypoint.rangeEnd;
+    }
+  }
+  return rangeEnd;
+}
+
+export function useStitchedListeningAudio({
+  enabled,
+  story,
+  paused,
+  onPartChange,
+  onFinished,
+}: {
+  enabled: boolean;
+  story: StoryData;
+  paused: boolean;
+  onPartChange: (partIndex: number) => void;
+  onFinished: () => void;
+}) {
+  const [status, setStatus] = React.useState<StitchedAudioStatus>(
+    rootUrl ? "loading" : "disabled",
+  );
+  const [audioRange, setAudioRange] = React.useState<number | undefined>();
+  const manifestRef = React.useRef<StitchedManifest | null>(null);
+  const playerRef = React.useRef<AudioPlayer | null>(null);
+  const subscriptionRef = React.useRef<{ remove: () => void } | null>(null);
+  const activePartRef = React.useRef<number | null>(null);
+  const finishedRef = React.useRef(false);
+  const pausedRef = React.useRef(paused);
+  pausedRef.current = paused;
+
+  const cleanup = React.useCallback(() => {
+    const player = playerRef.current;
+    subscriptionRef.current?.remove();
+    subscriptionRef.current = null;
+    playerRef.current = null;
+    manifestRef.current = null;
+    activePartRef.current = null;
+    finishedRef.current = false;
+    setAudioRange(undefined);
+    if (player) {
+      try {
+        player.pause();
+        player.remove();
+      } catch {}
+    }
+  }, []);
+
+  React.useEffect(() => cleanup, [cleanup]);
+
+  React.useEffect(() => {
+    cleanup();
+    if (!enabled || !rootUrl) {
+      setStatus(rootUrl ? "disabled" : "unavailable");
+      return;
+    }
+
+    let cancelled = false;
+    setStatus("loading");
+    void resolveManifest(story)
+      .then((resolved) => {
+        if (cancelled) return;
+        if (!resolved) {
+          setStatus("unavailable");
+          return;
+        }
+
+        stopAudio(false);
+        manifestRef.current = resolved.manifest;
+        const player = createAudioPlayer(
+          { uri: resolved.audioUrl },
+          { updateInterval: STATUS_UPDATE_INTERVAL_MS },
+        );
+        playerRef.current = player;
+        let activated = false;
+        const startupTimeout = setTimeout(() => {
+          if (activated || cancelled) return;
+          setStatus("unavailable");
+          cleanup();
+        }, PLAYBACK_START_TIMEOUT_MS);
+
+        const subscription = player.addListener("playbackStatusUpdate", (status) => {
+          const manifest = manifestRef.current;
+          if (!manifest) return;
+
+          if (!activated && (status.playing || status.currentTime > 0)) {
+            activated = true;
+            clearTimeout(startupTimeout);
+            stopAudio(false);
+            setStatus("ready");
+          }
+
+          const currentTimeMs = Math.max(status.currentTime, player.currentTime) * 1000;
+          const segment = getActiveSegment(manifest.segments, currentTimeMs);
+          if (segment && segment.partIndex !== activePartRef.current) {
+            activePartRef.current = segment.partIndex;
+            onPartChange(segment.partIndex);
+          }
+          setAudioRange(getAudioRange(segment, currentTimeMs));
+
+          if (status.didJustFinish && !finishedRef.current) {
+            finishedRef.current = true;
+            setAudioRange(undefined);
+            onFinished();
+          }
+        });
+        subscriptionRef.current = subscription;
+        if (!pausedRef.current) player.play();
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStatus("unavailable");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cleanup, enabled, onFinished, onPartChange, story]);
+
+  React.useEffect(() => {
+    if (status !== "ready") return;
+    const player = playerRef.current;
+    if (!player) return;
+    if (paused) player.pause();
+    else player.play();
+  }, [paused, status]);
+
+  const replay = React.useCallback(() => {
+    const player = playerRef.current;
+    if (!player) return;
+    finishedRef.current = false;
+    void player.seekTo(0).then(() => {
+      activePartRef.current = null;
+      onPartChange(0);
+      player.play();
+    });
+  }, [onPartChange]);
+
+  const skipToNext = React.useCallback(() => {
+    const player = playerRef.current;
+    const manifest = manifestRef.current;
+    if (!player || !manifest) return false;
+
+    const currentTimeMs = player.currentTime * 1000;
+    const nextSegment = manifest.segments.find(
+      (segment) => segment.startMs > currentTimeMs + 100,
+    );
+    if (!nextSegment) {
+      finishedRef.current = true;
+      onFinished();
+      return true;
+    }
+
+    void player.seekTo(nextSegment.startMs / 1000).then(() => {
+      activePartRef.current = nextSegment.partIndex;
+      onPartChange(nextSegment.partIndex);
+      player.play();
+    });
+    return true;
+  }, [onFinished, onPartChange]);
+
+  return {
+    status,
+    audioRange,
+    isReady: status === "ready",
+    isUnavailable: status === "unavailable" || status === "disabled",
+    replay,
+    skipToNext,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "optimize:flags": "pnpm dlx svgo -f flags --multipass",
     "audit:missing-story-images": "pnpm exec tsx scripts/find-missing-story-images.ts",
     "backfill:discord-avatars": "pnpm exec tsx scripts/backfill-discord-avatars.ts",
-    "backfill:course-contributors": "pnpm exec tsx scripts/backfill-course-contributors.ts"
+    "backfill:course-contributors": "pnpm exec tsx scripts/backfill-course-contributors.ts",
+    "audio:join-story": "tsx scripts/generate-joined-story-audio.ts",
+    "audio:join-course": "tsx scripts/generate-course-joined-audio.ts",
+    "audio:upload-joined": "tsx scripts/upload-joined-story-audio.ts"
   },
   "dependencies": {
     "@aws-sdk/client-polly": "^3.1061.0",

--- a/scripts/generate-course-joined-audio.ts
+++ b/scripts/generate-course-joined-audio.ts
@@ -1,0 +1,440 @@
+import dotenv from "dotenv";
+import { ConvexHttpClient } from "convex/browser";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { api } from "../convex/_generated/api";
+
+dotenv.config({ path: ".env.local" });
+
+type StorySummary = {
+  id: number;
+  name: string;
+  public: boolean;
+  set_id: number;
+  set_index: number;
+};
+
+type CourseSummary = {
+  id: number;
+  short: string;
+};
+
+type CliOptions = {
+  course: string;
+  contentRoot: string;
+  contentRepoUrl: string;
+  contentRepoDir: string;
+  syncContentRepo: boolean;
+  outDir: string;
+  limit?: number;
+  concurrency: number;
+  gapMs: number;
+  materializeFromConvex: boolean;
+  sourceOutDir: string;
+};
+
+function usage(exitCode: 0 | 1): never {
+  console.error(`Usage:
+  pnpm audio:join-course -- --course da-en --sync-content-repo
+
+Options:
+  --course <short>                 Course short code, e.g. da-en
+  --content-root <dir>             Directory containing course folders (default: database/stories)
+  --content-repo-url <url>         Content repo URL (default: https://github.com/rgerum/unofficial-duolingo-stories-content.git)
+  --content-repo-dir <dir>         Content repo checkout directory (default: tmp/story-content)
+  --sync-content-repo              Clone or pull the content repo before processing
+  --out-dir <dir>                  Output directory (default: tmp/story-audio/courses/<course>)
+  --limit <number>                 Process only the first N published stories
+  --concurrency <number>           Number of stories to process at once (default: 2)
+  --gap-ms <number>                Silence between lines, forwarded to audio:join-story (default: 800)
+  --materialize-from-convex        Fetch missing story text into tmp/story-source/<course>
+  --source-out-dir <dir>           Materialized source directory (default: tmp/story-source/<course>)
+`);
+  process.exit(exitCode);
+}
+
+function takeValue(args: string[], index: number, name: string) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${name}.`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value: string, name: string) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseCliOptions(args: string[]): CliOptions {
+  let course = "";
+  let contentRoot = "database/stories";
+  let contentRepoUrl =
+    "https://github.com/rgerum/unofficial-duolingo-stories-content.git";
+  let contentRepoDir = path.join("tmp", "story-content");
+  let syncContentRepo = false;
+  let outDir: string | undefined;
+  let limit: number | undefined;
+  let concurrency = 2;
+  let gapMs = 800;
+  let materializeFromConvex = false;
+  let sourceOutDir: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") usage(0);
+    if (arg === "--course") {
+      course = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--content-root") {
+      contentRoot = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--content-repo-url") {
+      contentRepoUrl = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--content-repo-dir") {
+      contentRepoDir = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--sync-content-repo") {
+      syncContentRepo = true;
+      continue;
+    }
+    if (arg === "--out-dir") {
+      outDir = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--limit") {
+      limit = parsePositiveInteger(takeValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--concurrency") {
+      concurrency = parsePositiveInteger(takeValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--gap-ms") {
+      gapMs = parsePositiveInteger(takeValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--materialize-from-convex") {
+      materializeFromConvex = true;
+      continue;
+    }
+    if (arg === "--source-out-dir") {
+      sourceOutDir = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!course) usage(1);
+
+  const resolvedContentRepoDir = path.resolve(contentRepoDir);
+  const resolvedContentRoot = syncContentRepo
+    ? path.join(resolvedContentRepoDir, "database", "stories")
+    : path.resolve(contentRoot);
+
+  return {
+    course,
+    contentRoot: resolvedContentRoot,
+    contentRepoUrl,
+    contentRepoDir: resolvedContentRepoDir,
+    syncContentRepo,
+    outDir: path.resolve(outDir ?? path.join("tmp", "story-audio", "courses", course)),
+    limit,
+    concurrency,
+    gapMs,
+    materializeFromConvex,
+    sourceOutDir: path.resolve(
+      sourceOutDir ?? path.join("tmp", "story-source", course),
+    ),
+  };
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+function expectedPrefix(story: StorySummary) {
+  return `${story.set_id}_${story.set_index}_`;
+}
+
+async function findLocalStoryFile(
+  story: StorySummary,
+  courseDir: string,
+): Promise<string | undefined> {
+  if (!existsSync(courseDir)) return undefined;
+  const storyIdFile = path.join(courseDir, `${story.id}.txt`);
+  if (existsSync(storyIdFile)) return storyIdFile;
+
+  const { readdir } = await import("node:fs/promises");
+  const files = await readdir(courseDir);
+  const prefix = expectedPrefix(story);
+  const matches = files
+    .filter((file) => file.endsWith(".txt") && file.startsWith(prefix))
+    .sort();
+  const exactish = matches.find((file) => file.includes(slugify(story.name)));
+  return matches.length > 0 ? path.join(courseDir, exactish ?? matches[0]) : undefined;
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with exit code ${code}\n${stderr}`,
+        ),
+      );
+    });
+  });
+}
+
+async function getClient() {
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL ?? process.env.CONVEX_URL;
+  if (!url) {
+    throw new Error("NEXT_PUBLIC_CONVEX_URL/CONVEX_URL is not set.");
+  }
+  return new ConvexHttpClient(url);
+}
+
+async function syncContentRepo(options: CliOptions) {
+  if (existsSync(path.join(options.contentRepoDir, ".git"))) {
+    console.log(`Updating content repo: ${options.contentRepoDir}`);
+    await runCommand("git", ["-C", options.contentRepoDir, "pull", "--ff-only"]);
+    return;
+  }
+
+  if (existsSync(options.contentRepoDir)) {
+    throw new Error(
+      `Content repo directory exists but is not a git checkout: ${options.contentRepoDir}`,
+    );
+  }
+
+  await mkdir(path.dirname(options.contentRepoDir), { recursive: true });
+  console.log(`Cloning content repo: ${options.contentRepoUrl}`);
+  await runCommand("git", [
+    "clone",
+    "--depth",
+    "1",
+    options.contentRepoUrl,
+    options.contentRepoDir,
+  ]);
+}
+
+async function getCourseStories(client: ConvexHttpClient, courseShort: string) {
+  const sidebar = await client.query(api.editorRead.getEditorSidebarData, {});
+  const course = (sidebar.courses ?? []).find(
+    (candidate) => candidate.short === courseShort,
+  ) as CourseSummary | undefined;
+  if (!course) throw new Error(`Course not found: ${courseShort}`);
+
+  const stories = (await client.query(
+    api.editorRead.getEditorStoriesByCourseLegacyId,
+    { identifier: String(course.id) },
+  )) as StorySummary[];
+
+  return {
+    course,
+    stories: stories
+      .filter((story) => story.public)
+      .sort((a, b) => a.set_id - b.set_id || a.set_index - b.set_index || a.id - b.id),
+  };
+}
+
+async function materializeStorySource(
+  client: ConvexHttpClient,
+  story: StorySummary,
+  outputDir: string,
+) {
+  await mkdir(outputDir, { recursive: true });
+  const filePath = path.join(
+    outputDir,
+    `${story.set_id}_${story.set_index}_${story.id}_${slugify(story.name)}.txt`,
+  );
+  if (existsSync(filePath)) return filePath;
+
+  const data = await client.query(api.editorRead.getEditorStoryPageData, {
+    storyId: story.id,
+  });
+  const text = data?.story_data?.text;
+  if (!text) throw new Error(`No story text returned for ${story.id}`);
+  await writeFile(filePath, text);
+  return filePath;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+) {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+
+  async function runWorker() {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () =>
+      runWorker(),
+    ),
+  );
+  return results;
+}
+
+async function main() {
+  const options = parseCliOptions(process.argv.slice(2));
+  if (options.syncContentRepo) await syncContentRepo(options);
+  const client = await getClient();
+  const { course, stories } = await getCourseStories(client, options.course);
+  const selectedStories = options.limit ? stories.slice(0, options.limit) : stories;
+  const courseDir = options.syncContentRepo
+    ? path.join(options.contentRepoDir, String(course.id))
+    : path.join(options.contentRoot, options.course);
+
+  console.log(
+    `Found ${stories.length} published ${options.course} stories; processing ${selectedStories.length}.`,
+  );
+  console.log(`Content directory: ${courseDir}`);
+  console.log(`Output directory: ${options.outDir}`);
+
+  await mkdir(options.outDir, { recursive: true });
+
+  const startedAt = Date.now();
+  const results = await mapWithConcurrency(
+    selectedStories,
+    options.concurrency,
+    async (story, index) => {
+      const storyLabel = `${story.set_id}_${story.set_index}_${story.id}_${slugify(story.name)}`;
+      const outputDir = path.join(options.outDir, storyLabel);
+      const localFile =
+        (await findLocalStoryFile(story, courseDir)) ??
+        (options.materializeFromConvex
+          ? await materializeStorySource(client, story, options.sourceOutDir)
+          : undefined);
+
+      if (!localFile) {
+        return {
+          storyId: story.id,
+          status: "missing_source" as const,
+          message: `No local story source found for ${storyLabel}`,
+        };
+      }
+
+      console.log(
+        `[${index + 1}/${selectedStories.length}] ${storyLabel} from ${path.relative(
+          process.cwd(),
+          localFile,
+        )}`,
+      );
+
+      try {
+        await runCommand("pnpm", [
+          "audio:join-story",
+          "--",
+          "--story-file",
+          localFile,
+          "--story-id",
+          String(story.id),
+          "--out-dir",
+          outputDir,
+          "--gap-ms",
+          String(options.gapMs),
+        ]);
+        const manifestPath = path.join(outputDir, "joined.audio.json");
+        const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+          durationMs: number;
+          segments: unknown[];
+        };
+        return {
+          storyId: story.id,
+          status: "ok" as const,
+          outputDir: path.relative(process.cwd(), outputDir),
+          durationMs: manifest.durationMs,
+          segments: manifest.segments.length,
+        };
+      } catch (error) {
+        return {
+          storyId: story.id,
+          status: "failed" as const,
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  );
+
+  const summary = {
+    course: options.course,
+    generatedAt: new Date().toISOString(),
+    elapsedMs: Date.now() - startedAt,
+    total: results.length,
+    ok: results.filter((result) => result.status === "ok").length,
+    missingSource: results.filter((result) => result.status === "missing_source")
+      .length,
+    failed: results.filter((result) => result.status === "failed").length,
+    results,
+  };
+
+  const summaryPath = path.join(options.outDir, "summary.json");
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(`Wrote ${summaryPath}`);
+  console.log(
+    `Done: ok=${summary.ok}, missing=${summary.missingSource}, failed=${summary.failed}, elapsed=${(
+      summary.elapsedMs / 1000
+    ).toFixed(1)}s`,
+  );
+
+  if (summary.failed > 0 || summary.missingSource > 0) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/generate-joined-story-audio.ts
+++ b/scripts/generate-joined-story-audio.ts
@@ -10,6 +10,7 @@ import type {
   StoryElementHeader,
   StoryElementLine,
 } from "../src/components/editor/story/syntax_parser_types";
+import { splitStoryElementsIntoParts } from "../src/lib/story-parts";
 
 const BLOB_BASE_URL =
   "https://ptoqrnbx8ghuucmt.public.blob.vercel-storage.com";
@@ -433,27 +434,6 @@ function getPartKind(parts: StoryElement[]) {
   return "line";
 }
 
-function getParts(elements: StoryElement[]) {
-  const parts: StoryElement[][] = [];
-  let lastId = -1;
-  for (const element of elements) {
-    if (element.trackingProperties === undefined) continue;
-    if (lastId !== element.trackingProperties.line_index) {
-      parts.push([]);
-      lastId = element.trackingProperties.line_index;
-    }
-    if (
-      element.type === "MULTIPLE_CHOICE" &&
-      (parts.at(-1)?.length ?? 0) > 1 &&
-      element.trackingProperties.challenge_type === "multiple-choice"
-    ) {
-      parts.push([]);
-    }
-    parts[parts.length - 1].push(element);
-  }
-  return parts;
-}
-
 function audioForHeader(element: StoryElementHeader) {
   return element.audio ?? element.learningLanguageTitleContent.audio;
 }
@@ -600,7 +580,7 @@ async function main() {
     },
     "",
   );
-  const parts = getParts(story.elements);
+  const parts = splitStoryElementsIntoParts(story.elements);
   const spokenSegments = parts
     .map((part, partIndex) => selectListeningSegment(part, partIndex))
     .filter((segment): segment is SpokenSegment => Boolean(segment));

--- a/scripts/generate-joined-story-audio.ts
+++ b/scripts/generate-joined-story-audio.ts
@@ -1,0 +1,724 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { processStoryFile } from "../src/components/editor/story/syntax_parser_new";
+import type {
+  Audio,
+  StoryElement,
+  StoryElementHeader,
+  StoryElementLine,
+} from "../src/components/editor/story/syntax_parser_types";
+
+const BLOB_BASE_URL =
+  "https://ptoqrnbx8ghuucmt.public.blob.vercel-storage.com";
+
+type CliOptions = {
+  storyFile: string;
+  outDir: string;
+  storyId: number;
+  fromLanguage: string;
+  learningLanguage: string;
+  gapMs: number;
+  silenceThreshold: string;
+  silenceDurationSeconds: number;
+  bitrate: string;
+  sampleRate: number;
+  normalize: boolean;
+  keepTemp: boolean;
+};
+
+type SpokenSegment = {
+  partIndex: number;
+  elementIndex: number;
+  kind: "header" | "line";
+  text: string;
+  audio: Audio;
+};
+
+type GeneratedSegment = {
+  index: number;
+  partIndex: number;
+  elementIndex: number;
+  kind: "header" | "line";
+  text: string;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  originalAudioUrl: string;
+  originalAudioPath: string;
+  trimmedAudioPath: string;
+  trim: {
+    leadingMs: number;
+    trailingMs: number;
+    originalDurationMs: number;
+    trimmedDurationMs: number;
+  };
+  keypoints: { rangeEnd: number; startMs: number }[];
+};
+
+type JoinedStoryAudioManifest = {
+  version: 1;
+  storyId: number;
+  sourceStoryFile: string;
+  generatedAt: string;
+  audio: {
+    filename: string;
+    codec: "aac-lc";
+    container: "m4a";
+    bitrate: string;
+    sampleRate: number;
+    channels: 1;
+  };
+  options: {
+    gapMs: number;
+    silenceThreshold: string;
+    silenceDurationSeconds: number;
+    normalize: boolean;
+  };
+  durationMs: number;
+  segments: GeneratedSegment[];
+};
+
+type SilenceEvent = {
+  start: number;
+  end?: number;
+};
+
+function usage(exitCode: 0 | 1): never {
+  console.error(`Usage:
+  pnpm audio:join-story -- --story-file database/stories/test-en/1_1_es-en-buenos-dias.txt
+
+Options:
+  --out-dir <dir>                  Output directory (default: tmp/story-audio/<story-file-name>)
+  --story-id <number>              Numeric parser story id (default: stable hash of story path)
+  --from-language <code>           Parser from-language code (default: en)
+  --learning-language <code>       Parser learning-language code (default: es)
+  --gap-ms <number>                Silence between lines (default: 800)
+  --silence-threshold <ffmpeg dB>  silencedetect threshold (default: -45dB)
+  --silence-duration <seconds>     Minimum silence duration (default: 0.05)
+  --bitrate <ffmpeg bitrate>       AAC output bitrate (default: 96k)
+  --sample-rate <number>           Output sample rate (default: 44100)
+  --no-normalize                   Disable loudnorm on each line
+  --keep-temp                      Keep ffmpeg concat list and silence WAV
+`);
+  process.exit(exitCode);
+}
+
+function takeValue(args: string[], index: number, name: string) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${name}.`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value: string, name: string) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parsePositiveNumber(value: string, name: string) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number.`);
+  }
+  return parsed;
+}
+
+function stableStoryId(storyFile: string) {
+  const hash = createHash("sha1").update(storyFile).digest("hex").slice(0, 8);
+  return Number.parseInt(hash, 16);
+}
+
+function parseCliOptions(args: string[]): CliOptions {
+  let storyFile: string | undefined;
+  let outDir: string | undefined;
+  let storyId: number | undefined;
+  let fromLanguage = "en";
+  let learningLanguage = "es";
+  let gapMs = 800;
+  let silenceThreshold = "-45dB";
+  let silenceDurationSeconds = 0.05;
+  let bitrate = "96k";
+  let sampleRate = 44100;
+  let normalize = true;
+  let keepTemp = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") usage(0);
+    if (arg === "--story-file") {
+      storyFile = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--out-dir") {
+      outDir = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--story-id") {
+      storyId = parsePositiveInteger(takeValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--from-language") {
+      fromLanguage = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--learning-language") {
+      learningLanguage = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--gap-ms") {
+      gapMs = parsePositiveInteger(takeValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--silence-threshold") {
+      silenceThreshold = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--silence-duration") {
+      silenceDurationSeconds = parsePositiveNumber(
+        takeValue(args, index, arg),
+        arg,
+      );
+      index += 1;
+      continue;
+    }
+    if (arg === "--bitrate") {
+      bitrate = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--sample-rate") {
+      sampleRate = parsePositiveInteger(takeValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--no-normalize") {
+      normalize = false;
+      continue;
+    }
+    if (arg === "--keep-temp") {
+      keepTemp = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!storyFile) usage(1);
+  const absoluteStoryFile = path.resolve(storyFile);
+  const defaultOutDir = path.join(
+    "tmp",
+    "story-audio",
+    path.basename(storyFile, path.extname(storyFile)),
+  );
+
+  return {
+    storyFile: absoluteStoryFile,
+    outDir: path.resolve(outDir ?? defaultOutDir),
+    storyId: storyId ?? stableStoryId(absoluteStoryFile),
+    fromLanguage,
+    learningLanguage,
+    gapMs,
+    silenceThreshold,
+    silenceDurationSeconds,
+    bitrate,
+    sampleRate,
+    normalize,
+    keepTemp,
+  };
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with exit code ${code}\n${stderr}`,
+        ),
+      );
+    });
+  });
+}
+
+async function ensureTool(name: string) {
+  try {
+    await runCommand(name, ["-version"]);
+  } catch (error) {
+    throw new Error(
+      `${name} is required to generate joined audio. Install ffmpeg and try again.\n${String(error)}`,
+    );
+  }
+}
+
+function resolveAudioUrl(url: string) {
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  return `${BLOB_BASE_URL}/${url.replace(/^\/+/, "")}`;
+}
+
+function filenameFromUrl(url: string, index: number) {
+  const parsed = new URL(resolveAudioUrl(url));
+  const extension = path.extname(parsed.pathname) || ".mp3";
+  return `${String(index).padStart(3, "0")}-original${extension}`;
+}
+
+async function downloadFile(url: string, outputPath: string) {
+  if (existsSync(outputPath)) return;
+
+  const response = await fetch(resolveAudioUrl(url));
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await writeFile(outputPath, buffer);
+}
+
+async function probeDurationSeconds(filePath: string) {
+  const { stdout } = await runCommand("ffprobe", [
+    "-v",
+    "error",
+    "-show_entries",
+    "format=duration",
+    "-of",
+    "default=noprint_wrappers=1:nokey=1",
+    filePath,
+  ]);
+  const duration = Number(stdout.trim());
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new Error(`Could not read duration for ${filePath}`);
+  }
+  return duration;
+}
+
+function parseSilenceEvents(stderr: string): SilenceEvent[] {
+  const events: SilenceEvent[] = [];
+  for (const line of stderr.split("\n")) {
+    const start = line.match(/silence_start:\s*([0-9.]+)/);
+    if (start) {
+      events.push({ start: Number(start[1]) });
+      continue;
+    }
+
+    const end = line.match(/silence_end:\s*([0-9.]+)/);
+    if (end && events.length > 0) {
+      events[events.length - 1].end = Number(end[1]);
+    }
+  }
+  return events.filter((event) => Number.isFinite(event.start));
+}
+
+async function detectTrimSeconds(
+  inputPath: string,
+  durationSeconds: number,
+  options: Pick<CliOptions, "silenceThreshold" | "silenceDurationSeconds">,
+) {
+  const { stderr } = await runCommand("ffmpeg", [
+    "-hide_banner",
+    "-i",
+    inputPath,
+    "-af",
+    `silencedetect=noise=${options.silenceThreshold}:d=${options.silenceDurationSeconds}`,
+    "-f",
+    "null",
+    "-",
+  ]);
+  const events = parseSilenceEvents(stderr);
+
+  let leadingSeconds = 0;
+  const first = events[0];
+  if (first && first.start <= 0.001 && first.end !== undefined) {
+    leadingSeconds = Math.min(first.end, durationSeconds);
+  }
+
+  let trailingSeconds = 0;
+  const last = events.at(-1);
+  if (last) {
+    const silenceEnd = last.end ?? durationSeconds;
+    if (Math.abs(silenceEnd - durationSeconds) <= 0.08) {
+      trailingSeconds = Math.max(0, durationSeconds - last.start);
+    }
+  }
+
+  if (leadingSeconds + trailingSeconds > durationSeconds - 0.1) {
+    return { leadingSeconds: 0, trailingSeconds: 0 };
+  }
+
+  return { leadingSeconds, trailingSeconds };
+}
+
+async function trimAndNormalizeAudio(
+  inputPath: string,
+  outputPath: string,
+  durationSeconds: number,
+  leadingSeconds: number,
+  trailingSeconds: number,
+  options: Pick<CliOptions, "normalize" | "sampleRate">,
+) {
+  const endSeconds = Math.max(
+    leadingSeconds + 0.1,
+    durationSeconds - trailingSeconds,
+  );
+  const filters = [
+    `atrim=start=${leadingSeconds.toFixed(3)}:end=${endSeconds.toFixed(3)}`,
+    "asetpts=PTS-STARTPTS",
+  ];
+  if (options.normalize) {
+    filters.push("loudnorm=I=-18:TP=-1.5:LRA=11");
+  }
+
+  await runCommand("ffmpeg", [
+    "-hide_banner",
+    "-y",
+    "-i",
+    inputPath,
+    "-af",
+    filters.join(","),
+    "-ar",
+    String(options.sampleRate),
+    "-ac",
+    "1",
+    outputPath,
+  ]);
+
+}
+
+function getPartKind(parts: StoryElement[]) {
+  const lastPart = parts[parts.length - 1];
+  if (parts[0].type === "HEADER") return "header";
+  if (parts[0].trackingProperties?.challenge_type === "arrange")
+    return "arrange";
+  if (lastPart.type === "POINT_TO_PHRASE") return "point-to-phrase";
+  if (
+    lastPart.type === "MULTIPLE_CHOICE" &&
+    lastPart.trackingProperties.challenge_type === "multiple-choice"
+  )
+    return "multiple-choice";
+  if (parts[0].trackingProperties?.challenge_type === "continuation")
+    return "continuation";
+  if (parts[0].trackingProperties?.challenge_type === "select-phrases")
+    return "select-phrases";
+  if (parts[0].trackingProperties?.challenge_type === "match") return "match";
+  return "line";
+}
+
+function getParts(elements: StoryElement[]) {
+  const parts: StoryElement[][] = [];
+  let lastId = -1;
+  for (const element of elements) {
+    if (element.trackingProperties === undefined) continue;
+    if (lastId !== element.trackingProperties.line_index) {
+      parts.push([]);
+      lastId = element.trackingProperties.line_index;
+    }
+    if (
+      element.type === "MULTIPLE_CHOICE" &&
+      (parts.at(-1)?.length ?? 0) > 1 &&
+      element.trackingProperties.challenge_type === "multiple-choice"
+    ) {
+      parts.push([]);
+    }
+    parts[parts.length - 1].push(element);
+  }
+  return parts;
+}
+
+function audioForHeader(element: StoryElementHeader) {
+  return element.audio ?? element.learningLanguageTitleContent.audio;
+}
+
+function audioForLine(element: StoryElementLine) {
+  return element.audio ?? element.line.content.audio;
+}
+
+function textForLine(element: StoryElementLine) {
+  return element.line.content.text;
+}
+
+function selectListeningSegment(parts: StoryElement[], partIndex: number) {
+  const kind = getPartKind(parts);
+  if (kind === "match") return undefined;
+
+  if (kind === "header") {
+    const header = parts[0] as StoryElementHeader;
+    const audio = audioForHeader(header);
+    if (!audio?.url) return undefined;
+    return {
+      partIndex,
+      elementIndex: 0,
+      kind: "header",
+      text: header.learningLanguageTitleContent.text,
+      audio,
+    } satisfies SpokenSegment;
+  }
+
+  const line = parts.find(
+    (element): element is StoryElementLine => element.type === "LINE",
+  );
+  if (!line) return undefined;
+  const audio = audioForLine(line);
+  if (!audio?.url) return undefined;
+
+  return {
+    partIndex,
+    elementIndex: parts.indexOf(line),
+    kind: "line",
+    text: textForLine(line),
+    audio,
+  } satisfies SpokenSegment;
+}
+
+function keypointsForSegment(
+  audio: Audio,
+  segmentStartMs: number,
+  leadingTrimMs: number,
+) {
+  return (audio.keypoints ?? []).map((keypoint) => ({
+    rangeEnd: keypoint.rangeEnd,
+    startMs: Math.max(
+      segmentStartMs,
+      Math.round(segmentStartMs + keypoint.audioStart - leadingTrimMs),
+    ),
+  }));
+}
+
+function escapeConcatPath(filePath: string) {
+  return filePath.replace(/'/g, "'\\''");
+}
+
+async function createSilenceFile(filePath: string, options: CliOptions) {
+  await runCommand("ffmpeg", [
+    "-hide_banner",
+    "-y",
+    "-f",
+    "lavfi",
+    "-i",
+    `anullsrc=r=${options.sampleRate}:cl=mono`,
+    "-t",
+    (options.gapMs / 1000).toFixed(3),
+    "-ar",
+    String(options.sampleRate),
+    "-ac",
+    "1",
+    filePath,
+  ]);
+}
+
+async function concatenateAudio(
+  trimmedPaths: string[],
+  outputPath: string,
+  workDir: string,
+  options: CliOptions,
+) {
+  const listPath = path.join(workDir, "concat-list.txt");
+  const silencePath = path.join(workDir, "gap.wav");
+  if (options.gapMs > 0 && trimmedPaths.length > 1) {
+    await createSilenceFile(silencePath, options);
+  }
+
+  const listLines: string[] = [];
+  trimmedPaths.forEach((trimmedPath, index) => {
+    listLines.push(`file '${escapeConcatPath(trimmedPath)}'`);
+    if (options.gapMs > 0 && index < trimmedPaths.length - 1) {
+      listLines.push(`file '${escapeConcatPath(silencePath)}'`);
+    }
+  });
+  await writeFile(listPath, `${listLines.join("\n")}\n`);
+
+  await runCommand("ffmpeg", [
+    "-hide_banner",
+    "-y",
+    "-f",
+    "concat",
+    "-safe",
+    "0",
+    "-i",
+    listPath,
+    "-c:a",
+    "aac",
+    "-b:a",
+    options.bitrate,
+    "-ar",
+    String(options.sampleRate),
+    "-ac",
+    "1",
+    "-movflags",
+    "+faststart",
+    outputPath,
+  ]);
+
+  if (!options.keepTemp) {
+    await rm(listPath, { force: true });
+    await rm(silencePath, { force: true });
+  }
+}
+
+async function main() {
+  const options = parseCliOptions(process.argv.slice(2));
+  await ensureTool("ffmpeg");
+  await ensureTool("ffprobe");
+
+  const storyText = await readFile(options.storyFile, "utf8");
+  const [story] = processStoryFile(
+    storyText,
+    options.storyId,
+    {},
+    {
+      from_language: options.fromLanguage,
+      learning_language: options.learningLanguage,
+    },
+    "",
+  );
+  const parts = getParts(story.elements);
+  const spokenSegments = parts
+    .map((part, partIndex) => selectListeningSegment(part, partIndex))
+    .filter((segment): segment is SpokenSegment => Boolean(segment));
+
+  if (spokenSegments.length === 0) {
+    throw new Error("No spoken story segments with audio URLs were found.");
+  }
+
+  const partsDir = path.join(options.outDir, "parts");
+  await mkdir(partsDir, { recursive: true });
+
+  const generatedSegments: GeneratedSegment[] = [];
+  const trimmedPaths: string[] = [];
+  let cursorMs = 0;
+
+  for (const [index, segment] of spokenSegments.entries()) {
+    const originalPath = path.join(partsDir, filenameFromUrl(segment.audio.url!, index));
+    const trimmedPath = path.join(
+      partsDir,
+      `${String(index).padStart(3, "0")}-trimmed.wav`,
+    );
+    const originalUrl = resolveAudioUrl(segment.audio.url!);
+
+    console.log(
+      `Processing ${index + 1}/${spokenSegments.length}: part ${segment.partIndex} ${segment.kind}`,
+    );
+    await downloadFile(segment.audio.url!, originalPath);
+
+    const originalDurationSeconds = await probeDurationSeconds(originalPath);
+    const trim = await detectTrimSeconds(originalPath, originalDurationSeconds, options);
+    await trimAndNormalizeAudio(
+      originalPath,
+      trimmedPath,
+      originalDurationSeconds,
+      trim.leadingSeconds,
+      trim.trailingSeconds,
+      options,
+    );
+
+    const trimmedDurationMs = Math.round(
+      (await probeDurationSeconds(trimmedPath)) * 1000,
+    );
+    const startMs = cursorMs;
+    const endMs = startMs + trimmedDurationMs;
+    const leadingMs = Math.round(trim.leadingSeconds * 1000);
+    const trailingMs = Math.round(trim.trailingSeconds * 1000);
+
+    generatedSegments.push({
+      index,
+      partIndex: segment.partIndex,
+      elementIndex: segment.elementIndex,
+      kind: segment.kind,
+      text: segment.text,
+      startMs,
+      endMs,
+      durationMs: trimmedDurationMs,
+      originalAudioUrl: originalUrl,
+      originalAudioPath: path.relative(options.outDir, originalPath),
+      trimmedAudioPath: path.relative(options.outDir, trimmedPath),
+      trim: {
+        leadingMs,
+        trailingMs,
+        originalDurationMs: Math.round(originalDurationSeconds * 1000),
+        trimmedDurationMs,
+      },
+      keypoints: keypointsForSegment(segment.audio, startMs, leadingMs),
+    });
+
+    trimmedPaths.push(trimmedPath);
+    cursorMs = endMs + (index < spokenSegments.length - 1 ? options.gapMs : 0);
+  }
+
+  const audioFilename = "joined.m4a";
+  const outputAudioPath = path.join(options.outDir, audioFilename);
+  await concatenateAudio(trimmedPaths, outputAudioPath, options.outDir, options);
+  const joinedDurationMs = Math.round(
+    (await probeDurationSeconds(outputAudioPath)) * 1000,
+  );
+
+  const manifest: JoinedStoryAudioManifest = {
+    version: 1,
+    storyId: options.storyId,
+    sourceStoryFile: path.relative(process.cwd(), options.storyFile),
+    generatedAt: new Date().toISOString(),
+    audio: {
+      filename: audioFilename,
+      codec: "aac-lc",
+      container: "m4a",
+      bitrate: options.bitrate,
+      sampleRate: options.sampleRate,
+      channels: 1,
+    },
+    options: {
+      gapMs: options.gapMs,
+      silenceThreshold: options.silenceThreshold,
+      silenceDurationSeconds: options.silenceDurationSeconds,
+      normalize: options.normalize,
+    },
+    durationMs: joinedDurationMs,
+    segments: generatedSegments,
+  };
+
+  await writeFile(
+    path.join(options.outDir, "joined.audio.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  console.log(`\nWrote ${outputAudioPath}`);
+  console.log(`Wrote ${path.join(options.outDir, "joined.audio.json")}`);
+  console.log(
+    `Segments: ${generatedSegments.length}, duration: ${(joinedDurationMs / 1000).toFixed(2)}s`,
+  );
+
+  // Keep parts/*.wav and originals for inspection; only concat helper files are
+  // deleted unless --keep-temp is passed.
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/serve-local-story-audio.ts
+++ b/scripts/serve-local-story-audio.ts
@@ -1,0 +1,84 @@
+import { createServer } from "node:http";
+import { createReadStream, statSync } from "node:fs";
+import path from "node:path";
+
+const port = Number(process.env.PORT ?? 8787);
+const root = process.cwd();
+
+const contentTypes: Record<string, string> = {
+  ".json": "application/json; charset=utf-8",
+  ".m4a": "audio/mp4",
+  ".mp4": "audio/mp4",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+};
+
+function resolveRequestPath(url: string | undefined) {
+  const parsed = new URL(url ?? "/", `http://localhost:${port}`);
+  const decodedPath = decodeURIComponent(parsed.pathname);
+  const normalizedPath = path.normalize(decodedPath).replace(/^(\.\.[/\\])+/, "");
+  const filePath = path.join(root, normalizedPath);
+  if (!filePath.startsWith(root)) return undefined;
+  return filePath;
+}
+
+createServer((request, response) => {
+  const filePath = resolveRequestPath(request.url);
+  if (!filePath) {
+    response.writeHead(400).end("Bad request");
+    return;
+  }
+
+  let stats;
+  try {
+    stats = statSync(filePath);
+  } catch {
+    response.writeHead(404).end("Not found");
+    return;
+  }
+
+  if (!stats.isFile()) {
+    response.writeHead(404).end("Not found");
+    return;
+  }
+
+  const contentType = contentTypes[path.extname(filePath)] ?? "application/octet-stream";
+  const range = request.headers.range;
+
+  if (range) {
+    const match = /^bytes=(\d*)-(\d*)$/.exec(range);
+    if (!match) {
+      response.writeHead(416, { "Content-Range": `bytes */${stats.size}` }).end();
+      return;
+    }
+
+    const start = match[1] ? Number(match[1]) : 0;
+    const end = match[2] ? Number(match[2]) : stats.size - 1;
+    if (start >= stats.size || end >= stats.size || start > end) {
+      response.writeHead(416, { "Content-Range": `bytes */${stats.size}` }).end();
+      return;
+    }
+
+    response.writeHead(206, {
+      "Accept-Ranges": "bytes",
+      "Content-Length": end - start + 1,
+      "Content-Range": `bytes ${start}-${end}/${stats.size}`,
+      "Content-Type": contentType,
+    });
+    if (request.method === "HEAD") response.end();
+    else createReadStream(filePath, { start, end }).pipe(response);
+    console.log(`${request.method} ${request.url} 206 ${start}-${end}`);
+    return;
+  }
+
+  response.writeHead(200, {
+    "Accept-Ranges": "bytes",
+    "Content-Length": stats.size,
+    "Content-Type": contentType,
+  });
+  if (request.method === "HEAD") response.end();
+  else createReadStream(filePath).pipe(response);
+  console.log(`${request.method} ${request.url} 200`);
+}).listen(port, "0.0.0.0", () => {
+  console.log(`Serving local story audio at http://0.0.0.0:${port}`);
+});

--- a/scripts/upload-joined-story-audio.ts
+++ b/scripts/upload-joined-story-audio.ts
@@ -1,0 +1,276 @@
+import dotenv from "dotenv";
+import { put } from "@vercel/blob";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+dotenv.config({ path: ".env.local" });
+
+type CliOptions = {
+  course: string;
+  inputDir: string;
+  prefix: string;
+  outputFile: string;
+  limit?: number;
+  dryRun: boolean;
+  overwrite: boolean;
+  cacheMaxAgeSeconds: number;
+};
+
+type CourseSummaryResult = {
+  storyId: number;
+  status: string;
+  outputDir?: string;
+  durationMs?: number;
+  segments?: number;
+};
+
+type CourseSummary = {
+  course: string;
+  generatedAt: string;
+  total: number;
+  ok: number;
+  missingSource: number;
+  failed: number;
+  results: CourseSummaryResult[];
+};
+
+function usage(exitCode: 0 | 1): never {
+  console.error(`Usage:
+  pnpm audio:upload-joined -- --course da-en --input-dir tmp/story-audio/courses/da-en
+
+Options:
+  --course <short>                 Course short code, e.g. da-en
+  --input-dir <dir>                Course audio output directory (default: tmp/story-audio/courses/<course>)
+  --prefix <path>                  Blob key prefix (default: stitched-audio/v1)
+  --output-file <path>             Upload summary file (default: <input-dir>/blob-upload-summary.json)
+  --limit <number>                 Upload only the first N ok stories
+  --dry-run                        Print planned uploads without writing to Blob
+  --overwrite                      Replace existing deterministic Blob keys
+  --cache-max-age-seconds <number> Blob cache max age (default: 31536000)
+`);
+  process.exit(exitCode);
+}
+
+function takeValue(args: string[], index: number, name: string) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${name}.`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value: string, name: string) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseCliOptions(args: string[]): CliOptions {
+  let course = "";
+  let inputDir: string | undefined;
+  let prefix = "stitched-audio/v1";
+  let outputFile: string | undefined;
+  let limit: number | undefined;
+  let dryRun = false;
+  let overwrite = false;
+  let cacheMaxAgeSeconds = 365 * 24 * 60 * 60;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") usage(0);
+    if (arg === "--course") {
+      course = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--input-dir") {
+      inputDir = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--prefix") {
+      prefix = takeValue(args, index, arg).replace(/^\/+|\/+$/g, "");
+      index += 1;
+      continue;
+    }
+    if (arg === "--output-file") {
+      outputFile = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--limit") {
+      limit = parsePositiveInteger(takeValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--overwrite") {
+      overwrite = true;
+      continue;
+    }
+    if (arg === "--cache-max-age-seconds") {
+      cacheMaxAgeSeconds = parsePositiveInteger(takeValue(args, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!course) usage(1);
+  const resolvedInputDir = path.resolve(
+    inputDir ?? path.join("tmp", "story-audio", "courses", course),
+  );
+
+  return {
+    course,
+    inputDir: resolvedInputDir,
+    prefix,
+    outputFile: path.resolve(
+      outputFile ?? path.join(resolvedInputDir, "blob-upload-summary.json"),
+    ),
+    limit,
+    dryRun,
+    overwrite,
+    cacheMaxAgeSeconds,
+  };
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, "utf8")) as T;
+}
+
+async function fileHash(filePath: string) {
+  const buffer = await readFile(filePath);
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function blobStoryPrefix(options: CliOptions, storyId: number) {
+  return `${options.prefix}/${options.course}/${storyId}`;
+}
+
+async function uploadFile({
+  filePath,
+  pathname,
+  contentType,
+  options,
+}: {
+  filePath: string;
+  pathname: string;
+  contentType: string;
+  options: CliOptions;
+}) {
+  const buffer = await readFile(filePath);
+  if (options.dryRun) {
+    return {
+      pathname,
+      url: null,
+      size: buffer.byteLength,
+      uploaded: false,
+    };
+  }
+
+  const result = await put(pathname, buffer, {
+    access: "public",
+    addRandomSuffix: false,
+    allowOverwrite: options.overwrite,
+    cacheControlMaxAge: options.cacheMaxAgeSeconds,
+    contentType,
+  });
+  return {
+    pathname: result.pathname,
+    url: result.url,
+    size: buffer.byteLength,
+    uploaded: true,
+  };
+}
+
+async function main() {
+  const options = parseCliOptions(process.argv.slice(2));
+  const summaryPath = path.join(options.inputDir, "summary.json");
+  const summary = await readJson<CourseSummary>(summaryPath);
+  if (summary.course !== options.course) {
+    throw new Error(
+      `Summary course mismatch: expected ${options.course}, got ${summary.course}`,
+    );
+  }
+  if (!options.dryRun && !process.env.BLOB_READ_WRITE_TOKEN) {
+    throw new Error("BLOB_READ_WRITE_TOKEN is not set.");
+  }
+
+  const stories = summary.results
+    .filter((result) => result.status === "ok" && result.outputDir)
+    .slice(0, options.limit);
+
+  console.log(
+    `${options.dryRun ? "Planning" : "Uploading"} ${stories.length} stitched ${options.course} stories to ${options.prefix}`,
+  );
+
+  const uploaded = [];
+  for (const [index, story] of stories.entries()) {
+    const sourceDir = path.resolve(story.outputDir!);
+    const audioPath = path.join(sourceDir, "joined.m4a");
+    const manifestPath = path.join(sourceDir, "joined.audio.json");
+    const prefix = blobStoryPrefix(options, story.storyId);
+
+    console.log(`[${index + 1}/${stories.length}] story ${story.storyId}`);
+    const [audioHash, manifestHash] = await Promise.all([
+      fileHash(audioPath),
+      fileHash(manifestPath),
+    ]);
+    const [audio, manifest] = await Promise.all([
+      uploadFile({
+        filePath: audioPath,
+        pathname: `${prefix}/joined.m4a`,
+        contentType: "audio/mp4",
+        options,
+      }),
+      uploadFile({
+        filePath: manifestPath,
+        pathname: `${prefix}/joined.audio.json`,
+        contentType: "application/json; charset=utf-8",
+        options,
+      }),
+    ]);
+
+    uploaded.push({
+      storyId: story.storyId,
+      course: options.course,
+      durationMs: story.durationMs,
+      segments: story.segments,
+      audio: {
+        ...audio,
+        sha256: audioHash,
+      },
+      manifest: {
+        ...manifest,
+        sha256: manifestHash,
+      },
+    });
+  }
+
+  const uploadSummary = {
+    course: options.course,
+    sourceSummary: path.relative(process.cwd(), summaryPath),
+    uploadedAt: new Date().toISOString(),
+    dryRun: options.dryRun,
+    overwrite: options.overwrite,
+    prefix: options.prefix,
+    total: uploaded.length,
+    artifacts: uploaded,
+  };
+
+  await writeFile(options.outputFile, `${JSON.stringify(uploadSummary, null, 2)}\n`);
+  console.log(`Wrote ${options.outputFile}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/components/StoryAutoPlay/StoryAutoPlay.tsx
+++ b/src/components/StoryAutoPlay/StoryAutoPlay.tsx
@@ -25,6 +25,7 @@ interface StoryAutoPlayProps {
 
 const BLOB_PUBLIC_BASE =
   "https://ptoqrnbx8ghuucmt.public.blob.vercel-storage.com/";
+const STITCHED_AUDIO_PREFIX = "stitched-audio/v1";
 const FETCH_RETRIES = 2;
 const LARGE_MERGE_SEGMENT_THRESHOLD = 60;
 
@@ -61,6 +62,18 @@ type TimelineMeta = {
   keypoints?: { rangeEnd: number; audioStart: number }[];
 };
 
+type StitchedAudioManifest = {
+  storyId: number;
+  durationMs: number;
+  audio: { filename: string };
+  segments: {
+    partIndex: number;
+    startMs: number;
+    endMs: number;
+    keypoints?: { rangeEnd: number; startMs: number }[];
+  }[];
+};
+
 function getParts(story: StoryType) {
   const parts: StoryElement[][] = [];
   let lastId = -1;
@@ -69,6 +82,13 @@ function getParts(story: StoryType) {
     if (lastId !== element.trackingProperties.line_index) {
       parts.push([]);
       lastId = element.trackingProperties.line_index;
+    }
+    if (
+      element.type === "MULTIPLE_CHOICE" &&
+      (parts.at(-1)?.length ?? 0) > 1 &&
+      element.trackingProperties.challenge_type === "multiple-choice"
+    ) {
+      parts.push([]);
     }
     parts[parts.length - 1].push(element);
   }
@@ -147,6 +167,32 @@ function formatTime(seconds: number): string {
   const m = Math.floor(safe / 60);
   const s = safe % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function revokeObjectUrl(src: string | null) {
+  if (src?.startsWith("blob:")) URL.revokeObjectURL(src);
+}
+
+async function fetchJsonWithRetry<T>(url: string): Promise<T> {
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt <= FETCH_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Could not fetch JSON (${response.status}).`);
+      }
+      return (await response.json()) as T;
+    } catch (error) {
+      lastError = error;
+      if (attempt === FETCH_RETRIES) break;
+      await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Could not fetch JSON after retries.");
 }
 
 async function fetchArrayBufferWithRetry(url: string): Promise<ArrayBuffer> {
@@ -260,6 +306,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
   const parts = React.useMemo(() => getParts(story), [story]);
   const course =
     story.course_short ?? `${story.learning_language}-${story.from_language}`;
+  const storyId = story.id;
 
   const settings = {
     ...autoPlaySettings,
@@ -268,7 +315,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
 
   const timelineSegments = React.useMemo(() => {
     const entries: TimelineSegment[] = [];
-    for (const part of parts) {
+    for (const [partIndex, part] of parts.entries()) {
       for (const element of part) {
         if (element.type !== "HEADER" && element.type !== "LINE") continue;
 
@@ -280,7 +327,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
         if (processed.type !== "HEADER" && processed.type !== "LINE") continue;
 
         entries.push({
-          lineIndex: processed.trackingProperties.line_index,
+          lineIndex: partIndex,
           audioUrl,
           keypoints,
           displayElement: processed,
@@ -305,6 +352,43 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
   const [activeAudioRange, setActiveAudioRange] = React.useState(99999);
   const [showLargeMergeWarning, setShowLargeMergeWarning] =
     React.useState(false);
+
+  const loadStitchedAudio = React.useCallback(async () => {
+    const base = `${BLOB_PUBLIC_BASE}${STITCHED_AUDIO_PREFIX}/${course}/${storyId}`;
+    const manifest = await fetchJsonWithRetry<StitchedAudioManifest>(
+      `${base}/joined.audio.json`,
+    );
+    if (manifest.storyId !== storyId) {
+      throw new Error(
+        `Stitched manifest story mismatch (${manifest.storyId} !== ${storyId}).`,
+      );
+    }
+    if (!manifest.segments.length) {
+      throw new Error("Stitched manifest has no segments.");
+    }
+
+    const meta = manifest.segments.map((segment) => ({
+      lineIndex: segment.partIndex,
+      start: segment.startMs / 1000,
+      duration: Math.max(0, (segment.endMs - segment.startMs) / 1000),
+      keypoints: segment.keypoints?.map((keypoint) => ({
+        rangeEnd: keypoint.rangeEnd,
+        audioStart: Math.max(0, keypoint.startMs - segment.startMs),
+      })),
+    }));
+
+    setTimelineMeta(meta);
+    setMergedSrc((prev) => {
+      revokeObjectUrl(prev);
+      return `${base}/${manifest.audio.filename}`;
+    });
+    setDuration(manifest.durationMs / 1000);
+    setCurrentTime(0);
+    setActiveAudioRange(99999);
+    setMergeState("ready");
+    setShowLargeMergeWarning(false);
+    return `${base}/${manifest.audio.filename}`;
+  }, [course, storyId]);
 
   const buildMergedAudio = React.useCallback(async () => {
     if (!timelineSegments.length) {
@@ -340,7 +424,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
 
       setTimelineMeta(meta);
       setMergedSrc((prev) => {
-        if (prev) URL.revokeObjectURL(prev);
+        revokeObjectUrl(prev);
         return nextSrc;
       });
       setDuration(start);
@@ -371,21 +455,27 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
       timelineSegments.length >= LARGE_MERGE_SEGMENT_THRESHOLD,
     );
     setMergedSrc((prev) => {
-      if (prev) URL.revokeObjectURL(prev);
+      revokeObjectUrl(prev);
       return null;
     });
   }, [timelineSegments]);
 
   React.useEffect(() => {
     return () => {
-      if (mergedSrc) URL.revokeObjectURL(mergedSrc);
+      revokeObjectUrl(mergedSrc);
     };
   }, [mergedSrc]);
 
-  const ensureMergedAndPlay = React.useCallback(async () => {
+  const ensureAudioAndPlay = React.useCallback(async () => {
     let src = mergedSrc;
     if (!src) {
-      src = await buildMergedAudio();
+      setMergeState("building");
+      setErrorMessage(null);
+      try {
+        src = await loadStitchedAudio();
+      } catch {
+        src = await buildMergedAudio();
+      }
     }
     if (!src || !audioRef.current) return;
 
@@ -400,7 +490,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
     } catch (error) {
       setIsPlaying(false);
     }
-  }, [buildMergedAudio, mergedSrc]);
+  }, [buildMergedAudio, loadStitchedAudio, mergedSrc]);
 
   const pause = React.useCallback(() => {
     audioRef.current?.pause();
@@ -412,8 +502,8 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
       pause();
       return;
     }
-    await ensureMergedAndPlay();
-  }, [ensureMergedAndPlay, isPlaying, pause]);
+    await ensureAudioAndPlay();
+  }, [ensureAudioAndPlay, isPlaying, pause]);
 
   const onSeek = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -474,8 +564,8 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
   }, [duration, timelineMeta]);
 
   React.useEffect(() => {
-    void ensureMergedAndPlay();
-  }, [ensureMergedAndPlay]);
+    void ensureAudioAndPlay();
+  }, [ensureAudioAndPlay]);
 
   const activeLineIndex = React.useMemo(() => {
     const idx = findSegmentIndexByTime(timelineMeta, currentTime);
@@ -509,7 +599,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
     }
 
     mediaSession.setActionHandler("play", () => {
-      void ensureMergedAndPlay();
+      void ensureAudioAndPlay();
     });
     mediaSession.setActionHandler("pause", () => {
       pause();
@@ -519,7 +609,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
       mediaSession.setActionHandler("play", null);
       mediaSession.setActionHandler("pause", null);
     };
-  }, [ensureMergedAndPlay, isPlaying, pause, story.learning_language]);
+  }, [ensureAudioAndPlay, isPlaying, pause, story.learning_language]);
 
   return (
     <div className="min-h-screen">
@@ -546,7 +636,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
             }
           >
             {mergeState === "building"
-              ? "Building..."
+              ? "Loading..."
               : isPlaying
                 ? "Pause"
                 : "Play"}
@@ -587,6 +677,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
           {parts.map((part, partIndex) => (
             <AutoPlayPart
               key={partIndex}
+              partIndex={partIndex}
               part={part}
               settings={settings}
               activeLineIndex={activeLineIndex}
@@ -602,6 +693,7 @@ export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
 }
 
 interface AutoPlayPartProps {
+  partIndex: number;
   part: StoryElement[];
   settings: typeof autoPlaySettings & { rtl: boolean };
   activeLineIndex?: number;
@@ -610,6 +702,7 @@ interface AutoPlayPartProps {
 }
 
 function AutoPlayPart({
+  partIndex,
   part,
   settings,
   activeLineIndex,
@@ -621,6 +714,7 @@ function AutoPlayPart({
       {part.map((element, i) => (
         <AutoPlayElement
           key={i}
+          partIndex={partIndex}
           element={element}
           settings={settings}
           activeLineIndex={activeLineIndex}
@@ -633,6 +727,7 @@ function AutoPlayPart({
 }
 
 interface AutoPlayElementProps {
+  partIndex: number;
   element: StoryElement;
   settings: typeof autoPlaySettings & { rtl: boolean };
   activeLineIndex?: number;
@@ -641,6 +736,7 @@ interface AutoPlayElementProps {
 }
 
 function AutoPlayElement({
+  partIndex,
   element,
   settings,
   activeLineIndex,
@@ -648,7 +744,7 @@ function AutoPlayElement({
   activeAudioRange,
 }: AutoPlayElementProps) {
   const processedElement = clearHints(element);
-  const lineIndex = processedElement.trackingProperties?.line_index;
+  const lineIndex = partIndex;
   const visibleUntil = activeLineIndex ?? 0;
 
   if (lineIndex !== undefined && lineIndex > visibleUntil) {

--- a/src/components/StoryAutoPlay/StoryAutoPlay.tsx
+++ b/src/components/StoryAutoPlay/StoryAutoPlay.tsx
@@ -153,6 +153,12 @@ function revokeObjectUrl(src: string | null) {
   if (src?.startsWith("blob:")) URL.revokeObjectURL(src);
 }
 
+class NonRetryableFetchError extends Error {}
+
+function isTerminalClientError(status: number) {
+  return status >= 400 && status < 500 && status !== 408 && status !== 429;
+}
+
 async function fetchJsonWithRetry<T>(url: string): Promise<T> {
   let lastError: unknown = null;
 
@@ -160,10 +166,15 @@ async function fetchJsonWithRetry<T>(url: string): Promise<T> {
     try {
       const response = await fetch(url);
       if (!response.ok) {
-        throw new Error(`Could not fetch JSON (${response.status}).`);
+        const message = `Could not fetch JSON (${response.status}).`;
+        if (isTerminalClientError(response.status)) {
+          throw new NonRetryableFetchError(message);
+        }
+        throw new Error(message);
       }
       return (await response.json()) as T;
     } catch (error) {
+      if (error instanceof NonRetryableFetchError) throw error;
       lastError = error;
       if (attempt === FETCH_RETRIES) break;
       await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));

--- a/src/components/StoryAutoPlay/StoryAutoPlay.tsx
+++ b/src/components/StoryAutoPlay/StoryAutoPlay.tsx
@@ -10,6 +10,7 @@ import type {
   StoryElementHeader,
   StoryElementLine,
 } from "@/components/editor/story/syntax_parser_types";
+import { splitStoryElementsIntoParts } from "@/lib/story-parts";
 import { cn } from "@/lib/utils";
 
 interface StoryAutoPlayProps {
@@ -73,27 +74,6 @@ type StitchedAudioManifest = {
     keypoints?: { rangeEnd: number; startMs: number }[];
   }[];
 };
-
-function getParts(story: StoryType) {
-  const parts: StoryElement[][] = [];
-  let lastId = -1;
-  for (const element of story.elements) {
-    if (element.trackingProperties === undefined) continue;
-    if (lastId !== element.trackingProperties.line_index) {
-      parts.push([]);
-      lastId = element.trackingProperties.line_index;
-    }
-    if (
-      element.type === "MULTIPLE_CHOICE" &&
-      (parts.at(-1)?.length ?? 0) > 1 &&
-      element.trackingProperties.challenge_type === "multiple-choice"
-    ) {
-      parts.push([]);
-    }
-    parts[parts.length - 1].push(element);
-  }
-  return parts;
-}
 
 function toAbsoluteAudioUrl(url: string): string | null {
   if (url.startsWith("blob:")) return url;
@@ -303,7 +283,10 @@ function mergeBuffersToWav(buffers: AudioBuffer[]): Blob {
 }
 
 export default function StoryAutoPlay({ story }: StoryAutoPlayProps) {
-  const parts = React.useMemo(() => getParts(story), [story]);
+  const parts = React.useMemo(
+    () => splitStoryElementsIntoParts(story.elements),
+    [story.elements],
+  );
   const course =
     story.course_short ?? `${story.learning_language}-${story.from_language}`;
   const storyId = story.id;

--- a/src/lib/story-parts.ts
+++ b/src/lib/story-parts.ts
@@ -1,0 +1,26 @@
+import type { StoryElement } from "@/components/editor/story/syntax_parser_types";
+
+export function splitStoryElementsIntoParts(
+  elements: StoryElement[],
+): StoryElement[][] {
+  const parts: StoryElement[][] = [];
+  let lastId = -1;
+
+  for (const element of elements) {
+    if (element.trackingProperties === undefined) continue;
+    if (lastId !== element.trackingProperties.line_index) {
+      parts.push([]);
+      lastId = element.trackingProperties.line_index;
+    }
+    if (
+      element.type === "MULTIPLE_CHOICE" &&
+      (parts.at(-1)?.length ?? 0) > 1 &&
+      element.trackingProperties.challenge_type === "multiple-choice"
+    ) {
+      parts.push([]);
+    }
+    parts[parts.length - 1].push(element);
+  }
+
+  return parts;
+}


### PR DESCRIPTION
## Summary

- adds scripts to generate joined story audio, sync story text from the content repo, serve local test audio with range support, and upload joined artifacts to Vercel Blob
- wires mobile listening mode to use stitched audio behind `EXPO_PUBLIC_STITCHED_AUDIO_ROOT_URL`, with fallback to per-line audio
- updates the web autoplay reader to prefer uploaded stitched audio/manifests from `stitched-audio/v1/<course>/<storyId>/...`, falling back to browser-merged line audio

## Danish artifacts

- uploaded 100 `da-en` stitched stories to Vercel Blob under `stitched-audio/v1/da-en/<storyId>/`
- verified sample audio serves `206 Partial Content`, `Accept-Ranges: bytes`, and `Content-Type: audio/mp4`
- upload summary: `tmp/story-audio/courses/da-en/blob-upload-summary.json` locally

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm --dir app-mobile typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stitched listening audio support for smoother playback, with per-part progress and next/replay controls.
  * Introduced joined-audio tooling, including generation, local serving, and upload to blob storage.
* **Bug Fixes**
  * Improved story audio playback to use the correct active segment, including proper handling of paused/manual play and autoplay.
  * Updated audio timing/visibility to respect per-part audio ranges and refreshed timeline-to-UI mapping.
  * Enhanced autoplay to prefer pre-stitched audio and fall back to local building when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->