### PR TITLE
Fix mobile course picker group label

### DIFF
--- a/app-mobile/src/components/CoursePicker.tsx
+++ b/app-mobile/src/components/CoursePicker.tsx
@@ -21,8 +21,8 @@ type LandingGroup = LandingData["groups"][number];
 type CourseItem = LandingGroup["courses"][number];
 
 /**
- * Course list grouped by base language ("Stories for English", …), fed by the
- * same landing-page query as the web. English group comes first server-side.
+ * Course list grouped by base language, fed by the same landing-page query as
+ * the web. English group comes first server-side.
  */
 export function CoursePicker({
   selectedShort,
@@ -68,7 +68,7 @@ export function CoursePicker({
       );
       return {
         key: String(group.fromLanguageId),
-        title: `${group.labels.storiesFor} ${group.fromLanguageName}`,
+        title: group.labels.storiesFor,
         template: group.labels.nStoriesTemplate,
         data: courses,
       };


### PR DESCRIPTION
## Summary
- render the mobile course picker group heading from the localized `storiesFor` label directly
- avoid appending the base language a second time, fixing labels like `Stories for English speakers English`

## Testing
- pnpm run format
- pnpm typecheck
- cd app-mobile && pnpm typecheck
- pnpm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated course section headers to show a cleaner title format.
  * Improved the grouping text shown in course lists for more consistent wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->