### PR TITLE
[codex] Update audio problem counts on editor save

### DIFF
--- a/convex/lib/courseCounts.ts
+++ b/convex/lib/courseCounts.ts
@@ -1,20 +1,30 @@
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
+
+type CourseStory = Doc<"stories">;
+
+export async function loadCourseStories(
+  ctx: MutationCtx,
+  courseId: Id<"courses">,
+) {
+  return await ctx.db
+    .query("stories")
+    .withIndex("by_course", (q) => q.eq("courseId", courseId))
+    .collect();
+}
 
 export async function recomputeCoursePublishedCount(
   ctx: MutationCtx,
   courseId: Id<"courses">,
+  stories?: CourseStory[],
 ) {
   const course = await ctx.db.get(courseId);
   if (!course) {
     throw new Error(`Course ${courseId} not found`);
   }
 
-  const stories = await ctx.db
-    .query("stories")
-    .withIndex("by_course", (q) => q.eq("courseId", courseId))
-    .collect();
-  const count = stories.filter(
+  const courseStories = stories ?? (await loadCourseStories(ctx, courseId));
+  const count = courseStories.filter(
     (story) => story.public && !story.deleted,
   ).length;
 
@@ -28,17 +38,15 @@ export async function recomputeCoursePublishedCount(
 export async function recomputeCourseAudioProblemCount(
   ctx: MutationCtx,
   courseId: Id<"courses">,
+  stories?: CourseStory[],
 ) {
   const course = await ctx.db.get(courseId);
   if (!course) {
     throw new Error(`Course ${courseId} not found`);
   }
 
-  const stories = await ctx.db
-    .query("stories")
-    .withIndex("by_course", (q) => q.eq("courseId", courseId))
-    .collect();
-  const count = stories.reduce((total, story) => {
+  const courseStories = stories ?? (await loadCourseStories(ctx, courseId));
+  const count = courseStories.reduce((total, story) => {
     if (!story.public || story.deleted) return total;
     return total + (story.audio_problem_count ?? 0);
   }, 0);

--- a/convex/lib/courseCounts.ts
+++ b/convex/lib/courseCounts.ts
@@ -24,3 +24,28 @@ export async function recomputeCoursePublishedCount(
 
   return count;
 }
+
+export async function recomputeCourseAudioProblemCount(
+  ctx: MutationCtx,
+  courseId: Id<"courses">,
+) {
+  const course = await ctx.db.get(courseId);
+  if (!course) {
+    throw new Error(`Course ${courseId} not found`);
+  }
+
+  const stories = await ctx.db
+    .query("stories")
+    .withIndex("by_course", (q) => q.eq("courseId", courseId))
+    .collect();
+  const count = stories.reduce((total, story) => {
+    if (!story.public || story.deleted) return total;
+    return total + (story.audio_problem_count ?? 0);
+  }, 0);
+
+  if ((course.audio_problem_count ?? 0) !== count) {
+    await ctx.db.patch(courseId, { audio_problem_count: count });
+  }
+
+  return count;
+}

--- a/convex/storyWrite.ts
+++ b/convex/storyWrite.ts
@@ -5,7 +5,10 @@ import {
   requireContributorOrAdmin,
   requireSessionLegacyUserId,
 } from "./lib/authorization";
-import { recomputeCoursePublishedCount } from "./lib/courseCounts";
+import {
+  recomputeCourseAudioProblemCount,
+  recomputeCoursePublishedCount,
+} from "./lib/courseCounts";
 import { upsertPublicStoryContent } from "./lib/publicStoryContent";
 
 export const setStory = mutation({
@@ -20,6 +23,7 @@ export const setStory = mutation({
     text: v.string(),
     json: v.any(),
     todo_count: v.number(),
+    audioProblemCount: v.optional(v.number()),
     change_date: v.string(),
     confirmOfficialOverwrite: v.optional(v.boolean()),
     operationKey: v.optional(v.string()),
@@ -99,6 +103,18 @@ export const setStory = mutation({
     const previousCourseId = story.courseId;
     const movedPublishedStory =
       previousCourseId !== course._id && story.public && !story.deleted;
+    if (
+      args.audioProblemCount !== undefined &&
+      (args.audioProblemCount < 0 || !Number.isInteger(args.audioProblemCount))
+    ) {
+      throw new Error("audioProblemCount must be a non-negative integer");
+    }
+    const nextAudioProblemCount =
+      args.audioProblemCount === undefined
+        ? story.audio_problem_count
+        : story.public && !story.deleted
+          ? args.audioProblemCount
+          : 0;
 
     await ctx.db.patch(story._id, {
       duo_id: args.duo_id,
@@ -112,6 +128,7 @@ export const setStory = mutation({
       set_index: args.set_index,
       courseId: course._id,
       todo_count: args.todo_count,
+      audio_problem_count: nextAudioProblemCount,
     });
 
     const existingContent = await ctx.db
@@ -146,9 +163,12 @@ export const setStory = mutation({
       0,
     );
     await ctx.db.patch(course._id, { todo_count: courseTodoCount });
+    await recomputeCourseAudioProblemCount(ctx, course._id);
     if (movedPublishedStory) {
       await recomputeCoursePublishedCount(ctx, previousCourseId);
       await recomputeCoursePublishedCount(ctx, course._id);
+      await recomputeCourseAudioProblemCount(ctx, previousCourseId);
+      await recomputeCourseAudioProblemCount(ctx, course._id);
     }
 
     await ctx.scheduler.runAfter(0, internal.editorSideEffects.onStorySaved, {
@@ -217,6 +237,7 @@ export const deleteStory = mutation({
     });
     if (story.public) {
       await recomputeCoursePublishedCount(ctx, story.courseId);
+      await recomputeCourseAudioProblemCount(ctx, story.courseId);
     }
 
     const operationKey =

--- a/convex/storyWrite.ts
+++ b/convex/storyWrite.ts
@@ -6,6 +6,7 @@ import {
   requireSessionLegacyUserId,
 } from "./lib/authorization";
 import {
+  loadCourseStories,
   recomputeCourseAudioProblemCount,
   recomputeCoursePublishedCount,
 } from "./lib/courseCounts";
@@ -163,12 +164,23 @@ export const setStory = mutation({
       0,
     );
     await ctx.db.patch(course._id, { todo_count: courseTodoCount });
-    await recomputeCourseAudioProblemCount(ctx, course._id);
+    await recomputeCourseAudioProblemCount(ctx, course._id, storiesInCourse);
     if (movedPublishedStory) {
-      await recomputeCoursePublishedCount(ctx, previousCourseId);
-      await recomputeCoursePublishedCount(ctx, course._id);
-      await recomputeCourseAudioProblemCount(ctx, previousCourseId);
-      await recomputeCourseAudioProblemCount(ctx, course._id);
+      const previousCourseStories = await loadCourseStories(
+        ctx,
+        previousCourseId,
+      );
+      await recomputeCoursePublishedCount(
+        ctx,
+        previousCourseId,
+        previousCourseStories,
+      );
+      await recomputeCoursePublishedCount(ctx, course._id, storiesInCourse);
+      await recomputeCourseAudioProblemCount(
+        ctx,
+        previousCourseId,
+        previousCourseStories,
+      );
     }
 
     await ctx.scheduler.runAfter(0, internal.editorSideEffects.onStorySaved, {
@@ -236,8 +248,13 @@ export const deleteStory = mutation({
       public: false,
     });
     if (story.public) {
-      await recomputeCoursePublishedCount(ctx, story.courseId);
-      await recomputeCourseAudioProblemCount(ctx, story.courseId);
+      const courseStories = await loadCourseStories(ctx, story.courseId);
+      await recomputeCoursePublishedCount(ctx, story.courseId, courseStories);
+      await recomputeCourseAudioProblemCount(
+        ctx,
+        story.courseId,
+        courseStories,
+      );
     }
 
     const operationKey =

--- a/scripts/sync-audio-problem-counts.ts
+++ b/scripts/sync-audio-problem-counts.ts
@@ -8,6 +8,7 @@ type CliOptions = {
   courses: string[];
   apply: boolean;
   identity: string | null;
+  prod: boolean;
 };
 
 type CourseSummary = {
@@ -30,15 +31,36 @@ type StoryAudioProblemCount = {
   audioProblemCount: number;
 };
 
+type StoryMetadata = {
+  legacyId: number;
+  missing?: boolean;
+  public?: boolean;
+  deleted?: boolean;
+  courseShort?: string | null;
+};
+
+type FilteredStory = {
+  course: string;
+  storyId: number;
+  status: "ok" | "missing_source" | "failed";
+  reason: string;
+};
+
+type CourseProblemPayload = {
+  course: CourseAudioProblemCount;
+  stories: StoryAudioProblemCount[];
+};
+
 function usage(exitCode: 0 | 1): never {
   console.error(`Usage:
-  pnpm audio:sync-problem-counts -- --course da-en --course ca-en --apply
+  pnpm audio:sync-problem-counts -- --course da-en --course ca-en --apply --prod
 
 Options:
   --input-dir <dir>   Course summary root (default: tmp/story-audio/courses)
   --course <short>    Course to sync. Can be repeated. Defaults to all summaries.
   --apply             Apply to Convex. Without this, print the payload only.
   --identity <json>   Convex run identity. Required with --apply.
+  --prod              Target the production Convex deployment.
 `);
   process.exit(exitCode);
 }
@@ -56,6 +78,7 @@ function parseCliOptions(args: string[]): CliOptions {
   let inputDir = path.join("tmp", "story-audio", "courses");
   let apply = false;
   let identity: string | null = null;
+  let prod = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -75,6 +98,10 @@ function parseCliOptions(args: string[]): CliOptions {
       apply = true;
       continue;
     }
+    if (arg === "--prod") {
+      prod = true;
+      continue;
+    }
     if (arg === "--identity") {
       identity = takeValue(args, index, arg);
       index += 1;
@@ -88,6 +115,7 @@ function parseCliOptions(args: string[]): CliOptions {
     courses,
     apply,
     identity,
+    prod,
   };
 }
 
@@ -152,19 +180,9 @@ function parseCourseSummary(raw: unknown): CourseSummary {
 
 async function readCourseSummary(inputDir: string, course: string) {
   const summaryPath = path.join(inputDir, course, "summary.json");
-  const summary = parseCourseSummary(
+  return parseCourseSummary(
     JSON.parse(await readFile(summaryPath, "utf8")),
   );
-  return {
-    course: {
-      courseShort: course,
-      audioProblemCount: (summary.missingSource ?? 0) + (summary.failed ?? 0),
-    },
-    stories: (summary.results ?? []).map((result) => ({
-      legacyStoryId: result.storyId,
-      audioProblemCount: result.status === "ok" ? 0 : 1,
-    })),
-  };
 }
 
 function runCommand(command: string, args: string[]) {
@@ -178,6 +196,81 @@ function runCommand(command: string, args: string[]) {
   });
 }
 
+function runCommandOutput(command: string, args: string[]) {
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "inherit"] });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`${command} ${args.join(" ")} failed with ${code}`));
+    });
+  });
+}
+
+function parseJsonOutput<T>(stdout: string): T {
+  const trimmed = stdout.trim();
+  const jsonStart = Math.min(
+    ...[trimmed.indexOf("{"), trimmed.indexOf("[")].filter((index) => index >= 0),
+  );
+  if (!Number.isFinite(jsonStart)) {
+    throw new Error("Convex command did not print JSON.");
+  }
+  return JSON.parse(trimmed.slice(jsonStart)) as T;
+}
+
+async function readStoryMetadata(storyIds: number[], prod: boolean) {
+  const metadata = new Map<number, StoryMetadata>();
+  const uniqueStoryIds = [...new Set(storyIds)].sort((left, right) => left - right);
+  const batchSize = 400;
+
+  for (let index = 0; index < uniqueStoryIds.length; index += batchSize) {
+    const batch = uniqueStoryIds.slice(index, index + batchSize);
+    const query = `const ids = ${JSON.stringify(batch)};
+const out = [];
+for (const id of ids) {
+  const story = await ctx.db
+    .query("stories")
+    .withIndex("by_legacy_id", (q) => q.eq("legacyId", id))
+    .unique();
+  if (!story) {
+    out.push({ legacyId: id, missing: true });
+    continue;
+  }
+  const course = await ctx.db.get(story.courseId);
+  out.push({
+    legacyId: story.legacyId,
+    public: !!story.public,
+    deleted: !!story.deleted,
+    courseShort: course?.short ?? null,
+  });
+}
+return out;`;
+    const args = ["convex", "run"];
+    if (prod) {
+      args.push("--prod");
+    }
+    args.push("--inline-query", query);
+    const stdout = await runCommandOutput("pnpm", args);
+    for (const story of parseJsonOutput<StoryMetadata[]>(stdout)) {
+      metadata.set(story.legacyId, story);
+    }
+  }
+
+  return metadata;
+}
+
+function filterReason(metadata: StoryMetadata | undefined, course: string) {
+  if (!metadata || metadata.missing) return "missing-prod-story";
+  if (metadata.deleted) return "deleted";
+  if (!metadata.public) return "private";
+  if (metadata.courseShort !== course) return `course-mismatch:${metadata.courseShort}`;
+  return null;
+}
+
 async function main() {
   const options = parseCliOptions(process.argv.slice(2));
   const selectedCourses =
@@ -188,8 +281,7 @@ async function main() {
           .map((entry) => entry.name)
           .sort();
 
-  const counts: CourseAudioProblemCount[] = [];
-  const stories: StoryAudioProblemCount[] = [];
+  const summaries: Array<{ course: string; summary: CourseSummary }> = [];
   const skipped = [];
   for (const course of selectedCourses) {
     if (!existsSync(path.join(options.inputDir, course, "summary.json"))) {
@@ -198,8 +290,7 @@ async function main() {
     }
     try {
       const summary = await readCourseSummary(options.inputDir, course);
-      counts.push(summary.course);
-      stories.push(...summary.stories);
+      summaries.push({ course, summary });
     } catch (error) {
       skipped.push(course);
       console.error(
@@ -208,8 +299,66 @@ async function main() {
     }
   }
 
+  const storyMetadata = await readStoryMetadata(
+    summaries.flatMap(({ summary }) => summary.results.map((result) => result.storyId)),
+    options.prod,
+  );
+  const coursePayloads: CourseProblemPayload[] = [];
+  const filtered: FilteredStory[] = [];
+
+  for (const { course, summary } of summaries) {
+    let audioProblemCount = 0;
+    const courseStories: StoryAudioProblemCount[] = [];
+    for (const result of summary.results) {
+      const metadata = storyMetadata.get(result.storyId);
+      const reason = filterReason(metadata, course);
+      if (reason) {
+        filtered.push({
+          course,
+          storyId: result.storyId,
+          status: result.status,
+          reason,
+        });
+        if (metadata && !metadata.missing) {
+          courseStories.push({
+            legacyStoryId: result.storyId,
+            audioProblemCount: 0,
+          });
+        }
+        continue;
+      }
+
+      const storyAudioProblemCount = result.status === "ok" ? 0 : 1;
+      audioProblemCount += storyAudioProblemCount;
+      courseStories.push({
+        legacyStoryId: result.storyId,
+        audioProblemCount: storyAudioProblemCount,
+      });
+    }
+    coursePayloads.push({
+      course: {
+        courseShort: course,
+        audioProblemCount,
+      },
+      stories: courseStories,
+    });
+  }
+
+  const counts = coursePayloads.map((entry) => entry.course);
+  const stories = coursePayloads.flatMap((entry) => entry.stories);
   const payload = { counts, stories };
-  console.log(JSON.stringify({ ...payload, skipped }, null, 2));
+  console.log(
+    JSON.stringify(
+      {
+        ...payload,
+        skipped,
+        filtered,
+        filteredCount: filtered.length,
+      },
+      null,
+      2,
+    ),
+  );
 
   if (!options.apply) return;
   if (!options.identity) {
@@ -221,14 +370,31 @@ async function main() {
   }
 
   const operationKey = `audio-problem-counts:${Date.now()}`;
-  await runCommand("pnpm", [
-    "convex",
-    "run",
-    "courseWrite:setAudioProblemCounts",
-    JSON.stringify({ ...payload, operationKey }),
-    "--identity",
-    options.identity,
-  ]);
+  const chunkSize = 20;
+  for (let index = 0; index < coursePayloads.length; index += chunkSize) {
+    const chunk = coursePayloads.slice(index, index + chunkSize);
+    const chunkPayload = {
+      operationKey: `${operationKey}:${Math.floor(index / chunkSize) + 1}`,
+      counts: chunk.map((entry) => entry.course),
+      stories: chunk.flatMap((entry) => entry.stories),
+    };
+    console.log(
+      `Applying chunk ${Math.floor(index / chunkSize) + 1}/${Math.ceil(
+        coursePayloads.length / chunkSize,
+      )}: courses=${chunkPayload.counts.length} stories=${chunkPayload.stories.length}`,
+    );
+    const args = ["convex", "run"];
+    if (options.prod) {
+      args.push("--prod");
+    }
+    args.push(
+      "courseWrite:setAudioProblemCounts",
+      JSON.stringify(chunkPayload),
+      "--identity",
+      options.identity,
+    );
+    await runCommand("pnpm", args);
+  }
 }
 
 main().catch((error) => {

--- a/scripts/sync-audio-problem-counts.ts
+++ b/scripts/sync-audio-problem-counts.ts
@@ -213,13 +213,64 @@ function runCommandOutput(command: string, args: string[]) {
 
 function parseJsonOutput<T>(stdout: string): T {
   const trimmed = stdout.trim();
-  const jsonStart = Math.min(
-    ...[trimmed.indexOf("{"), trimmed.indexOf("[")].filter((index) => index >= 0),
+  const candidateStarts = [...trimmed.matchAll(/[\[{]/g)].map(
+    (match) => match.index,
   );
-  if (!Number.isFinite(jsonStart)) {
+  if (candidateStarts.length === 0) {
     throw new Error("Convex command did not print JSON.");
   }
-  return JSON.parse(trimmed.slice(jsonStart)) as T;
+
+  for (const jsonStart of candidateStarts) {
+    if (jsonStart === undefined) continue;
+    const jsonEnd = findJsonEnd(trimmed, jsonStart);
+    if (jsonEnd === null) continue;
+    try {
+      return JSON.parse(trimmed.slice(jsonStart, jsonEnd)) as T;
+    } catch {
+      // Keep scanning; leading log output can contain bracket-like text.
+    }
+  }
+
+  throw new Error("Convex command did not print valid JSON.");
+}
+
+function findJsonEnd(text: string, start: number) {
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") {
+      stack.push("}");
+      continue;
+    }
+    if (char === "[") {
+      stack.push("]");
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      if (stack.pop() !== char) return null;
+      if (stack.length === 0) return index + 1;
+    }
+  }
+
+  return null;
 }
 
 async function readStoryMetadata(storyIds: number[], prod: boolean) {

--- a/src/app/editor/story/[story]/v2/audio_problem_check.test.ts
+++ b/src/app/editor/story/[story]/v2/audio_problem_check.test.ts
@@ -88,3 +88,21 @@ test("checkStoryLineAudio falls back to GET when HEAD is unsupported", async () 
   assert.equal(result.audioProblemCount, 0);
   assert.deepEqual(calls, ["HEAD", "GET"]);
 });
+
+test("checkStoryLineAudio falls back to GET when HEAD throws a TypeError", async () => {
+  const calls: string[] = [];
+  globalThis.fetch = async (_url, init) => {
+    calls.push(init?.method ?? "GET");
+    if (init?.method === "HEAD") {
+      throw new TypeError("HEAD request blocked");
+    }
+    return new Response(null, { status: 206 });
+  };
+
+  const result = await checkStoryLineAudio(
+    storyWithAudioUrls(["https://example.com/audio.mp3"]),
+  );
+
+  assert.equal(result.audioProblemCount, 0);
+  assert.deepEqual(calls, ["HEAD", "GET"]);
+});

--- a/src/app/editor/story/[story]/v2/audio_problem_check.test.ts
+++ b/src/app/editor/story/[story]/v2/audio_problem_check.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import type { StoryType } from "@/components/editor/story/syntax_parser_new";
+import {
+  checkStoryLineAudio,
+  collectStoryLineAudioUrls,
+} from "./audio_problem_check";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function storyWithAudioUrls(urls: (string | undefined)[]): StoryType {
+  return {
+    elements: urls.map((url, index) => ({
+      type: "LINE",
+      line: {
+        type: "PROSE",
+        content: {
+          text: `Line ${index}`,
+          hintMap: [],
+          audio: {
+            ssml: {
+              text: `Line ${index}`,
+              speaker: "Speaker",
+              id: 1,
+              inser_index: index,
+            },
+            url,
+            keypoints: [],
+          },
+        },
+      },
+      trackingProperties: { line_index: index + 1 },
+      lang: "en",
+      editor: {},
+    })),
+  } as StoryType;
+}
+
+test("collectStoryLineAudioUrls resolves relative blob audio paths", () => {
+  assert.deepEqual(
+    collectStoryLineAudioUrls(storyWithAudioUrls(["audio/1/example.mp3"])),
+    [
+      "https://ptoqrnbx8ghuucmt.public.blob.vercel-storage.com/audio/1/example.mp3",
+    ],
+  );
+});
+
+test("checkStoryLineAudio reports missing audio references", async () => {
+  globalThis.fetch = async () => new Response(null, { status: 200 });
+
+  const result = await checkStoryLineAudio(storyWithAudioUrls([undefined]));
+
+  assert.equal(result.audioProblemCount, 1);
+  assert.equal(result.expectedAudioCount, 1);
+  assert.equal(result.missingAudioCount, 1);
+  assert.equal(result.checkedUrlCount, 0);
+});
+
+test("checkStoryLineAudio reports failed audio URLs", async () => {
+  globalThis.fetch = async () => new Response(null, { status: 404 });
+
+  const result = await checkStoryLineAudio(
+    storyWithAudioUrls(["https://example.com/missing.mp3"]),
+  );
+
+  assert.equal(result.audioProblemCount, 1);
+  assert.equal(result.failedUrlCount, 1);
+});
+
+test("checkStoryLineAudio falls back to GET when HEAD is unsupported", async () => {
+  const calls: string[] = [];
+  globalThis.fetch = async (_url, init) => {
+    calls.push(init?.method ?? "GET");
+    if (init?.method === "HEAD") {
+      return new Response(null, { status: 405 });
+    }
+    return new Response(null, { status: 206 });
+  };
+
+  const result = await checkStoryLineAudio(
+    storyWithAudioUrls(["https://example.com/audio.mp3"]),
+  );
+
+  assert.equal(result.audioProblemCount, 0);
+  assert.deepEqual(calls, ["HEAD", "GET"]);
+});

--- a/src/app/editor/story/[story]/v2/audio_problem_check.ts
+++ b/src/app/editor/story/[story]/v2/audio_problem_check.ts
@@ -45,6 +45,9 @@ async function fetchWithTimeout(
   init: RequestInit,
   timeoutMs: number,
 ) {
+  if (timeoutMs <= 0) {
+    throw new DOMException("Audio request timed out.", "AbortError");
+  }
   const controller = new AbortController();
   const timeout = globalThis.setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -57,20 +60,35 @@ async function fetchWithTimeout(
   }
 }
 
+function remainingTime(deadline: number) {
+  return Math.max(0, deadline - Date.now());
+}
+
+function isHeadUnsupportedStatus(status: number) {
+  return status === 405 || status === 501;
+}
+
+function shouldFallbackFromHeadError(error: unknown) {
+  if (error instanceof Error && error.name === "AbortError") return false;
+  return error instanceof TypeError;
+}
+
 async function canLoadAudioUrl(url: string) {
+  const deadline = Date.now() + 10_000;
+  let shouldTryGet = false;
+
   try {
     const headResponse = await fetchWithTimeout(
       url,
       { method: "HEAD", cache: "no-store" },
-      10_000,
+      remainingTime(deadline),
     );
     if (headResponse.ok) return true;
-    if (headResponse.status !== 405 && headResponse.status !== 501) {
-      return false;
-    }
-  } catch {
-    // Fall back to a tiny GET; some object stores do not support HEAD/CORS HEAD.
+    shouldTryGet = isHeadUnsupportedStatus(headResponse.status);
+  } catch (error) {
+    shouldTryGet = shouldFallbackFromHeadError(error);
   }
+  if (!shouldTryGet) return false;
 
   try {
     const getResponse = await fetchWithTimeout(
@@ -80,7 +98,7 @@ async function canLoadAudioUrl(url: string) {
         cache: "no-store",
         headers: { Range: "bytes=0-0" },
       },
-      10_000,
+      remainingTime(deadline),
     );
     return getResponse.ok;
   } catch {

--- a/src/app/editor/story/[story]/v2/audio_problem_check.ts
+++ b/src/app/editor/story/[story]/v2/audio_problem_check.ts
@@ -1,0 +1,130 @@
+import type { StoryType } from "@/components/editor/story/syntax_parser_new";
+import type { Audio } from "@/components/editor/story/syntax_parser_types";
+
+const PUBLIC_BLOB_BASE_URL =
+  "https://ptoqrnbx8ghuucmt.public.blob.vercel-storage.com/";
+
+type AudioCheckItem = {
+  url: string | null;
+};
+
+export type StoryAudioProblemCheckResult = {
+  audioProblemCount: 0 | 1;
+  expectedAudioCount: number;
+  missingAudioCount: number;
+  checkedUrlCount: number;
+  failedUrlCount: number;
+};
+
+function getAudioUrl(audio: Audio | undefined) {
+  if (!audio?.url) return null;
+  if (audio.url.startsWith("blob:") || audio.url.startsWith("http")) {
+    return audio.url;
+  }
+  return `${PUBLIC_BLOB_BASE_URL}${audio.url}`;
+}
+
+export function collectStoryLineAudioUrls(story: StoryType): (string | null)[] {
+  const items: AudioCheckItem[] = [];
+  for (const element of story.elements) {
+    if (element.type === "HEADER") {
+      items.push({ url: getAudioUrl(element.audio) });
+      continue;
+    }
+    if (element.type === "LINE") {
+      items.push({
+        url: getAudioUrl(element.line.content.audio ?? element.audio),
+      });
+    }
+  }
+  return items.map((item) => item.url);
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+) {
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    globalThis.clearTimeout(timeout);
+  }
+}
+
+async function canLoadAudioUrl(url: string) {
+  try {
+    const headResponse = await fetchWithTimeout(
+      url,
+      { method: "HEAD", cache: "no-store" },
+      10_000,
+    );
+    if (headResponse.ok) return true;
+    if (headResponse.status !== 405 && headResponse.status !== 501) {
+      return false;
+    }
+  } catch {
+    // Fall back to a tiny GET; some object stores do not support HEAD/CORS HEAD.
+  }
+
+  try {
+    const getResponse = await fetchWithTimeout(
+      url,
+      {
+        method: "GET",
+        cache: "no-store",
+        headers: { Range: "bytes=0-0" },
+      },
+      10_000,
+    );
+    return getResponse.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<R>,
+) {
+  const results: R[] = new Array(values.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (nextIndex < values.length) {
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+        results[currentIndex] = await mapper(values[currentIndex]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+export async function checkStoryLineAudio(
+  story: StoryType,
+): Promise<StoryAudioProblemCheckResult> {
+  const urls = collectStoryLineAudioUrls(story);
+  const missingAudioCount = urls.filter((url) => !url).length;
+  const uniqueUrls = [
+    ...new Set(urls.filter((url): url is string => Boolean(url))),
+  ];
+  const loadResults = await mapWithConcurrency(uniqueUrls, 8, canLoadAudioUrl);
+  const failedUrlCount = loadResults.filter((ok) => !ok).length;
+
+  return {
+    audioProblemCount: missingAudioCount > 0 || failedUrlCount > 0 ? 1 : 0,
+    expectedAudioCount: urls.length,
+    missingAudioCount,
+    checkedUrlCount: uniqueUrls.length,
+    failedUrlCount,
+  };
+}

--- a/src/app/editor/story/[story]/v2/use_story_editor_model.ts
+++ b/src/app/editor/story/[story]/v2/use_story_editor_model.ts
@@ -9,6 +9,7 @@ import {
 } from "@/components/editor/story/syntax_parser_new";
 import type { Avatar, StoryData } from "@/app/editor/story/[story]/types";
 import { retryOnceAfterAuthRefresh } from "./save_auth_retry";
+import { checkStoryLineAudio } from "./audio_problem_check";
 
 type LanguageLike = {
   short: string;
@@ -268,22 +269,24 @@ export function useStoryEditorModel({
     setIsSaving(true);
     const saveStartRevision = revision;
     const operationKey = `story:${storyData.id}:set_story:v2:${Date.now()}:${saveStartRevision}`;
-    const saveArgs = {
-      legacyStoryId: storyData.id,
-      duo_id: storyData.duo_id ?? "",
-      name: parsedMeta.fromLanguageName,
-      image: parsedMeta.icon ?? "",
-      set_id: parsedMeta.set_id,
-      set_index: parsedMeta.set_index,
-      legacyCourseId: storyData.course_id,
-      text: docText,
-      json: toConvexValue(parsedStoryBase),
-      todo_count: parsedMeta.todo_count,
-      change_date: new Date().toISOString(),
-      confirmOfficialOverwrite,
-      operationKey,
-    };
     try {
+      const audioCheck = await checkStoryLineAudio(parsedStoryBase);
+      const saveArgs = {
+        legacyStoryId: storyData.id,
+        duo_id: storyData.duo_id ?? "",
+        name: parsedMeta.fromLanguageName,
+        image: parsedMeta.icon ?? "",
+        set_id: parsedMeta.set_id,
+        set_index: parsedMeta.set_index,
+        legacyCourseId: storyData.course_id,
+        text: docText,
+        json: toConvexValue(parsedStoryBase),
+        todo_count: parsedMeta.todo_count,
+        audioProblemCount: audioCheck.audioProblemCount,
+        change_date: new Date().toISOString(),
+        confirmOfficialOverwrite,
+        operationKey,
+      };
       const result = await retryOnceAfterAuthRefresh(
         () => setStoryMutation(saveArgs),
         {


### PR DESCRIPTION
## What changed

- Adds a client-side line-audio availability check before saving stories in the editor.
- Sends `audioProblemCount` with `storyWrite.setStory` so a saved story is marked as having an audio problem when any spoken header/line audio is missing or unloadable.
- Recomputes course `audio_problem_count` from published, non-deleted stories after story saves/deletes.
- Hardens the audio problem count sync script so stale private/deleted/course-mismatched story summary entries are filtered and cleared instead of counted.
- Adds tests for audio URL resolution, missing audio, failed audio URLs, and HEAD-to-GET fallback.

## Why

The editor badge should track the first audio goal: every published story should have loadable line audio for each spoken line. Previously the count was only updated by offline scripts, so editor saves could leave course/story audio problem badges stale.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm convex dev --once`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Story saving now checks audio links and records an audio problem count.
  * Course audio problem totals are recalculated automatically when stories are saved or deleted.
  * The audio-count sync tool now handles larger updates in batches and can target production.

* **Bug Fixes**
  * Missing, broken, or inaccessible audio references are now detected more reliably, including fallback checks when needed.
  * Course audio problem counts stay in sync when stories move between courses or change visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->