### PR TITLE
Enforce contributor auth on editor Convex read queries

### DIFF
--- a/convex/editorRead.ts
+++ b/convex/editorRead.ts
@@ -2,7 +2,10 @@ import { query, type QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { components } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
-import { getSessionLegacyUserId } from "./lib/authorization";
+import {
+  getSessionLegacyUserId,
+  isContributorOrAdmin,
+} from "./lib/authorization";
 import { courseContributorValidator } from "./lib/courseContributors";
 
 type LanguageDoc = Doc<"languages">;
@@ -215,6 +218,8 @@ async function buildAvatarRows(
 export const getEditorSidebarData = query({
   args: {},
   handler: async (ctx) => {
+    if (!(await isContributorOrAdmin(ctx))) return { courses: [] };
+
     const courseRows = await ctx.db.query("courses").collect();
 
     const referencedLanguageIds = Array.from(
@@ -247,6 +252,8 @@ export const getEditorCourseByIdentifier = query({
   args: { identifier: v.string() },
   returns: editorCourseValidator,
   handler: async (ctx, args) => {
+    if (!(await isContributorOrAdmin(ctx))) return null;
+
     const course = await getCourseByIdentifier(ctx, args.identifier);
     if (!course) return null;
 
@@ -286,6 +293,8 @@ export const getEditorCourseByIdentifier = query({
 export const getEditorStoriesByCourseLegacyId = query({
   args: { identifier: v.string() },
   handler: async (ctx, args) => {
+    if (!(await isContributorOrAdmin(ctx))) return [];
+
     const timerBase = `editorRead:getEditorStoriesByCourseLegacyId:course:${args.identifier}`;
     const storiesTimer = `${timerBase}:stories`;
     const imagesTimer = `${timerBase}:images`;

--- a/convex/lib/authorization.ts
+++ b/convex/lib/authorization.ts
@@ -30,6 +30,11 @@ export async function requireContributorOrAdmin(ctx: AuthCtx) {
   }
 }
 
+export async function isContributorOrAdmin(ctx: AuthCtx) {
+  const role = await getRole(ctx);
+  return role === "contributor" || role === "admin";
+}
+
 export async function requireSessionLegacyUserId(ctx: AuthCtx) {
   const identity = await getIdentity(ctx);
   const rawUserId = identity?.userId;

--- a/plans/README.md
+++ b/plans/README.md
@@ -11,7 +11,7 @@ Repo verification gate (used by every plan): `pnpm typecheck && pnpm lint && pnp
 | Plan | Title | Priority | Effort | Depends on | Status |
 |------|-------|----------|--------|------------|--------|
 | 001 | CI runs tests; delete dead workflows; add .env.example | P1 | S | — | TODO |
-| 002 | Enforce contributor auth on editor Convex queries | P1 | S | — | TODO |
+| 002 | Enforce contributor auth on editor Convex queries | P1 | S | — | DONE (tests deferred to 006) |
 | 003 | Scope storyDone progress queries to the session user | P1 | S | — | TODO |
 | 004 | Surface story save/delete/upload failures to the user | P1 | S | — | TODO |
 | 005 | Fix out-of-bounds in bulk audio editor timing text | P2 | S | — | TODO |

--- a/src/app/editor/(course)/course/[course_id]/import/[from_id]/page.tsx
+++ b/src/app/editor/(course)/course/[course_id]/import/[from_id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import React from "react";
 import { Metadata } from "next";
-import { fetchQuery } from "convex/nextjs";
+import { fetchAuthQuery } from "@/lib/auth-server";
 import { api } from "@convex/_generated/api";
 import ImportPageClient from "./page_client";
 
@@ -10,9 +10,12 @@ export async function generateMetadata({
 }: {
   params: Promise<{ course_id: string; from_id: string }>;
 }): Promise<Metadata> {
-  const course = await fetchQuery(api.editorRead.getEditorCourseByIdentifier, {
-    identifier: (await params).course_id,
-  });
+  const course = await fetchAuthQuery(
+    api.editorRead.getEditorCourseByIdentifier,
+    {
+      identifier: (await params).course_id,
+    },
+  );
 
   if (!course) notFound();
 

--- a/src/app/editor/(course)/course/[course_id]/localization/page.tsx
+++ b/src/app/editor/(course)/course/[course_id]/localization/page.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
-import { fetchQuery } from "convex/nextjs";
+import { fetchAuthQuery } from "@/lib/auth-server";
 import { api } from "@convex/_generated/api";
 import CourseLocalizationPageClient from "./page_client";
 
@@ -15,9 +15,12 @@ export async function generateMetadata({
   params: Promise<{ course_id: string }>;
 }): Promise<Metadata> {
   const courseId = (await params).course_id;
-  const course = await fetchQuery(api.editorRead.getEditorCourseByIdentifier, {
-    identifier: courseId,
-  });
+  const course = await fetchAuthQuery(
+    api.editorRead.getEditorCourseByIdentifier,
+    {
+      identifier: courseId,
+    },
+  );
 
   if (!course) notFound();
 

--- a/src/app/editor/(course)/course/[course_id]/page.tsx
+++ b/src/app/editor/(course)/course/[course_id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
-import { fetchQuery } from "convex/nextjs";
+import { fetchAuthQuery } from "@/lib/auth-server";
 import { api } from "@convex/_generated/api";
 import CourseEditorPageClient from "./page_client";
 
@@ -9,9 +9,12 @@ export async function generateMetadata({
 }: {
   params: Promise<{ course_id: string }>;
 }): Promise<Metadata> {
-  const course = await fetchQuery(api.editorRead.getEditorCourseByIdentifier, {
-    identifier: (await params).course_id,
-  });
+  const course = await fetchAuthQuery(
+    api.editorRead.getEditorCourseByIdentifier,
+    {
+      identifier: (await params).course_id,
+    },
+  );
 
   if (!course) notFound();
 

--- a/src/app/editor/(course)/course/[course_id]/voices/edit/page.tsx
+++ b/src/app/editor/(course)/course/[course_id]/voices/edit/page.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
-import { fetchQuery } from "convex/nextjs";
+import { fetchAuthQuery } from "@/lib/auth-server";
 import { api } from "@convex/_generated/api";
 import CourseVoicesEditPageClient from "./page_client";
 
@@ -15,9 +15,12 @@ export async function generateMetadata({
   params: Promise<{ course_id: string }>;
 }): Promise<Metadata> {
   const courseId = (await params).course_id;
-  const course = await fetchQuery(api.editorRead.getEditorCourseByIdentifier, {
-    identifier: courseId,
-  });
+  const course = await fetchAuthQuery(
+    api.editorRead.getEditorCourseByIdentifier,
+    {
+      identifier: courseId,
+    },
+  );
 
   if (!course) notFound();
 

--- a/src/app/editor/(course)/course/[course_id]/voices/page.tsx
+++ b/src/app/editor/(course)/course/[course_id]/voices/page.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
-import { fetchQuery } from "convex/nextjs";
+import { fetchAuthQuery } from "@/lib/auth-server";
 import { api } from "@convex/_generated/api";
 import CourseVoicesPageClient from "./page_client";
 
@@ -15,9 +15,12 @@ export async function generateMetadata({
   params: Promise<{ course_id: string }>;
 }): Promise<Metadata> {
   const courseId = (await params).course_id;
-  const course = await fetchQuery(api.editorRead.getEditorCourseByIdentifier, {
-    identifier: courseId,
-  });
+  const course = await fetchAuthQuery(
+    api.editorRead.getEditorCourseByIdentifier,
+    {
+      identifier: courseId,
+    },
+  );
 
   if (!course) notFound();
 


### PR DESCRIPTION
Implements `plans/002-guard-editor-convex-queries.md`.

## What & why

Three public Convex queries in `convex/editorRead.ts` — `getEditorSidebarData`, `getEditorCourseByIdentifier`, and `getEditorStoriesByCourseLegacyId` — had no authorization check. The only protection was a client-side redirect in the editor layout, so anyone knowing the public deployment URL and function names could read the full editorial state (all courses including non-public ones, todo counts, story statuses, author names, contributor lists). Write mutations were already guarded; this **partially** closes the read-side gap — it covers exactly the three queries named in the plan's scope. Other public `getEditor*` queries in the same file remain unauthenticated and are tracked separately (see "Scope & known gap" below).

## Changes

- `convex/lib/authorization.ts`: add non-throwing `isContributorOrAdmin(ctx)` helper (reuses existing `getRole`).
- `convex/editorRead.ts`: guard the three queries at the top of each handler, returning empty data (`{ courses: [] }`, `null`, `[]`) when the caller is not a contributor/admin. Empty-data (rather than throwing) is deliberate: `useQuery` subscriptions fire while the client auth token is still loading, and the existing UI already handles `null`/empty; throwing would surface transient errors on every editor screen.
- 5 server pages under `src/app/editor/(course)/course/[course_id]/` (`page.tsx`, `voices/page.tsx`, `voices/edit/page.tsx`, `import/[from_id]/page.tsx`, `localization/page.tsx`): switch `getEditorCourseByIdentifier` from the unauthenticated `fetchQuery` (convex/nextjs) to the authenticated `fetchAuthQuery` (`@/lib/auth-server`) so `generateMetadata` still receives real data for contributors instead of hitting `notFound()`.
- `plans/README.md`: status row 002 → DONE (tests deferred to plan 006).

## Scope & known gap

Per the plan, only the three named queries are in scope; the remaining public `getEditor*` queries were to be **reported, not fixed** here (plan STOP condition #4). Still unauthenticated after this PR and tracked in #564:

- `getEditorStoryPageData` (most sensitive — returns full `story_content.text`; reads `role` only for an `isAdmin` flag, not to gate access)
- `getEditorCourseImport`, `resolveEditorLanguage`, `getEditorSpeakersByLanguageLegacyId`, `getEditorAvatarNamesByLanguageLegacyId`, `getEditorLocalizationRowsByLanguageLegacyId`, `getEditorImageByLegacyId`, `getEditorLanguageByLegacyId`

These intentionally keep unauthenticated `fetchQuery` in this PR and should be guarded as a follow-up (#564).

## Verification

- `pnpm run format` — no fixes needed
- `pnpm run typecheck` — pass
- `pnpm run lint` — pass
- `pnpm run test` — 39 passed
- `pnpm exec convex codegen` — not run (no Convex deployment configured in the isolated worktree); change adds no new/renamed Convex functions, so generated bindings are unaffected.
- Tests for the guards are deferred to plan 006 (Convex test harness), per this plan's test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened editor read access so editor sidebar data, course details, and story lists are only visible to contributors and admins.
  * Updated editor course metadata pages to fetch course details using authenticated requests for consistent access-controlled behavior.
* **Chores**
  * Marked the contributor authorization enforcement rollout plan as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->