### PR TITLE
[codex] Fix feedback modal hints and line previews

### DIFF
--- a/src/app/editor/feedback/feedback_review_view.tsx
+++ b/src/app/editor/feedback/feedback_review_view.tsx
@@ -136,6 +136,7 @@ function FeedbackReportRow({
   onSetStatus: (status: FeedbackStatus) => void | Promise<void>;
 }) {
   const editorHref = getEditorHref(report);
+  const linePreview = getLinePreview(report.lineText);
 
   return (
     <article className="grid gap-4 rounded-[8px] border-2 border-[var(--overview-hr)] bg-[var(--body-background)] p-4 min-[900px]:grid-cols-[minmax(0,1fr)_220px]">
@@ -169,9 +170,9 @@ function FeedbackReportRow({
           <span>{report.userName || report.userEmail || "Anonymous"}</span>
         </div>
 
-        {report.lineText ? (
-          <blockquote className="m-0 mb-3 rounded-[8px] border-l-4 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-4 py-3 text-[0.95rem] leading-6">
-            {report.lineText}
+        {linePreview ? (
+          <blockquote className="m-0 mb-3 rounded-[8px] border-l-4 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-4 py-3 text-[0.95rem] leading-6 whitespace-pre-wrap">
+            {linePreview}
           </blockquote>
         ) : null}
 
@@ -255,6 +256,17 @@ function formatDateTime(timestamp: number) {
     timeStyle: "short",
     timeZone: "UTC",
   }).format(new Date(timestamp));
+}
+
+function getLinePreview(lineText?: string) {
+  if (!lineText) return "";
+
+  return (
+    lineText
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
 }
 
 function getCategoryClassName(category: FeedbackReport["category"]) {

--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -111,6 +111,7 @@ export default function StoryFeedback({
                 element={lineElement}
                 settings={settings}
                 compact
+                disableHintTooltips
               />
             </div>
           ) : (

--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -160,6 +160,7 @@ function StoryLineHints({
   hideRangesForChallenge,
   unhide,
   editorState,
+  disableTooltips = false,
 }: {
   content: ContentWithHints;
   showHints?: boolean;
@@ -168,6 +169,7 @@ function StoryLineHints({
   hideRangesForChallenge?: { start: number; end: number }[];
   unhide?: number;
   editorState?: EditorStateType;
+  disableTooltips?: boolean;
 }) {
   if (!content) return <>Empty</>;
   const visibleContent = showHints
@@ -305,7 +307,8 @@ function StoryLineHints({
       visibleContent.hints_pronunciation?.[hint.hintIndex];
     const has_any_hint = Boolean(hint_translation || hint_pronunciation);
     const has_translation_hint = Boolean(hint_translation);
-    const isInteractive = !is_hidden && !showTrans && has_translation_hint;
+    const showTooltip = !disableTooltips && !showTrans;
+    const isInteractive = !is_hidden && showTooltip && has_translation_hint;
     const was_hidden_for_challenge = hideRangesForChallenge?.some((range) =>
       getOverlap(hint.rangeFrom, hint.rangeTo + 1, range.start, range.end),
     );
@@ -325,9 +328,11 @@ function StoryLineHints({
         <span
           className={cn(
             "pointer-events-none invisible absolute whitespace-nowrap leading-none opacity-0 transition-opacity duration-200",
-            !is_hidden &&
+            !disableTooltips &&
+              !is_hidden &&
               "group-hover/tooltip:visible group-hover/tooltip:opacity-95",
-            !is_hidden &&
+            !disableTooltips &&
+              !is_hidden &&
               "group-focus-within/tooltip:visible group-focus-within/tooltip:opacity-95",
             showTrans &&
               "group-hover/editorhint:visible group-hover/editorhint:opacity-95",
@@ -352,7 +357,7 @@ function StoryLineHints({
         ? has_any_hint
           ? "group/editorhint inline-flex grow flex-col"
           : ""
-        : has_translation_hint
+        : showTooltip && has_translation_hint
           ? cn(
               "group/tooltip relative inline-block align-baseline",
               "focus:outline-none focus-visible:rounded focus-visible:outline-2 focus-visible:outline-offset-2",
@@ -395,7 +400,7 @@ function StoryLineHints({
               ) : null}
             </span>
           ) : null
-        ) : has_translation_hint ? (
+        ) : showTooltip && has_translation_hint ? (
           <span
             className={hintTextClassName}
             data-hint-tooltip

--- a/src/components/StoryProgress/StoryProgress.tsx
+++ b/src/components/StoryProgress/StoryProgress.tsx
@@ -323,12 +323,7 @@ function getFeedbackTextForElement(element: StoryElement) {
   }
 
   if (element.type === "LINE") {
-    const speaker =
-      element.line.type === "CHARACTER"
-        ? (element.line.characterName ?? `${element.line.characterId}`)
-        : "";
-    const text = element.line.content.text;
-    return speaker ? `${speaker}: ${text}` : text;
+    return getFeedbackTextForLineElement(element);
   }
 
   if (element.type === "MULTIPLE_CHOICE") {
@@ -373,7 +368,26 @@ function getFeedbackTextForElement(element: StoryElement) {
   return "";
 }
 
-function getFeedbackLineText(currentPart?: StoryElement[]) {
+function getFeedbackTextForLineElement(element: StoryElementLine) {
+  const speaker =
+    element.line.type === "CHARACTER"
+      ? (element.line.characterName ?? `${element.line.characterId}`)
+      : "";
+  const text = element.line.content.text;
+  return speaker ? `${speaker}: ${text}` : text;
+}
+
+function getFeedbackLineText({
+  currentPart,
+  currentLineElement,
+}: {
+  currentPart?: StoryElement[];
+  currentLineElement?: StoryElementLine;
+}) {
+  if (currentLineElement) {
+    return getFeedbackTextForLineElement(currentLineElement);
+  }
+
   if (!currentPart) return "";
 
   return currentPart
@@ -583,10 +597,13 @@ function StoryProgress({
     currentPart,
     partProgress,
   });
-  const currentFeedbackLineText = getFeedbackLineText(currentPart);
   const currentFeedbackLineElement = getFeedbackLineElement({
     currentPart,
     currentEditorLine,
+  });
+  const currentFeedbackLineText = getFeedbackLineText({
+    currentPart,
+    currentLineElement: currentFeedbackLineElement,
   });
   const editHref =
     editHrefBase && currentEditorLine

--- a/src/components/StoryTextLine/StoryTextLine.tsx
+++ b/src/components/StoryTextLine/StoryTextLine.tsx
@@ -29,6 +29,7 @@ function StoryTextLine({
   audioRangeOverride,
   hideAudioButton = false,
   compact = false,
+  disableHintTooltips = false,
 }: {
   active: boolean;
   element: StoryElementLine;
@@ -43,6 +44,7 @@ function StoryTextLine({
   audioRangeOverride?: number;
   hideAudioButton?: boolean;
   compact?: boolean;
+  disableHintTooltips?: boolean;
 }) {
   const editorProps: EditorProps = {
     editorState,
@@ -121,6 +123,7 @@ function StoryTextLine({
             hideRangesForChallenge={hideRangesForChallenge}
             content={element.line.content}
             editorState={editorState}
+            disableTooltips={disableHintTooltips}
           />
         </span>
       </div>
@@ -162,6 +165,7 @@ function StoryTextLine({
             unhide={unhide}
             content={element.line.content}
             editorState={editorState}
+            disableTooltips={disableHintTooltips}
           />
           {showEditorAudioDetails &&
             element.line.content.audio &&
@@ -201,6 +205,7 @@ function StoryTextLine({
             unhide={unhide}
             content={element.line.content}
             editorState={editorState}
+            disableTooltips={disableHintTooltips}
           />
           {showEditorAudioDetails &&
             element.line.content.audio &&


### PR DESCRIPTION
## Summary

- Adds a `disableHintTooltips` path from the feedback modal through `StoryTextLine` into `StoryLineHints`.
- Keeps hint underlines visible in the feedback modal preview, but prevents translation tooltip popovers from rendering/opening there.
- Saves future feedback context from the current story line instead of the full visible part with question/answer text.
- Shows only the first saved line in the feedback review card so older reports do not display appended challenge options.

## Why

The feedback modal reuses the real story line component. On open, the first hinted word could receive focus/hover-style tooltip behavior, which made the hint appear automatically and get clipped inside the modal. Separately, the stored `lineText` was built from the whole current story part, so reports after a story line plus a multiple-choice prompt displayed the Dutch line followed by English prompt/options.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- Captured a small-screen modal screenshot confirming the hint bubble no longer appears on open.