### PR TITLE
[codex] Fix sticky story progress header

### DIFF
--- a/src/components/StoryHeaderProgress/StoryHeaderProgress.tsx
+++ b/src/components/StoryHeaderProgress/StoryHeaderProgress.tsx
@@ -55,7 +55,7 @@ function StoryHeaderProgress({
   const courseHref = (setId ?? 0) > 0 ? `/${course}#${setId}` : `/${course}`;
 
   return (
-    <div className="sticky top-0 z-[1] mx-auto flex max-w-[1000px] items-center gap-4 bg-[var(--body-background)] px-10 py-10 max-[500px]:px-5 max-[500px]:py-[17px]">
+    <div className="sticky top-0 z-20 mx-auto flex w-full max-w-[1000px] items-center gap-4 bg-[var(--body-background)] px-10 py-10 max-[500px]:px-5 max-[500px]:py-[17px]">
       <Link
         className="inline-block h-[18px] w-[18px] shrink-0 align-middle bg-no-repeat"
         data-cy="quit"


### PR DESCRIPTION
## Summary

Fixes a regression where the story progress header could stop visually behaving like a sticky top bar while reading a story.

The story header was already positioned with `sticky top-0`, but it used a very low stacking layer. Story content and fixed story UI could visually overtake it. This raises the header above the story layers and makes its painted background span the full available width.

## Verification

Browser metrics from the local capture:

- Top: `scrollY: 0`, header `top: 0`
- Scrolled: `scrollY: 700`, header `top: 0`

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`

Note: the real story route could not render in this local worktree because Convex auth environment variables are not present, so verification used a temporary local route rendering the real `StoryHeaderProgress` component. The temporary route was removed before commit.
