### PR TITLE
[codex] Fix feedback modal on small screens

### DIFF
--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -92,7 +92,7 @@ export default function StoryFeedback({
           <span>Feedback</span>
         </button>
       </DialogTrigger>
-      <DialogContent className="max-w-[640px] rounded-[18px] bg-[var(--body-background)] text-[var(--text-color)] sm:max-w-[640px]">
+      <DialogContent className="max-w-[640px] overflow-x-hidden rounded-[18px] bg-[var(--body-background)] text-[var(--text-color)] sm:max-w-[640px]">
         <DialogTitle className="text-[1.2rem] font-bold">
           Give feedback
         </DialogTitle>
@@ -100,20 +100,21 @@ export default function StoryFeedback({
           Report a problem with this story line.
         </DialogDescription>
 
-        <div className="rounded-[14px] border-2 border-[var(--overview-hr)] bg-[color:color-mix(in_srgb,var(--body-background)_88%,var(--body-background-faint))] p-4">
+        <div className="min-w-0 overflow-hidden">
           <div className="mb-1 text-[0.76rem] font-bold tracking-[0.1em] text-[var(--title-color-dim)] uppercase">
             Current line
           </div>
           {lineElement ? (
-            <div className="mt-3 rounded-[12px] bg-[var(--body-background)] px-3 py-1 [&_.audio-button]:shrink-0">
+            <div className="mt-3 min-w-0 overflow-hidden [&_.audio-button]:shrink-0">
               <StoryTextLine
                 active={false}
                 element={lineElement}
                 settings={settings}
+                compact
               />
             </div>
           ) : (
-            <p className="mt-3 mb-0 whitespace-pre-wrap rounded-[12px] bg-[var(--body-background)] px-4 py-3 text-[1rem] leading-6">
+            <p className="mt-3 mb-0 whitespace-pre-wrap text-[1rem] leading-6">
               {lineText || storyTitle}
             </p>
           )}
@@ -152,7 +153,7 @@ export default function StoryFeedback({
         >
           <div className="grid gap-2">
             <div className="text-[0.92rem] font-bold">Category</div>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <div className="grid min-w-0 grid-cols-2 gap-2 sm:grid-cols-4">
               {feedbackCategories.map((option) => {
                 const selected = category === option.value;
 
@@ -164,7 +165,7 @@ export default function StoryFeedback({
                     disabled={isSubmitting || isSubmitted}
                     onClick={() => setCategory(option.value)}
                     className={cn(
-                      "min-h-11 rounded-[13px] border-2 px-3 py-2 text-[0.86rem] font-bold whitespace-nowrap transition-[background-color,border-color,color,transform] duration-100 focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-[color:color-mix(in_srgb,var(--ring)_35%,transparent)]",
+                      "min-h-11 min-w-0 rounded-[13px] border-2 px-2 py-2 text-[0.82rem] font-bold whitespace-nowrap transition-[background-color,border-color,color,transform] duration-100 focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-[color:color-mix(in_srgb,var(--ring)_35%,transparent)] sm:px-3 sm:text-[0.86rem]",
                       selected
                         ? "border-[var(--button-blue-border)] bg-[var(--button-blue-background)] text-[var(--button-blue-color)]"
                         : "border-[var(--overview-hr)] bg-[var(--body-background)] text-[var(--text-color)] hover:border-[color:color-mix(in_srgb,var(--link-blue)_35%,var(--overview-hr))] hover:bg-[color:color-mix(in_srgb,var(--link-blue)_8%,var(--body-background))]",

--- a/src/components/StoryTextLine/StoryTextLine.tsx
+++ b/src/components/StoryTextLine/StoryTextLine.tsx
@@ -28,6 +28,7 @@ function StoryTextLine({
   onOpenAudioEditor,
   audioRangeOverride,
   hideAudioButton = false,
+  compact = false,
 }: {
   active: boolean;
   element: StoryElementLine;
@@ -41,6 +42,7 @@ function StoryTextLine({
   ) => void | Promise<void>;
   audioRangeOverride?: number;
   hideAudioButton?: boolean;
+  compact?: boolean;
 }) {
   const editorProps: EditorProps = {
     editorState,
@@ -67,6 +69,8 @@ function StoryTextLine({
     "after:absolute after:top-0 after:left-[-9px] after:content-[''] after:border-r-[12px] after:border-b-[12px] after:border-r-[var(--color_base_background)] after:border-b-transparent",
     isRtl &&
       "rounded-tl-[14px] rounded-tr-none before:left-auto before:right-[-14px] before:border-r-0 before:border-l-[12px] before:border-l-[var(--color_base_border)] after:left-auto after:right-[-9px] after:border-r-0 after:border-l-[12px] after:border-l-[var(--color_base_background)]",
+    compact &&
+      "min-w-0 max-w-[calc(100%-68px)] whitespace-normal break-words [overflow-wrap:anywhere]",
   );
 
   if (element.line === undefined) return <></>;
@@ -135,6 +139,7 @@ function StoryTextLine({
         <img
           className={cn(
             "mr-[18px] flex h-[50px] w-[50px] flex-[0_0_50px]",
+            compact && "mr-3 h-10 w-10 flex-[0_0_40px]",
             isRtl && "mr-0 ml-3 scale-x-[-1]",
           )}
           src={element.line.avatarUrl}


### PR DESCRIPTION
## Summary

Fixes the feedback modal on narrow screens after the story feedback workflow merged.

- Adds an opt-in compact mode to `StoryTextLine` so the modal can reuse the real story line renderer without forcing desktop-width bubbles.
- Clips and constrains the modal preview card to prevent horizontal page overflow.
- Tightens category button sizing for small screens.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- Captured a 390px-wide modal screenshot and confirmed `documentElement.scrollWidth === clientWidth`.

Screenshot: http://100.77.207.26:8787/HsTB7lNHT302laoxtvOaon72/20260703T155156Z-duostories-feedback-modal-small-fixed-clean.png

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the feedback dialog layout to handle narrower spaces more gracefully and improve horizontal overflow behavior.
  * Refined the current-line display so text and avatar sizing adapt better in compact views.
  * Adjusted category option spacing, typography, and focus behavior for a cleaner selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->