### PR TITLE
Scope storyDone progress queries to the session user (plan 003)

### DIFF
--- a/convex/storyDone.ts
+++ b/convex/storyDone.ts
@@ -89,27 +89,6 @@ export const recordStoryDone = mutation({
   },
 });
 
-export const getDoneStoryIdsForCourse = query({
-  args: {
-    legacyCourseId: v.number(),
-    legacyUserId: v.number(),
-  },
-  returns: v.array(v.number()),
-  handler: async (ctx, args) => {
-    const course = await ctx.db
-      .query("courses")
-      .withIndex("by_id_value", (q) => q.eq("legacyId", args.legacyCourseId))
-      .unique();
-    if (!course) return [];
-
-    return await getDoneStoryIdsForCourseIdAndUser(
-      ctx,
-      course._id,
-      args.legacyUserId,
-    );
-  },
-});
-
 export const getDoneStoryIdsForCurrentUserInCourse = query({
   args: {
     courseShort: v.string(),
@@ -270,16 +249,17 @@ export const getDoneCourseIdsForUser = query({
   },
 });
 
-export const getLastDoneCourseShortForLegacyUser = query({
-  args: {
-    legacyUserId: v.number(),
-  },
+export const getLastDoneCourseShortForCurrentUser = query({
+  args: {},
   returns: v.union(v.string(), v.null()),
-  handler: async (ctx, args) => {
+  handler: async (ctx) => {
+    const legacyUserId = await getSessionLegacyUserId(ctx);
+    if (legacyUserId === null) return null;
+
     const activityRows = await ctx.db
       .query("course_activity")
       .withIndex("by_user_and_last_done_at", (q) =>
-        q.eq("legacyUserId", args.legacyUserId),
+        q.eq("legacyUserId", legacyUserId),
       )
       .order("desc")
       .take(20);

--- a/docs/mobile-app-design.md
+++ b/docs/mobile-app-design.md
@@ -67,7 +67,7 @@ Root (tab-less stack)
 - **Welcome** mirrors the PWA's start screen (`src/app/(stories)/learn/welcome.tsx`,
   the PWA `start_url`): see §3.0.
 - **Learn** is the default tab and opens the *last used course* (stored locally;
-  for logged-in users seeded from `storyDone.getLastDoneCourseShortForLegacyUser`).
+  for logged-in users seeded from `storyDone.getLastDoneCourseShortForCurrentUser`).
 - The reader is a full-screen modal with no tab bar — a story is an immersive,
   do-not-interrupt flow, same as Duolingo's apps.
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -12,7 +12,7 @@ Repo verification gate (used by every plan): `pnpm typecheck && pnpm lint && pnp
 |------|-------|----------|--------|------------|--------|
 | 001 | CI runs tests; delete dead workflows; add .env.example | P1 | S | — | TODO |
 | 002 | Enforce contributor auth on editor Convex queries | P1 | S | — | TODO |
-| 003 | Scope storyDone progress queries to the session user | P1 | S | — | TODO |
+| 003 | Scope storyDone progress queries to the session user | P1 | S | — | DONE |
 | 004 | Surface story save/delete/upload failures to the user | P1 | S | — | TODO |
 | 005 | Fix out-of-bounds in bulk audio editor timing text | P2 | S | — | TODO |
 | 006 | Convex function test harness (convex-test + vitest) | P1 | M | 001 | TODO |

--- a/src/app/(stories)/learn/page.tsx
+++ b/src/app/(stories)/learn/page.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { redirect } from "next/navigation";
 import Welcome from "./welcome";
 import { getUser } from "@/lib/userInterface";
-import { fetchQuery } from "convex/nextjs";
+import { fetchAuthQuery } from "@/lib/auth-server";
 import { api } from "@convex/_generated/api";
 
 export const metadata = {
@@ -18,11 +18,8 @@ export default async function Page() {
   const user = await getUser();
 
   if (user?.userId) {
-    const lastCourseShort = await fetchQuery(
-      api.storyDone.getLastDoneCourseShortForLegacyUser,
-      {
-        legacyUserId: user.userId,
-      },
+    const lastCourseShort = await fetchAuthQuery(
+      api.storyDone.getLastDoneCourseShortForCurrentUser,
     );
     if (lastCourseShort) redirect("/" + lastCourseShort);
   }


### PR DESCRIPTION
Implements `plans/003-scope-storydone-queries-to-session.md`.

## What & why

Two public Convex queries in `convex/storyDone.ts` accepted an arbitrary `legacyUserId` argument and returned that user's private progress data with no ownership check (IDOR): any caller could read any user's story-completion history and last-active course.

- Deleted the unused public query `getDoneStoryIdsForCourse` (zero callers anywhere in `src/` or `convex/`).
- Renamed and rewrote `getLastDoneCourseShortForLegacyUser` -> `getLastDoneCourseShortForCurrentUser`, deriving the user from the session via `getSessionLegacyUserId(ctx)` (the same pattern already used by `getDoneStoryIdsForCurrentUserInCourse`).
- Updated the only caller, `src/app/(stories)/learn/page.tsx`, to use the authenticated `fetchAuthQuery` helper instead of the unauthenticated `fetchQuery`.

No callers of `getDoneStoryIdsForCourse` existed. The generated Convex API resolves function names via `typeof storyDone`, so no codegen diff was needed.

## Verification

- `pnpm run format` — clean
- `pnpm run typecheck` — exit 0
- `pnpm run lint` — exit 0
- `pnpm run test` — 39 pass, 0 fail
- Done-criteria greps: no `getDoneStoryIdsForCourse`, no `legacyUserId: v.number()` in `storyDone.ts` query args, no remaining references to the old query name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logged-in users now have their last completed course detected automatically from their current session, improving the Learn tab’s resume behavior.

* **Bug Fixes**
  * Completed story progress now loads using the signed-in user context, which should make progress tracking more reliable.
  * Users without an active session now safely see no progress data instead of errors.

* **Documentation**
  * Updated design notes and planning status to reflect the completed progress-query work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->