### PR TITLE
Fix out-of-bounds access in bulk audio editor timing text

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -14,7 +14,7 @@ Repo verification gate (used by every plan): `pnpm typecheck && pnpm lint && pnp
 | 002 | Enforce contributor auth on editor Convex queries | P1 | S | — | TODO |
 | 003 | Scope storyDone progress queries to the session user | P1 | S | — | TODO |
 | 004 | Surface story save/delete/upload failures to the user | P1 | S | — | TODO |
-| 005 | Fix out-of-bounds in bulk audio editor timing text | P2 | S | — | TODO |
+| 005 | Fix out-of-bounds in bulk audio editor timing text | P2 | S | — | DONE |
 | 006 | Convex function test harness (convex-test + vitest) | P1 | M | 001 | TODO |
 | 007 | Repo hygiene: tmp/ untrack, @types/pg, kysely note, debug logs | P3 | S | — | TODO |
 | 008 | Harden shared-secret HTTP endpoints; internalize backfills | P3 | S | — | TODO |

--- a/src/app/editor/story/[story]/bulk-audio-editor.tsx
+++ b/src/app/editor/story/[story]/bulk-audio-editor.tsx
@@ -25,6 +25,7 @@ import {
   text_to_keypoints,
   timings_to_text,
 } from "@/lib/editor/audio/audio_edit_tools";
+import { buildTimingText } from "@/lib/editor/audio/timing_text";
 import { splitTextTokens } from "@/lib/editor/tts_transcripte";
 import {
   consumeAudioCutterOutput,
@@ -447,23 +448,19 @@ function BulkAudioRow({
       const regions = plugin.regions.sort(
         (left, right) => left.start - right.start,
       );
-      let nextTimingText = "";
-      for (let index = 0; index < regions.length; index += 1) {
+      for (
+        let index = 0;
+        index < Math.min(regions.length, parts.length);
+        index += 1
+      ) {
         if (
           regions[index]!.content !== undefined &&
           parts[index] !== undefined
         ) {
           regions[index]!.content!.innerText = parts[index]!.text;
         }
-        nextTimingText +=
-          ";" +
-          (parts[index]!.text.length +
-            parts[index]!.pos -
-            (parts[index - 1]?.text.length + parts[index - 1]?.pos || 0)) +
-          "," +
-          (Math.floor(regions[index]!.start * 1000) -
-            Math.floor(regions[index - 1]?.start * 1000 || 0));
       }
+      const nextTimingText = buildTimingText(parts, regions);
 
       onChange((currentDraft) => ({
         ...currentDraft,

--- a/src/lib/editor/audio/timing_text.test.ts
+++ b/src/lib/editor/audio/timing_text.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildTimingText,
+  type TimingPart,
+  type TimingRegion,
+} from "@/lib/editor/audio/timing_text";
+
+const parts: TimingPart[] = [
+  { text: "ab", pos: 0 },
+  { text: "cde", pos: 5 },
+  { text: "f", pos: 9 },
+  { text: "ghij", pos: 12 },
+];
+const regions: TimingRegion[] = [
+  { start: 0.1 },
+  { start: 0.5 },
+  { start: 1.2 },
+  { start: 2.0 },
+];
+
+test("buildTimingText matches the inline formula for equal-length inputs", () => {
+  assert.equal(
+    buildTimingText(parts.slice(0, 3), regions.slice(0, 3)),
+    ";2,100;6,400;2,700",
+  );
+});
+
+test("buildTimingText ignores surplus regions without throwing", () => {
+  const twoParts = parts.slice(0, 2);
+  assert.equal(
+    buildTimingText(twoParts, regions),
+    buildTimingText(twoParts, regions.slice(0, 2)),
+  );
+  assert.equal(buildTimingText(twoParts, regions), ";2,100;6,400");
+});
+
+test("buildTimingText ignores surplus parts without throwing", () => {
+  const twoRegions = regions.slice(0, 2);
+  assert.equal(
+    buildTimingText(parts, twoRegions),
+    buildTimingText(parts.slice(0, 2), twoRegions),
+  );
+  assert.equal(buildTimingText(parts, twoRegions), ";2,100;6,400");
+});
+
+test("buildTimingText returns empty string for empty inputs", () => {
+  assert.equal(buildTimingText([], []), "");
+});

--- a/src/lib/editor/audio/timing_text.ts
+++ b/src/lib/editor/audio/timing_text.ts
@@ -1,0 +1,28 @@
+export type TimingPart = { text: string; pos: number };
+export type TimingRegion = { start: number };
+
+/** Builds the ";chars,ms" timing string for aligned (part, region) pairs.
+ *  Pairs beyond the shorter of the two arrays are ignored. */
+export function buildTimingText(
+  parts: readonly TimingPart[],
+  regions: readonly TimingRegion[],
+): string {
+  const count = Math.min(parts.length, regions.length);
+  let timingText = "";
+  for (let index = 0; index < count; index += 1) {
+    const part = parts[index]!;
+    const previousPart = parts[index - 1];
+    const previousEnd = previousPart
+      ? previousPart.text.length + previousPart.pos
+      : 0;
+    const previousMs = regions[index - 1]
+      ? Math.floor(regions[index - 1]!.start * 1000)
+      : 0;
+    timingText +=
+      ";" +
+      (part.text.length + part.pos - previousEnd) +
+      "," +
+      (Math.floor(regions[index]!.start * 1000) - previousMs);
+  }
+  return timingText;
+}


### PR DESCRIPTION
Implements `plans/005-fix-bulk-audio-editor-bounds.md`.

## What & why

`onRegionUpdated` in the bulk audio editor built the audio timing text by iterating over all waveform regions and indexing into the transcript `parts` array with non-null assertions. When a user added more regions than there are parts, `parts[index]!.text.length` dereferenced `undefined` and threw a `TypeError` inside the wavesurfer callback, breaking timing-text updates for the rest of the session.

- Extracts the pure `";chars,ms"` timing-text computation into a new bounds-safe helper `buildTimingText` in `src/lib/editor/audio/timing_text.ts`. It iterates only up to `min(parts.length, regions.length)`, silently ignoring surplus pairs, and preserves the exact existing output for the in-bounds case (verified against the old inline formula).
- Uses `buildTimingText` in `onRegionUpdated`; the region label loop is likewise bounded.
- Adds `src/lib/editor/audio/timing_text.test.ts` (node:test) covering happy-path parity, more-regions-than-parts, more-parts-than-regions, and empty inputs.

The timing-text format is unchanged (stored story data depends on it).

## Verification

- `pnpm run format` — no fixes needed
- `pnpm run typecheck` — exit 0
- `pnpm run lint` — exit 0
- `pnpm run test` — 43 passed, 0 failed (including 4 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio timing updates in the bulk audio editor so region changes are applied more reliably, even when the number of text parts and audio regions don’t match.
  * Prevented out-of-bounds updates when refreshing timing text.

* **Tests**
  * Added coverage for timing-text generation across matching, extra-part, extra-region, and empty-input cases.

* **Documentation**
  * Marked the related plan as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->