### PR TITLE
Show audio problem counts in editor

### DIFF
--- a/convex/courseWrite.ts
+++ b/convex/courseWrite.ts
@@ -34,6 +34,7 @@ export const recomputePublishedCount = mutation({
 
 export const setAudioProblemCounts = mutation({
   args: {
+    operationKey: v.optional(v.string()),
     counts: v.array(
       v.object({
         courseShort: v.optional(v.string()),
@@ -61,6 +62,8 @@ export const setAudioProblemCounts = mutation({
   handler: async (ctx, args) => {
     await requireContributorOrAdmin(ctx);
 
+    const operationKey =
+      args.operationKey ?? `course:audio_problem_counts:${Date.now()}`;
     let updated = 0;
     let unchanged = 0;
     let updatedStories = 0;
@@ -104,6 +107,7 @@ export const setAudioProblemCounts = mutation({
 
       await ctx.db.patch(course._id, {
         audio_problem_count: entry.audioProblemCount,
+        lastOperationKey: operationKey,
       });
       updated += 1;
     }
@@ -134,6 +138,7 @@ export const setAudioProblemCounts = mutation({
 
       await ctx.db.patch(story._id, {
         audio_problem_count: entry.audioProblemCount,
+        lastOperationKey: operationKey,
       });
       updatedStories += 1;
     }

--- a/convex/courseWrite.ts
+++ b/convex/courseWrite.ts
@@ -41,10 +41,21 @@ export const setAudioProblemCounts = mutation({
         audioProblemCount: v.number(),
       }),
     ),
+    stories: v.optional(
+      v.array(
+        v.object({
+          legacyStoryId: v.number(),
+          audioProblemCount: v.number(),
+        }),
+      ),
+    ),
   },
   returns: v.object({
     updated: v.number(),
     unchanged: v.number(),
+    updatedStories: v.number(),
+    unchangedStories: v.number(),
+    missingStories: v.array(v.number()),
     missing: v.array(v.string()),
   }),
   handler: async (ctx, args) => {
@@ -52,7 +63,10 @@ export const setAudioProblemCounts = mutation({
 
     let updated = 0;
     let unchanged = 0;
+    let updatedStories = 0;
+    let unchangedStories = 0;
     const missing: string[] = [];
+    const missingStories: number[] = [];
 
     for (const entry of args.counts) {
       if (
@@ -94,6 +108,43 @@ export const setAudioProblemCounts = mutation({
       updated += 1;
     }
 
-    return { updated, unchanged, missing };
+    for (const entry of args.stories ?? []) {
+      if (
+        entry.audioProblemCount < 0 ||
+        !Number.isInteger(entry.audioProblemCount)
+      ) {
+        throw new Error(
+          "story audioProblemCount must be a non-negative integer",
+        );
+      }
+
+      const story = await ctx.db
+        .query("stories")
+        .withIndex("by_legacy_id", (q) => q.eq("legacyId", entry.legacyStoryId))
+        .unique();
+      if (!story) {
+        missingStories.push(entry.legacyStoryId);
+        continue;
+      }
+
+      if ((story.audio_problem_count ?? 0) === entry.audioProblemCount) {
+        unchangedStories += 1;
+        continue;
+      }
+
+      await ctx.db.patch(story._id, {
+        audio_problem_count: entry.audioProblemCount,
+      });
+      updatedStories += 1;
+    }
+
+    return {
+      updated,
+      unchanged,
+      updatedStories,
+      unchangedStories,
+      missingStories,
+      missing,
+    };
   },
 });

--- a/convex/courseWrite.ts
+++ b/convex/courseWrite.ts
@@ -31,3 +31,69 @@ export const recomputePublishedCount = mutation({
     };
   },
 });
+
+export const setAudioProblemCounts = mutation({
+  args: {
+    counts: v.array(
+      v.object({
+        courseShort: v.optional(v.string()),
+        legacyCourseId: v.optional(v.number()),
+        audioProblemCount: v.number(),
+      }),
+    ),
+  },
+  returns: v.object({
+    updated: v.number(),
+    unchanged: v.number(),
+    missing: v.array(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    await requireContributorOrAdmin(ctx);
+
+    let updated = 0;
+    let unchanged = 0;
+    const missing: string[] = [];
+
+    for (const entry of args.counts) {
+      if (
+        entry.audioProblemCount < 0 ||
+        !Number.isInteger(entry.audioProblemCount)
+      ) {
+        throw new Error("audioProblemCount must be a non-negative integer");
+      }
+      if (!entry.courseShort && entry.legacyCourseId === undefined) {
+        throw new Error("Each count needs courseShort or legacyCourseId");
+      }
+
+      const course =
+        entry.legacyCourseId !== undefined
+          ? await ctx.db
+              .query("courses")
+              .withIndex("by_id_value", (q) =>
+                q.eq("legacyId", entry.legacyCourseId!),
+              )
+              .unique()
+          : await ctx.db
+              .query("courses")
+              .withIndex("by_short", (q) => q.eq("short", entry.courseShort))
+              .unique();
+
+      if (!course) {
+        missing.push(entry.courseShort ?? String(entry.legacyCourseId));
+        continue;
+      }
+
+      if ((course.audio_problem_count ?? 0) === entry.audioProblemCount) {
+        unchanged += 1;
+        continue;
+      }
+
+      await ctx.db.patch(course._id, {
+        audio_problem_count: entry.audioProblemCount,
+      });
+      updated += 1;
+    }
+
+    return { updated, unchanged, missing };
+  },
+});

--- a/convex/editorRead.ts
+++ b/convex/editorRead.ts
@@ -30,6 +30,7 @@ const editorCourseValidator = v.union(
     contributors: v.array(courseContributorValidator),
     contributors_past: v.array(courseContributorValidator),
     todo_count: v.number(),
+    audio_problem_count: v.number(),
   }),
   v.null(),
 );
@@ -83,6 +84,7 @@ function toCourse(
     contributors: course.contributors ?? [],
     contributors_past: course.contributors_past ?? [],
     todo_count: course.todo_count ?? 0,
+    audio_problem_count: course.audio_problem_count ?? 0,
   };
 }
 
@@ -276,6 +278,7 @@ export const getEditorCourseByIdentifier = query({
       contributors: contributorLists.contributors,
       contributors_past: contributorLists.contributors_past,
       todo_count: course.todo_count ?? 0,
+      audio_problem_count: course.audio_problem_count ?? 0,
     };
   },
 });

--- a/convex/editorRead.ts
+++ b/convex/editorRead.ts
@@ -404,6 +404,7 @@ export const getEditorStoriesByCourseLegacyId = query({
         status: derivedStatus,
         public: story.public,
         todo_count: story.todo_count ?? 0,
+        audio_problem_count: story.audio_problem_count ?? 0,
         approvalCount: approvalCount ?? 0,
         approvedByCurrentUser: storyIdsApprovedByCurrentUser.has(story._id),
         author:

--- a/convex/lookupTables.ts
+++ b/convex/lookupTables.ts
@@ -325,6 +325,7 @@ export const upsertCourse = mutation({
       contributors: args.course.contributors,
       contributors_past: args.course.contributors_past,
       todo_count: args.course.todo_count,
+      audio_problem_count: existing?.audio_problem_count,
       mirrorUpdatedAt: Date.now(),
       lastOperationKey: args.operationKey,
     };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -107,6 +107,7 @@ export default defineSchema({
       v.array(courseContributorDetailsValidator),
     ),
     todo_count: v.optional(v.number()),
+    audio_problem_count: v.optional(v.number()),
     mirrorUpdatedAt: v.optional(v.number()),
     lastOperationKey: v.optional(v.string()),
   })

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -153,6 +153,7 @@ export default defineSchema({
     approvalCount: v.optional(v.number()),
     deleted: v.boolean(),
     todo_count: v.number(),
+    audio_problem_count: v.optional(v.number()),
     legacyId: v.optional(v.number()),
   })
     .index("by_course", ["courseId"])

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -154,6 +154,7 @@ export default defineSchema({
     deleted: v.boolean(),
     todo_count: v.number(),
     audio_problem_count: v.optional(v.number()),
+    lastOperationKey: v.optional(v.string()),
     legacyId: v.optional(v.number()),
   })
     .index("by_course", ["courseId"])

--- a/convex/storyTables.ts
+++ b/convex/storyTables.ts
@@ -92,6 +92,7 @@ export const upsertStory = mutation({
       deleted: args.story.deleted,
       todo_count: args.story.todo_count,
       audio_problem_count: existing?.audio_problem_count,
+      lastOperationKey: args.operationKey ?? existing?.lastOperationKey,
     };
 
     if (existing) {

--- a/convex/storyTables.ts
+++ b/convex/storyTables.ts
@@ -91,6 +91,7 @@ export const upsertStory = mutation({
       approvalCount: args.story.approvalCount ?? existing?.approvalCount ?? 0,
       deleted: args.story.deleted,
       todo_count: args.story.todo_count,
+      audio_problem_count: existing?.audio_problem_count,
     };
 
     if (existing) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "backfill:course-contributors": "pnpm exec tsx scripts/backfill-course-contributors.ts",
     "audio:join-story": "tsx scripts/generate-joined-story-audio.ts",
     "audio:join-course": "tsx scripts/generate-course-joined-audio.ts",
-    "audio:upload-joined": "tsx scripts/upload-joined-story-audio.ts"
+    "audio:upload-joined": "tsx scripts/upload-joined-story-audio.ts",
+    "audio:sync-problem-counts": "tsx scripts/sync-audio-problem-counts.ts"
   },
   "dependencies": {
     "@aws-sdk/client-polly": "^3.1061.0",

--- a/scripts/sync-audio-problem-counts.ts
+++ b/scripts/sync-audio-problem-counts.ts
@@ -7,7 +7,7 @@ type CliOptions = {
   inputDir: string;
   courses: string[];
   apply: boolean;
-  identity: string;
+  identity: string | null;
 };
 
 type CourseSummary = {
@@ -38,7 +38,7 @@ Options:
   --input-dir <dir>   Course summary root (default: tmp/story-audio/courses)
   --course <short>    Course to sync. Can be repeated. Defaults to all summaries.
   --apply             Apply to Convex. Without this, print the payload only.
-  --identity <json>   Convex run identity (default: {"role":"admin","userId":1})
+  --identity <json>   Convex run identity. Required with --apply.
 `);
   process.exit(exitCode);
 }
@@ -55,7 +55,7 @@ function parseCliOptions(args: string[]): CliOptions {
   const courses: string[] = [];
   let inputDir = path.join("tmp", "story-audio", "courses");
   let apply = false;
-  let identity = JSON.stringify({ role: "admin", userId: 1 });
+  let identity: string | null = null;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -91,9 +91,70 @@ function parseCliOptions(args: string[]): CliOptions {
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertNonNegativeInteger(
+  value: unknown,
+  field: string,
+): asserts value is number {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
+    throw new Error(`${field} must be a non-negative integer.`);
+  }
+}
+
+function parseCourseSummary(raw: unknown): CourseSummary {
+  if (!isRecord(raw)) {
+    throw new Error("summary must be an object.");
+  }
+  if (typeof raw.course !== "string" || raw.course.length === 0) {
+    throw new Error("summary.course must be a non-empty string.");
+  }
+  assertNonNegativeInteger(raw.missingSource, "summary.missingSource");
+  assertNonNegativeInteger(raw.failed, "summary.failed");
+  if (!Array.isArray(raw.results)) {
+    throw new Error("summary.results must be an array.");
+  }
+
+  const missingSource = raw.missingSource;
+  const failed = raw.failed;
+  return {
+    course: raw.course,
+    missingSource,
+    failed,
+    results: raw.results.map((entry, index) => {
+      if (!isRecord(entry)) {
+        throw new Error(`summary.results[${index}] must be an object.`);
+      }
+      const storyId = entry.storyId;
+      assertNonNegativeInteger(storyId, `summary.results[${index}].storyId`);
+      if (
+        entry.status !== "ok" &&
+        entry.status !== "missing_source" &&
+        entry.status !== "failed"
+      ) {
+        throw new Error(
+          `summary.results[${index}].status must be ok, missing_source, or failed.`,
+        );
+      }
+      return {
+        storyId,
+        status: entry.status,
+      };
+    }),
+  };
+}
+
 async function readCourseSummary(inputDir: string, course: string) {
   const summaryPath = path.join(inputDir, course, "summary.json");
-  const summary = JSON.parse(await readFile(summaryPath, "utf8")) as CourseSummary;
+  const summary = parseCourseSummary(
+    JSON.parse(await readFile(summaryPath, "utf8")),
+  );
   return {
     course: {
       courseShort: course,
@@ -151,16 +212,20 @@ async function main() {
   console.log(JSON.stringify({ ...payload, skipped }, null, 2));
 
   if (!options.apply) return;
+  if (!options.identity) {
+    throw new Error("--identity is required when using --apply.");
+  }
   if (counts.length === 0) {
     console.log("No counts to apply.");
     return;
   }
 
+  const operationKey = `audio-problem-counts:${Date.now()}`;
   await runCommand("pnpm", [
     "convex",
     "run",
     "courseWrite:setAudioProblemCounts",
-    JSON.stringify(payload),
+    JSON.stringify({ ...payload, operationKey }),
     "--identity",
     options.identity,
   ]);

--- a/scripts/sync-audio-problem-counts.ts
+++ b/scripts/sync-audio-problem-counts.ts
@@ -14,6 +14,20 @@ type CourseSummary = {
   course: string;
   missingSource: number;
   failed: number;
+  results: Array<{
+    storyId: number;
+    status: "ok" | "missing_source" | "failed";
+  }>;
+};
+
+type CourseAudioProblemCount = {
+  courseShort: string;
+  audioProblemCount: number;
+};
+
+type StoryAudioProblemCount = {
+  legacyStoryId: number;
+  audioProblemCount: number;
 };
 
 function usage(exitCode: 0 | 1): never {
@@ -81,8 +95,14 @@ async function readCourseSummary(inputDir: string, course: string) {
   const summaryPath = path.join(inputDir, course, "summary.json");
   const summary = JSON.parse(await readFile(summaryPath, "utf8")) as CourseSummary;
   return {
-    courseShort: course,
-    audioProblemCount: (summary.missingSource ?? 0) + (summary.failed ?? 0),
+    course: {
+      courseShort: course,
+      audioProblemCount: (summary.missingSource ?? 0) + (summary.failed ?? 0),
+    },
+    stories: (summary.results ?? []).map((result) => ({
+      legacyStoryId: result.storyId,
+      audioProblemCount: result.status === "ok" ? 0 : 1,
+    })),
   };
 }
 
@@ -107,7 +127,8 @@ async function main() {
           .map((entry) => entry.name)
           .sort();
 
-  const counts = [];
+  const counts: CourseAudioProblemCount[] = [];
+  const stories: StoryAudioProblemCount[] = [];
   const skipped = [];
   for (const course of selectedCourses) {
     if (!existsSync(path.join(options.inputDir, course, "summary.json"))) {
@@ -115,7 +136,9 @@ async function main() {
       continue;
     }
     try {
-      counts.push(await readCourseSummary(options.inputDir, course));
+      const summary = await readCourseSummary(options.inputDir, course);
+      counts.push(summary.course);
+      stories.push(...summary.stories);
     } catch (error) {
       skipped.push(course);
       console.error(
@@ -124,7 +147,7 @@ async function main() {
     }
   }
 
-  const payload = { counts };
+  const payload = { counts, stories };
   console.log(JSON.stringify({ ...payload, skipped }, null, 2));
 
   if (!options.apply) return;

--- a/scripts/sync-audio-problem-counts.ts
+++ b/scripts/sync-audio-problem-counts.ts
@@ -1,0 +1,149 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+type CliOptions = {
+  inputDir: string;
+  courses: string[];
+  apply: boolean;
+  identity: string;
+};
+
+type CourseSummary = {
+  course: string;
+  missingSource: number;
+  failed: number;
+};
+
+function usage(exitCode: 0 | 1): never {
+  console.error(`Usage:
+  pnpm audio:sync-problem-counts -- --course da-en --course ca-en --apply
+
+Options:
+  --input-dir <dir>   Course summary root (default: tmp/story-audio/courses)
+  --course <short>    Course to sync. Can be repeated. Defaults to all summaries.
+  --apply             Apply to Convex. Without this, print the payload only.
+  --identity <json>   Convex run identity (default: {"role":"admin","userId":1})
+`);
+  process.exit(exitCode);
+}
+
+function takeValue(args: string[], index: number, name: string) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${name}.`);
+  }
+  return value;
+}
+
+function parseCliOptions(args: string[]): CliOptions {
+  const courses: string[] = [];
+  let inputDir = path.join("tmp", "story-audio", "courses");
+  let apply = false;
+  let identity = JSON.stringify({ role: "admin", userId: 1 });
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") usage(0);
+    if (arg === "--input-dir") {
+      inputDir = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--course") {
+      courses.push(takeValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+    if (arg === "--apply") {
+      apply = true;
+      continue;
+    }
+    if (arg === "--identity") {
+      identity = takeValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    inputDir: path.resolve(inputDir),
+    courses,
+    apply,
+    identity,
+  };
+}
+
+async function readCourseSummary(inputDir: string, course: string) {
+  const summaryPath = path.join(inputDir, course, "summary.json");
+  const summary = JSON.parse(await readFile(summaryPath, "utf8")) as CourseSummary;
+  return {
+    courseShort: course,
+    audioProblemCount: (summary.missingSource ?? 0) + (summary.failed ?? 0),
+  };
+}
+
+function runCommand(command: string, args: string[]) {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit" });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(" ")} failed with ${code}`));
+    });
+  });
+}
+
+async function main() {
+  const options = parseCliOptions(process.argv.slice(2));
+  const selectedCourses =
+    options.courses.length > 0
+      ? options.courses
+      : (await readdir(options.inputDir, { withFileTypes: true }))
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => entry.name)
+          .sort();
+
+  const counts = [];
+  const skipped = [];
+  for (const course of selectedCourses) {
+    if (!existsSync(path.join(options.inputDir, course, "summary.json"))) {
+      skipped.push(course);
+      continue;
+    }
+    try {
+      counts.push(await readCourseSummary(options.inputDir, course));
+    } catch (error) {
+      skipped.push(course);
+      console.error(
+        `Skipping ${course}: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+  }
+
+  const payload = { counts };
+  console.log(JSON.stringify({ ...payload, skipped }, null, 2));
+
+  if (!options.apply) return;
+  if (counts.length === 0) {
+    console.log("No counts to apply.");
+    return;
+  }
+
+  await runCommand("pnpm", [
+    "convex",
+    "run",
+    "courseWrite:setAudioProblemCounts",
+    JSON.stringify(payload),
+    "--identity",
+    options.identity,
+  ]);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/app/editor/(course)/CountBadge.tsx
+++ b/src/app/editor/(course)/CountBadge.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+type CountBadgeProps = {
+  count: number | undefined;
+  icon: string;
+  title: string;
+  label: string;
+  className: string;
+};
+
+export function CountBadge({
+  count,
+  icon,
+  title,
+  label,
+  className,
+}: CountBadgeProps) {
+  if (!count) return null;
+
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-full px-[8px] py-[5px] text-[14px] leading-none font-bold ${className}`}
+      role="img"
+      title={title}
+      aria-label={label}
+    >
+      <span aria-hidden="true">
+        {icon} {count}
+      </span>
+    </span>
+  );
+}

--- a/src/app/editor/(course)/course_list.tsx
+++ b/src/app/editor/(course)/course_list.tsx
@@ -6,6 +6,7 @@ import LanguageFlag from "@/components/ui/language-flag";
 import { useInput } from "@/lib/hooks";
 import { useRouter } from "next/navigation";
 import { Spinner } from "@/components/ui/spinner";
+import { CountBadge } from "./CountBadge";
 import type { CourseProps } from "./types";
 
 interface CourseListProps {
@@ -99,28 +100,20 @@ export default function CourseList({
                   course.learning_language_name
                 } [${course.from_language_short}] `}</span>
                 <span className="flex grow items-center justify-end gap-[6px] whitespace-nowrap pr-[10px]">
-                  {course.todo_count ? (
-                    <span
-                      className="inline-flex shrink-0 items-center whitespace-nowrap rounded-full bg-amber-100 px-[8px] py-[5px] text-[14px] leading-none font-bold text-amber-900"
-                      role="img"
-                      title={`This course has ${course.todo_count} TODOs.`}
-                      aria-label={`${course.todo_count} TODOs`}
-                    >
-                      <span aria-hidden="true">📝 {course.todo_count}</span>
-                    </span>
-                  ) : null}
-                  {course.audio_problem_count ? (
-                    <span
-                      className="inline-flex shrink-0 items-center whitespace-nowrap rounded-full bg-sky-100 px-[8px] py-[5px] text-[14px] leading-none font-bold text-sky-950"
-                      role="img"
-                      title={`This course has ${course.audio_problem_count} published stories with audio problems.`}
-                      aria-label={`${course.audio_problem_count} audio problems`}
-                    >
-                      <span aria-hidden="true">
-                        🔊 {course.audio_problem_count}
-                      </span>
-                    </span>
-                  ) : null}
+                  <CountBadge
+                    count={course.todo_count}
+                    icon="📝"
+                    title={`This course has ${course.todo_count} TODOs.`}
+                    label={`${course.todo_count} TODOs`}
+                    className="bg-amber-100 text-amber-900"
+                  />
+                  <CountBadge
+                    count={course.audio_problem_count}
+                    icon="🔊"
+                    title={`This course has ${course.audio_problem_count} published stories with audio problems.`}
+                    label={`${course.audio_problem_count} audio problems`}
+                    className="bg-sky-100 text-sky-950"
+                  />
                   {course.official ? (
                     <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center">
                       <img

--- a/src/app/editor/(course)/course_list.tsx
+++ b/src/app/editor/(course)/course_list.tsx
@@ -109,6 +109,18 @@ export default function CourseList({
                       <span aria-hidden="true">📝 {course.todo_count}</span>
                     </span>
                   ) : null}
+                  {course.audio_problem_count ? (
+                    <span
+                      className="inline-flex shrink-0 items-center whitespace-nowrap rounded-full bg-sky-100 px-[8px] py-[5px] text-[14px] leading-none font-bold text-sky-950"
+                      role="img"
+                      title={`This course has ${course.audio_problem_count} published stories with audio problems.`}
+                      aria-label={`${course.audio_problem_count} audio problems`}
+                    >
+                      <span aria-hidden="true">
+                        🔊 {course.audio_problem_count}
+                      </span>
+                    </span>
+                  ) : null}
                   {course.official ? (
                     <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center">
                       <img

--- a/src/app/editor/(course)/edit_list.tsx
+++ b/src/app/editor/(course)/edit_list.tsx
@@ -25,6 +25,7 @@ import {
   rememberCourseScrollPosition,
   restoreCourseScrollPosition,
 } from "./course_view_memory";
+import { CountBadge } from "./CountBadge";
 import type {
   DetailedCourseProps,
   StoryListDataProps,
@@ -342,26 +343,20 @@ export default function EditList({
                   >
                     {story.name}
                   </Link>
-                  {story.todo_count ? (
-                    <span
-                      title={`This story has ${story.todo_count} TODOs.`}
-                      role="img"
-                      aria-label={`${story.todo_count} TODOs`}
-                      className="inline-flex shrink-0 items-center whitespace-nowrap rounded-full bg-amber-100 px-[8px] py-[5px] text-[14px] leading-none font-bold text-amber-900"
-                    >
-                      <span aria-hidden="true">📝 {story.todo_count}</span>
-                    </span>
-                  ) : null}
-                  {story.audio_problem_count ? (
-                    <span
-                      title="This published story has audio problems."
-                      role="img"
-                      aria-label="Audio problem"
-                      className="inline-flex shrink-0 items-center whitespace-nowrap rounded-full bg-sky-100 px-[8px] py-[5px] text-[14px] leading-none font-bold text-sky-950"
-                    >
-                      <span aria-hidden="true">🔊</span>
-                    </span>
-                  ) : null}
+                  <CountBadge
+                    count={story.todo_count}
+                    icon="📝"
+                    title={`This story has ${story.todo_count} TODOs.`}
+                    label={`${story.todo_count} TODOs`}
+                    className="bg-amber-100 text-amber-900"
+                  />
+                  <CountBadge
+                    count={story.audio_problem_count}
+                    icon="🔊"
+                    title="This published story has audio problems."
+                    label={`${story.audio_problem_count} audio problems`}
+                    className="bg-sky-100 text-sky-950"
+                  />
                 </div>
               </div>
               <div className="overflow-hidden text-ellipsis whitespace-nowrap text-right max-[1000px]:ml-auto max-[1000px]:shrink-0 max-[500px]:max-w-[85px] max-[500px]:[&>div]:flex max-[500px]:overflow-hidden min-[1000px]:px-[5px]">

--- a/src/app/editor/(course)/edit_list.tsx
+++ b/src/app/editor/(course)/edit_list.tsx
@@ -352,6 +352,16 @@ export default function EditList({
                       <span aria-hidden="true">📝 {story.todo_count}</span>
                     </span>
                   ) : null}
+                  {story.audio_problem_count ? (
+                    <span
+                      title="This published story has audio problems."
+                      role="img"
+                      aria-label="Audio problem"
+                      className="inline-flex shrink-0 items-center whitespace-nowrap rounded-full bg-sky-100 px-[8px] py-[5px] text-[14px] leading-none font-bold text-sky-950"
+                    >
+                      <span aria-hidden="true">🔊</span>
+                    </span>
+                  ) : null}
                 </div>
               </div>
               <div className="overflow-hidden text-ellipsis whitespace-nowrap text-right max-[1000px]:ml-auto max-[1000px]:shrink-0 max-[500px]:max-w-[85px] max-[500px]:[&>div]:flex max-[500px]:overflow-hidden min-[1000px]:px-[5px]">

--- a/src/app/editor/(course)/types.ts
+++ b/src/app/editor/(course)/types.ts
@@ -46,6 +46,7 @@ export type StoryListDataProps = {
   status: string;
   public: boolean;
   todo_count: number;
+  audio_problem_count: number;
   approvalCount: number;
   approvedByCurrentUser: boolean;
   author: string;

--- a/src/app/editor/(course)/types.ts
+++ b/src/app/editor/(course)/types.ts
@@ -16,6 +16,7 @@ export type CourseProps = {
   contributors: string[];
   contributors_past: string[];
   todo_count: number;
+  audio_problem_count: number;
 };
 
 export type ContributorSummaryProps = {


### PR DESCRIPTION
## Summary
- add course and story audio problem count fields in Convex
- show audio problem badges in the editor course/story lists
- add a standalone sync script for applying counts from existing audio summary reports

## Scope
This intentionally excludes the stitched audio playback and batch generation changes. It only contains the badge/count plumbing and the summary-to-Convex sync helper.

## Validation
- pnpm run format
- pnpm typecheck
- pnpm run lint
- CONVEX_DEPLOYMENT=dev:compassionate-chinchilla-392 pnpm convex dev --once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audio problem counts to the editor for courses and stories, with new 🔊 count badges when issues exist.
  * Introduced an `audio:sync-problem-counts` command to import audio problem counts from course summary files.
* **Bug Fixes**
  * Audio problem counts are now stored and kept consistent during course and story updates.
  * Added validation to ensure audio problem counts are non-negative and identifiers are present.
* **Chores**
  * Extended editor read outputs, shared editor types, and database schema to include `audio_problem_count`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->