### PR TITLE
Add story feedback capture and review workflow

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -41,6 +41,7 @@ import type * as lookupTables from "../lookupTables.js";
 import type * as roles from "../roles.js";
 import type * as storyApproval from "../storyApproval.js";
 import type * as storyDone from "../storyDone.js";
+import type * as storyFeedback from "../storyFeedback.js";
 import type * as storyPublicContent from "../storyPublicContent.js";
 import type * as storyRead from "../storyRead.js";
 import type * as storyTables from "../storyTables.js";
@@ -87,6 +88,7 @@ declare const fullApi: ApiFromModules<{
   roles: typeof roles;
   storyApproval: typeof storyApproval;
   storyDone: typeof storyDone;
+  storyFeedback: typeof storyFeedback;
   storyPublicContent: typeof storyPublicContent;
   storyRead: typeof storyRead;
   storyTables: typeof storyTables;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -235,6 +235,35 @@ export default defineSchema({
     .index("by_story_and_user", ["storyId", "legacyUserId"])
     .index("by_legacy_id", ["legacyId"]),
 
+  story_feedback_reports: defineTable({
+    storyId: v.number(),
+    storyTitle: v.string(),
+    courseShort: v.string(),
+    line: v.optional(v.number()),
+    lineText: v.optional(v.string()),
+    category: v.union(
+      v.literal("Text"),
+      v.literal("Translation hints"),
+      v.literal("Audio"),
+      v.literal("Other"),
+    ),
+    comment: v.string(),
+    userId: v.union(v.string(), v.null()),
+    userName: v.union(v.string(), v.null()),
+    userEmail: v.union(v.string(), v.null()),
+    status: v.union(
+      v.literal("open"),
+      v.literal("reviewed"),
+      v.literal("resolved"),
+    ),
+    createdAt: v.number(),
+  })
+    .index("by_story_id", ["storyId"])
+    .index("by_course_short", ["courseShort"])
+    .index("by_category", ["category"])
+    .index("by_user_id", ["userId"])
+    .index("by_status_and_created_at", ["status", "createdAt"]),
+
   discord_stories_role_sync: defineTable({
     legacyUserId: v.number(),
     discordAccountId: v.union(v.string(), v.null()),

--- a/convex/storyFeedback.ts
+++ b/convex/storyFeedback.ts
@@ -1,0 +1,118 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { requireContributorOrAdmin } from "./lib/authorization";
+
+const feedbackCategoryValidator = v.union(
+  v.literal("Text"),
+  v.literal("Translation hints"),
+  v.literal("Audio"),
+  v.literal("Other"),
+);
+
+const feedbackStatusValidator = v.union(
+  v.literal("open"),
+  v.literal("reviewed"),
+  v.literal("resolved"),
+);
+
+const feedbackReportValidator = v.object({
+  _id: v.id("story_feedback_reports"),
+  _creationTime: v.number(),
+  storyId: v.number(),
+  storyTitle: v.string(),
+  courseShort: v.string(),
+  line: v.optional(v.number()),
+  lineText: v.optional(v.string()),
+  category: feedbackCategoryValidator,
+  comment: v.string(),
+  userId: v.union(v.string(), v.null()),
+  userName: v.union(v.string(), v.null()),
+  userEmail: v.union(v.string(), v.null()),
+  status: feedbackStatusValidator,
+  createdAt: v.number(),
+});
+
+export const submitStoryFeedback = mutation({
+  args: {
+    storyId: v.number(),
+    storyTitle: v.string(),
+    courseShort: v.string(),
+    line: v.optional(v.number()),
+    lineText: v.optional(v.string()),
+    category: feedbackCategoryValidator,
+    comment: v.string(),
+  },
+  returns: v.object({
+    reportId: v.id("story_feedback_reports"),
+  }),
+  handler: async (ctx, args) => {
+    const comment = args.comment.trim();
+    if (!comment) {
+      throw new Error("Comment is required");
+    }
+
+    const identity = (await ctx.auth.getUserIdentity()) as {
+      tokenIdentifier?: string | null;
+      name?: string | null;
+      email?: string | null;
+    } | null;
+
+    const lineText = args.lineText?.trim();
+    const reportId = await ctx.db.insert("story_feedback_reports", {
+      storyId: args.storyId,
+      storyTitle: args.storyTitle.trim(),
+      courseShort: args.courseShort.trim(),
+      ...(args.line !== undefined ? { line: args.line } : {}),
+      ...(lineText ? { lineText } : {}),
+      category: args.category,
+      comment,
+      userId: identity?.tokenIdentifier ?? null,
+      userName: identity?.name?.trim() || null,
+      userEmail: identity?.email?.trim() || null,
+      status: "open",
+      createdAt: Date.now(),
+    });
+
+    return { reportId };
+  },
+});
+
+export const listStoryFeedbackReports = query({
+  args: {
+    status: feedbackStatusValidator,
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(feedbackReportValidator),
+  handler: async (ctx, args) => {
+    await requireContributorOrAdmin(ctx);
+
+    const limit = Math.min(Math.max(args.limit ?? 100, 1), 100);
+    return await ctx.db
+      .query("story_feedback_reports")
+      .withIndex("by_status_and_created_at", (q) => q.eq("status", args.status))
+      .order("desc")
+      .take(limit);
+  },
+});
+
+export const updateStoryFeedbackStatus = mutation({
+  args: {
+    reportId: v.id("story_feedback_reports"),
+    status: feedbackStatusValidator,
+  },
+  returns: feedbackReportValidator,
+  handler: async (ctx, args) => {
+    await requireContributorOrAdmin(ctx);
+
+    await ctx.db.patch(args.reportId, {
+      status: args.status,
+    });
+
+    const report = await ctx.db.get(args.reportId);
+    if (!report) {
+      throw new Error("Feedback report not found");
+    }
+
+    return report;
+  },
+});

--- a/src/app/editor/(course)/feedback/feedback_review_view.tsx
+++ b/src/app/editor/(course)/feedback/feedback_review_view.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+export {
+  default,
+  type FeedbackReport,
+  type FeedbackStatus,
+} from "@/app/editor/feedback/feedback_review_view";

--- a/src/app/editor/(course)/feedback/page.tsx
+++ b/src/app/editor/(course)/feedback/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import StoryFeedbackPageClient from "./page_client";
+
+export const metadata: Metadata = {
+  title: "Story Feedback | Duostories Editor",
+};
+
+export default function StoryFeedbackPage() {
+  return <StoryFeedbackPageClient />;
+}

--- a/src/app/editor/(course)/feedback/page_client.tsx
+++ b/src/app/editor/(course)/feedback/page_client.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useMutation, useQuery } from "convex/react";
+import Link from "next/link";
+import React from "react";
+import { api } from "@convex/_generated/api";
+import type { Id } from "@convex/_generated/dataModel";
+import { Breadcrumbs } from "@/app/editor/_components/breadcrumbs";
+import {
+  EditorHeaderActions,
+  EditorHeaderBreadcrumbs,
+} from "@/app/editor/_components/header_context";
+import FeedbackReviewView, {
+  type FeedbackReport,
+  type FeedbackStatus,
+} from "./feedback_review_view";
+
+export default function StoryFeedbackPageClient() {
+  const [status, setStatus] = React.useState<FeedbackStatus>("open");
+  const reports = useQuery(api.storyFeedback.listStoryFeedbackReports, {
+    status,
+    limit: 100,
+  });
+  const updateStatus = useMutation(api.storyFeedback.updateStoryFeedbackStatus);
+  const [updatingId, setUpdatingId] =
+    React.useState<Id<"story_feedback_reports"> | null>(null);
+
+  async function setReportStatus(
+    reportId: Id<"story_feedback_reports">,
+    nextStatus: FeedbackStatus,
+  ) {
+    setUpdatingId(reportId);
+    try {
+      await updateStatus({ reportId, status: nextStatus });
+    } finally {
+      setUpdatingId(null);
+    }
+  }
+
+  return (
+    <>
+      <EditorHeaderBreadcrumbs>
+        <Breadcrumbs
+          path={[
+            { type: "Editor", href: "/editor" },
+            { type: "sep" },
+            { type: "Feedback" },
+          ]}
+        />
+      </EditorHeaderBreadcrumbs>
+      <EditorHeaderActions>
+        <Link
+          href="/editor"
+          className="inline-flex min-h-10 items-center rounded-[12px] border-2 border-[var(--overview-hr)] bg-[var(--body-background)] px-4 text-[0.92rem] font-bold text-[var(--text-color)] hover:bg-[var(--body-background-faint)]"
+        >
+          Editor
+        </Link>
+      </EditorHeaderActions>
+
+      <FeedbackReviewView
+        status={status}
+        reports={reports as FeedbackReport[] | undefined}
+        updatingId={updatingId}
+        onStatusChange={setStatus}
+        onSetReportStatus={setReportStatus}
+      />
+    </>
+  );
+}

--- a/src/app/editor/(course)/layout_flag.tsx
+++ b/src/app/editor/(course)/layout_flag.tsx
@@ -33,6 +33,10 @@ export default function LayoutFlag() {
   const nestedRoute = segment[2];
   const import_id = nestedRoute === "import" ? segment[3] : undefined;
 
+  if (segment[0] === "feedback") {
+    return null;
+  }
+
   if (
     nestedRoute === "story" ||
     nestedRoute === "voices" ||
@@ -117,7 +121,15 @@ export default function LayoutFlag() {
             )}
             <div className="ml-[50px] max-[1120px]:ml-0" />
           </>
-        ) : null}
+        ) : (
+          <EditorButton
+            id="button_feedback"
+            href="/editor/feedback"
+            data-cy="button_feedback"
+            img="stories.png"
+            text="Feedback"
+          />
+        )}
       </EditorHeaderActions>
     </>
   );

--- a/src/app/editor/feedback/feedback_review_view.tsx
+++ b/src/app/editor/feedback/feedback_review_view.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import {
+  CheckCircle2Icon,
+  CircleDotIcon,
+  ExternalLinkIcon,
+  EyeIcon,
+  MessageSquareTextIcon,
+} from "lucide-react";
+import Link from "next/link";
+import React from "react";
+import type { Id } from "@convex/_generated/dataModel";
+import Button from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+
+export type FeedbackStatus = "open" | "reviewed" | "resolved";
+
+export type FeedbackReport = {
+  _id: Id<"story_feedback_reports">;
+  storyId: number;
+  storyTitle: string;
+  courseShort: string;
+  line?: number;
+  lineText?: string;
+  category: "Text" | "Translation hints" | "Audio" | "Other";
+  comment: string;
+  userName: string | null;
+  userEmail: string | null;
+  status: FeedbackStatus;
+  createdAt: number;
+};
+
+const statusOptions: Array<{
+  value: FeedbackStatus;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}> = [
+  { value: "open", label: "Open", icon: CircleDotIcon },
+  { value: "reviewed", label: "Reviewed", icon: EyeIcon },
+  { value: "resolved", label: "Resolved", icon: CheckCircle2Icon },
+];
+
+const statusLabels: Record<FeedbackStatus, string> = {
+  open: "Open",
+  reviewed: "Reviewed",
+  resolved: "Resolved",
+};
+
+export default function FeedbackReviewView({
+  status,
+  reports,
+  updatingId,
+  onStatusChange,
+  onSetReportStatus,
+}: {
+  status: FeedbackStatus;
+  reports?: FeedbackReport[];
+  updatingId: Id<"story_feedback_reports"> | null;
+  onStatusChange: (status: FeedbackStatus) => void;
+  onSetReportStatus: (
+    reportId: Id<"story_feedback_reports">,
+    status: FeedbackStatus,
+  ) => void | Promise<void>;
+}) {
+  return (
+    <main className="mx-auto w-full max-w-[1120px] px-5 py-6">
+      <div className="mb-5 flex flex-col gap-4 min-[760px]:flex-row min-[760px]:items-end min-[760px]:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-[0.82rem] font-bold tracking-[0.08em] text-[var(--title-color-dim)] uppercase">
+            <MessageSquareTextIcon className="h-4 w-4" />
+            Story reports
+          </div>
+          <h1 className="m-0 text-[1.8rem] leading-tight font-bold">
+            Feedback
+          </h1>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {statusOptions.map((option) => {
+            const Icon = option.icon;
+            const selected = status === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => onStatusChange(option.value)}
+                className={cn(
+                  "inline-flex min-h-10 items-center gap-2 rounded-full border px-4 text-[0.92rem] font-bold transition-colors",
+                  selected
+                    ? "border-[var(--button-background)] bg-[var(--button-background)] text-[var(--button-color)]"
+                    : "border-[var(--header-border)] bg-[var(--body-background-faint)] text-[var(--text-color)] hover:bg-[var(--body-background)]",
+                )}
+              >
+                <Icon className="h-4 w-4" />
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {reports === undefined ? (
+        <Spinner />
+      ) : reports.length === 0 ? (
+        <div className="rounded-[8px] border-2 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-5 py-8 text-center text-[var(--text-color-dim)]">
+          No {statusLabels[status].toLowerCase()} feedback reports.
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {reports.map((report) => (
+            <FeedbackReportRow
+              key={report._id}
+              report={report}
+              updating={updatingId === report._id}
+              onSetStatus={(nextStatus) =>
+                onSetReportStatus(report._id, nextStatus)
+              }
+            />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function FeedbackReportRow({
+  report,
+  updating,
+  onSetStatus,
+}: {
+  report: FeedbackReport;
+  updating: boolean;
+  onSetStatus: (status: FeedbackStatus) => void | Promise<void>;
+}) {
+  const editorHref = getEditorHref(report);
+
+  return (
+    <article className="grid gap-4 rounded-[8px] border-2 border-[var(--overview-hr)] bg-[var(--body-background)] p-4 min-[900px]:grid-cols-[minmax(0,1fr)_220px]">
+      <div className="min-w-0">
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              "rounded-full px-3 py-1 text-[0.78rem] font-bold",
+              getCategoryClassName(report.category),
+            )}
+          >
+            {report.category === "Translation hints"
+              ? "Translation"
+              : report.category}
+          </span>
+          <span className="rounded-full bg-[var(--body-background-faint)] px-3 py-1 text-[0.78rem] font-bold text-[var(--text-color-dim)]">
+            {statusLabels[report.status]}
+          </span>
+          <time className="text-[0.82rem] text-[var(--text-color-dim)]">
+            {formatDateTime(report.createdAt)}
+          </time>
+        </div>
+
+        <h2 className="m-0 mb-1 overflow-hidden text-ellipsis whitespace-nowrap text-[1.15rem] font-bold">
+          {report.storyTitle}
+        </h2>
+        <div className="mb-3 flex flex-wrap gap-x-3 gap-y-1 text-[0.9rem] text-[var(--text-color-dim)]">
+          <span>{report.courseShort}</span>
+          <span>Story {report.storyId}</span>
+          {report.line ? <span>Line {report.line}</span> : null}
+          <span>{report.userName || report.userEmail || "Anonymous"}</span>
+        </div>
+
+        {report.lineText ? (
+          <blockquote className="m-0 mb-3 rounded-[8px] border-l-4 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-4 py-3 text-[0.95rem] leading-6">
+            {report.lineText}
+          </blockquote>
+        ) : null}
+
+        <p className="m-0 whitespace-pre-wrap text-[1rem] leading-7">
+          {report.comment}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 min-[900px]:items-stretch">
+        <Link
+          href={editorHref}
+          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-[12px] border-2 border-[var(--button-blue-border)] bg-[var(--button-blue-background)] px-4 text-center font-bold text-[var(--button-blue-color)]"
+        >
+          <ExternalLinkIcon className="h-4 w-4" />
+          Open in editor
+        </Link>
+
+        <div className="grid grid-cols-2 gap-2 min-[900px]:grid-cols-1">
+          {report.status !== "open" ? (
+            <StatusButton
+              disabled={updating}
+              onClick={() => onSetStatus("open")}
+            >
+              Open
+            </StatusButton>
+          ) : null}
+          {report.status !== "reviewed" ? (
+            <StatusButton
+              disabled={updating}
+              onClick={() => onSetStatus("reviewed")}
+            >
+              Reviewed
+            </StatusButton>
+          ) : null}
+          {report.status !== "resolved" ? (
+            <StatusButton
+              disabled={updating}
+              onClick={() => onSetStatus("resolved")}
+            >
+              Resolved
+            </StatusButton>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function StatusButton({
+  children,
+  disabled,
+  onClick,
+}: {
+  children: React.ReactNode;
+  disabled?: boolean;
+  onClick: () => void | Promise<void>;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      disabled={disabled}
+      onClick={() => {
+        void onClick();
+      }}
+    >
+      {disabled ? "Updating" : children}
+    </Button>
+  );
+}
+
+function getEditorHref(report: FeedbackReport) {
+  const lineSearch = report.line ? `?line=${report.line}` : "";
+  return `/editor/course/${report.courseShort}/story/${report.storyId}${lineSearch}`;
+}
+
+function formatDateTime(timestamp: number) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(new Date(timestamp));
+}
+
+function getCategoryClassName(category: FeedbackReport["category"]) {
+  if (category === "Audio") {
+    return "bg-[#e9f6ff] text-[#075985]";
+  }
+  if (category === "Translation hints") {
+    return "bg-[#eef7e9] text-[#2f6b22]";
+  }
+  if (category === "Text") {
+    return "bg-[#fff4d6] text-[#7a4a00]";
+  }
+  return "bg-[var(--body-background-faint)] text-[var(--text-color)]";
+}

--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import React from "react";
+import { useMutation } from "convex/react";
+import { MessageCircle } from "lucide-react";
+import StoryTextLine from "@/components/StoryTextLine";
+import Button from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { StorySettings } from "@/components/StoryProgress";
+import type { StoryElementLine } from "@/components/editor/story/syntax_parser_types";
+import { api } from "@convex/_generated/api";
+import { cn } from "@/lib/utils";
+
+type StoryFeedbackProps = {
+  storyId: number;
+  storyTitle: string;
+  courseShort: string;
+  line?: number;
+  lineText?: string;
+  lineElement?: StoryElementLine;
+  settings: StorySettings;
+  hidden?: boolean;
+  className?: string;
+};
+
+const feedbackCategories = [
+  { label: "Text", value: "Text" },
+  { label: "Translation", value: "Translation hints" },
+  { label: "Audio", value: "Audio" },
+  { label: "Other", value: "Other" },
+] as const;
+
+type FeedbackCategory = (typeof feedbackCategories)[number]["value"];
+
+export default function StoryFeedback({
+  storyId,
+  storyTitle,
+  courseShort,
+  line,
+  lineText,
+  lineElement,
+  settings,
+  hidden = false,
+  className,
+}: StoryFeedbackProps) {
+  const submitStoryFeedback = useMutation(
+    api.storyFeedback.submitStoryFeedback,
+  );
+  const [open, setOpen] = React.useState(false);
+  const [category, setCategory] = React.useState<FeedbackCategory>(
+    feedbackCategories[0].value,
+  );
+  const [comment, setComment] = React.useState("");
+  const [submitState, setSubmitState] = React.useState<
+    "idle" | "submitting" | "submitted"
+  >("idle");
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+  const isSubmitting = submitState === "submitting";
+  const isSubmitted = submitState === "submitted";
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setSubmitState("idle");
+      setSubmitError(null);
+    } else {
+      setComment("");
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex h-12 items-center gap-2 rounded-full border-2 border-[color:color-mix(in_srgb,var(--link-blue)_34%,var(--overview-hr))] bg-[var(--body-background)] px-4 text-[0.92rem] font-bold text-[var(--text-color)] no-underline shadow-[0_10px_28px_color-mix(in_srgb,#000_18%,transparent)] transition-[background-color,border-color,color,transform,opacity] duration-100 hover:-translate-y-0.5 hover:border-[color:color-mix(in_srgb,var(--link-blue)_58%,var(--overview-hr))] hover:bg-[color:color-mix(in_srgb,var(--link-blue)_10%,var(--body-background))] hover:text-[var(--text-color)] focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-[color:color-mix(in_srgb,var(--ring)_35%,transparent)]",
+            hidden && "pointer-events-none opacity-0",
+            className,
+          )}
+          aria-label="Give feedback about this story"
+          title="Give feedback"
+        >
+          <MessageCircle aria-hidden="true" className="h-6 w-6" />
+          <span>Feedback</span>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-w-[640px] rounded-[18px] bg-[var(--body-background)] text-[var(--text-color)] sm:max-w-[640px]">
+        <DialogTitle className="text-[1.2rem] font-bold">
+          Give feedback
+        </DialogTitle>
+        <DialogDescription className="text-[0.95rem] text-[var(--text-color-dim)]">
+          Report a problem with this story line.
+        </DialogDescription>
+
+        <div className="rounded-[14px] border-2 border-[var(--overview-hr)] bg-[color:color-mix(in_srgb,var(--body-background)_88%,var(--body-background-faint))] p-4">
+          <div className="mb-1 text-[0.76rem] font-bold tracking-[0.1em] text-[var(--title-color-dim)] uppercase">
+            Current line
+          </div>
+          {lineElement ? (
+            <div className="mt-3 rounded-[12px] bg-[var(--body-background)] px-3 py-1 [&_.audio-button]:shrink-0">
+              <StoryTextLine
+                active={false}
+                element={lineElement}
+                settings={settings}
+              />
+            </div>
+          ) : (
+            <p className="mt-3 mb-0 whitespace-pre-wrap rounded-[12px] bg-[var(--body-background)] px-4 py-3 text-[1rem] leading-6">
+              {lineText || storyTitle}
+            </p>
+          )}
+        </div>
+
+        <form
+          className="grid gap-4"
+          onSubmit={async (event) => {
+            event.preventDefault();
+            if (isSubmitting) return;
+
+            setSubmitState("submitting");
+            setSubmitError(null);
+
+            try {
+              await submitStoryFeedback({
+                storyId,
+                storyTitle,
+                courseShort,
+                line,
+                lineText,
+                category,
+                comment,
+              });
+              setSubmitState("submitted");
+              setComment("");
+            } catch (error) {
+              setSubmitState("idle");
+              setSubmitError(
+                error instanceof Error
+                  ? error.message
+                  : "Could not submit feedback.",
+              );
+            }
+          }}
+        >
+          <div className="grid gap-2">
+            <div className="text-[0.92rem] font-bold">Category</div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              {feedbackCategories.map((option) => {
+                const selected = category === option.value;
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={selected}
+                    disabled={isSubmitting || isSubmitted}
+                    onClick={() => setCategory(option.value)}
+                    className={cn(
+                      "min-h-11 rounded-[13px] border-2 px-3 py-2 text-[0.86rem] font-bold whitespace-nowrap transition-[background-color,border-color,color,transform] duration-100 focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-[color:color-mix(in_srgb,var(--ring)_35%,transparent)]",
+                      selected
+                        ? "border-[var(--button-blue-border)] bg-[var(--button-blue-background)] text-[var(--button-blue-color)]"
+                        : "border-[var(--overview-hr)] bg-[var(--body-background)] text-[var(--text-color)] hover:border-[color:color-mix(in_srgb,var(--link-blue)_35%,var(--overview-hr))] hover:bg-[color:color-mix(in_srgb,var(--link-blue)_8%,var(--body-background))]",
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <label className="grid gap-2 text-[0.92rem] font-bold">
+            Comment
+            <textarea
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              rows={5}
+              required
+              disabled={isSubmitting || isSubmitted}
+              className="w-full resize-y rounded-[14px] border-2 border-[var(--input-border)] bg-[var(--input-background)] px-4 py-3 text-[1rem] font-normal leading-6 text-[var(--text-color)] outline-none focus:border-[color:color-mix(in_srgb,var(--link-blue)_45%,var(--input-border))]"
+              placeholder="What should be fixed?"
+            />
+          </label>
+
+          {submitError ? (
+            <div
+              className="rounded-[12px] border-2 border-[#e66969] bg-[#fff1f1] px-4 py-3 text-[0.95rem] font-bold text-[#9b1c1c]"
+              role="alert"
+            >
+              {submitError}
+            </div>
+          ) : null}
+          {isSubmitted ? (
+            <div className="rounded-[12px] border-2 border-[color:color-mix(in_srgb,var(--button-blue-background)_45%,var(--overview-hr))] bg-[color:color-mix(in_srgb,var(--button-blue-background)_10%,var(--body-background))] px-4 py-3 text-[0.95rem] font-bold text-[var(--text-color)]">
+              Thanks, your feedback was saved.
+            </div>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <DialogClose asChild>
+              <Button type="button" variant="secondary" disabled={isSubmitting}>
+                {isSubmitted ? "Done" : "Cancel"}
+              </Button>
+            </DialogClose>
+            {!isSubmitted ? (
+              <Button
+                type="submit"
+                variant="primary"
+                disabled={isSubmitting || comment.trim().length === 0}
+              >
+                {isSubmitting ? "Submitting" : "Submit feedback"}
+              </Button>
+            ) : null}
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/StoryFooter/StoryFooter.tsx
+++ b/src/components/StoryFooter/StoryFooter.tsx
@@ -43,6 +43,7 @@ function StoryFooter({
   nextStoryPreview,
   learningLanguageName,
   showFinishedPrimaryAction = true,
+  feedback,
 }: {
   buttonStatus: string;
   onClick: () => void;
@@ -56,6 +57,7 @@ function StoryFooter({
   } | null;
   learningLanguageName?: string;
   showFinishedPrimaryAction?: boolean;
+  feedback?: React.ReactNode;
 }) {
   const localisation = useLocalisation();
 
@@ -144,6 +146,11 @@ function StoryFooter({
   if (buttonStatus === "wait") {
     return (
       <div className={footerBaseClassName}>
+        {feedback ? (
+          <div className="absolute right-6 bottom-[calc(100%+16px)] z-[1] max-[500px]:right-4 max-[500px]:bottom-[calc(100%+12px)]">
+            {feedback}
+          </div>
+        ) : null}
         <div className={widthWrapperBaseClassName}>
           <Button key={"c"} disabled onClick={onContinueClick}>
             {localisation("button_continue") || "continue"}
@@ -155,6 +162,11 @@ function StoryFooter({
   if (buttonStatus !== "right") {
     return (
       <div className={footerBaseClassName}>
+        {feedback ? (
+          <div className="absolute right-6 bottom-[calc(100%+16px)] z-[1] max-[500px]:right-4 max-[500px]:bottom-[calc(100%+12px)]">
+            {feedback}
+          </div>
+        ) : null}
         <div className={widthWrapperBaseClassName}>
           <Button key={"c"} onClick={onContinueClick}>
             {localisation("button_continue") || "continue"}
@@ -170,6 +182,11 @@ function StoryFooter({
         "border-[var(--footer-right-background)] bg-[var(--footer-right-background)] text-[var(--footer-right-color)]",
       )}
     >
+      {feedback ? (
+        <div className="absolute right-6 bottom-[calc(100%+16px)] z-[1] max-[500px]:right-4 max-[500px]:bottom-[calc(100%+12px)]">
+          {feedback}
+        </div>
+      ) : null}
       <div
         className={cn(
           widthWrapperBaseClassName,

--- a/src/components/StoryProgress/StoryProgress.tsx
+++ b/src/components/StoryProgress/StoryProgress.tsx
@@ -11,6 +11,7 @@ import StoryTextLine from "../StoryTextLine";
 import StoryHeader from "../StoryHeader";
 import StoryHeaderProgress from "../StoryHeaderProgress";
 import StoryFooter from "../StoryFooter";
+import StoryFeedback from "../StoryFeedback/StoryFeedback";
 import StoryFinishedScreen from "../StoryFinishedScreen";
 import StoryTitlePage from "../StoryTitlePage";
 import { playSoundEffect } from "@/lib/sound-effects";
@@ -312,6 +313,96 @@ function getVisibleEditorLine({
     .find((lineNumber): lineNumber is number => typeof lineNumber === "number");
 }
 
+function getAnswerText(answer: string | { text?: string }) {
+  return typeof answer === "string" ? answer : (answer.text ?? "");
+}
+
+function getFeedbackTextForElement(element: StoryElement) {
+  if (element.type === "HEADER") {
+    return element.learningLanguageTitleContent.text;
+  }
+
+  if (element.type === "LINE") {
+    const speaker =
+      element.line.type === "CHARACTER"
+        ? (element.line.characterName ?? `${element.line.characterId}`)
+        : "";
+    const text = element.line.content.text;
+    return speaker ? `${speaker}: ${text}` : text;
+  }
+
+  if (element.type === "MULTIPLE_CHOICE") {
+    return [
+      element.question?.text,
+      ...element.answers.map(getAnswerText),
+    ].filter(Boolean);
+  }
+
+  if (element.type === "CHALLENGE_PROMPT") {
+    return element.prompt.text;
+  }
+
+  if (element.type === "SELECT_PHRASE") {
+    return element.answers.map(getAnswerText).filter(Boolean);
+  }
+
+  if (element.type === "ARRANGE") {
+    return element.selectablePhrases;
+  }
+
+  if (element.type === "POINT_TO_PHRASE") {
+    return [
+      element.question.text,
+      element.transcriptParts.map((part) => part.text).join(""),
+    ].filter(Boolean);
+  }
+
+  if (element.type === "MATCH") {
+    return [
+      element.prompt,
+      ...element.fallbackHints.map(
+        (hint) => `${hint.phrase} = ${hint.translation}`,
+      ),
+    ].filter(Boolean);
+  }
+
+  if (element.type === "ERROR") {
+    return element.text;
+  }
+
+  return "";
+}
+
+function getFeedbackLineText(currentPart?: StoryElement[]) {
+  if (!currentPart) return "";
+
+  return currentPart
+    .flatMap((element) => getFeedbackTextForElement(element))
+    .filter(Boolean)
+    .join("\n");
+}
+
+function getFeedbackLineElement({
+  currentPart,
+  currentEditorLine,
+}: {
+  currentPart?: StoryElement[];
+  currentEditorLine?: number;
+}) {
+  if (!currentPart) return undefined;
+
+  const lineElements = currentPart.filter(
+    (element): element is StoryElementLine => element.type === "LINE",
+  );
+  if (currentEditorLine !== undefined) {
+    return lineElements.find(
+      (element) => element.editor?.block_start_no === currentEditorLine,
+    );
+  }
+
+  return lineElements[0];
+}
+
 function getCurrentVisiblePart({
   partsList,
   storyProgress,
@@ -492,6 +583,11 @@ function StoryProgress({
     currentPart,
     partProgress,
   });
+  const currentFeedbackLineText = getFeedbackLineText(currentPart);
+  const currentFeedbackLineElement = getFeedbackLineElement({
+    currentPart,
+    currentEditorLine,
+  });
   const editHref =
     editHrefBase && currentEditorLine
       ? `${editHrefBase}?line=${currentEditorLine}`
@@ -634,6 +730,18 @@ function StoryProgress({
               nextStoryPreview={nextStoryPreview}
               learningLanguageName={story.learning_language_long}
               showFinishedPrimaryAction={showFinishedPrimaryAction}
+              feedback={
+                <StoryFeedback
+                  storyId={story.id}
+                  storyTitle={story.from_language_name}
+                  courseShort={story.course_short}
+                  line={currentEditorLine}
+                  lineText={currentFeedbackLineText}
+                  lineElement={currentFeedbackLineElement}
+                  settings={settings}
+                  hidden={buttonStatus === "..."}
+                />
+              }
             />
           </div>
         ) : null}


### PR DESCRIPTION
## Summary
- Adds a new story feedback form in the story footer so readers can report issues by category with optional line context.
- Stores feedback in a new `story_feedback_reports` Convex table and exposes mutations/queries for submitting and reviewing reports.
- Adds an editor review page for browsing feedback by status, opening the relevant story in the editor, and updating report status.
- Updates the editor navigation to surface the new Feedback section.

## Testing
- Not run
- Verified the new Convex schema and API wiring were added for feedback reports.
- Verified the story UI now passes current line text and editor line context into the feedback dialog.
- Verified the editor review screen supports status filtering and status updates.