### PR TITLE
Fix speaker avatar fallback

### DIFF
--- a/src/components/editor/story/parser.test.ts
+++ b/src/components/editor/story/parser.test.ts
@@ -345,6 +345,53 @@ $8275/8e8657d3.mp3;5,50;2,550;1,438;7,162;0,525`);
   });
 });
 
+test("LINE uses the default avatar link when a speaker override only changes the voice", () => {
+  const avatarLink = "https://stories-cdn.duolingo.com/avatar/speaker-6.svg";
+  const [story, meta] = processStoryFile(
+    `[DATA]
+speaker_6=nl-BE-Wavenet-B
+
+[LINE]
+Speaker6: Waarom niet?`,
+    0,
+    {
+      0: {
+        id: 0,
+        avatar_id: 0,
+        language_id: 0,
+        name: "Narrator",
+        link: "",
+        speaker: "nl-NL-FennaNeural",
+      },
+      6: {
+        id: 6,
+        avatar_id: 6,
+        language_id: 0,
+        name: "Rob",
+        link: avatarLink,
+        speaker: "nl-NL-FennaNeural",
+      },
+    },
+    {
+      learning_language: "nl",
+      from_language: "en",
+    },
+    "",
+  );
+
+  const line = story.elements[0];
+  assert.equal(line?.type, "LINE");
+  if (line?.type !== "LINE") return;
+
+  assert.equal(line.line.type, "CHARACTER");
+  if (line.line.type !== "CHARACTER") return;
+
+  assert.equal(line.line.avatarUrl, avatarLink);
+  assert.equal(line.line.characterName, "Rob");
+  assert.equal(meta.cast["6"]?.link, avatarLink);
+  assert.equal(meta.cast["6"]?.speaker, "nl-BE-Wavenet-B");
+});
+
 test("curly brace TTS override keeps the full tilde-connected phrase", () => {
   const [story] = processStoryFile(
     `[DATA]

--- a/src/components/editor/story/syntax_parser_new.ts
+++ b/src/components/editor/story/syntax_parser_new.ts
@@ -548,13 +548,15 @@ function get_avatar(
   avatar_names: Record<string, Avatar>,
   avatar_overwrites: Record<string, AvatarOverwrites>,
 ) {
-  const id2 = parseInt(id) ?? id;
-  if (avatar_overwrites[id2])
-    return { characterId: id2, avatarUrl: avatar_overwrites[id2]?.link };
+  const parsedId = parseInt(id);
+  const id2 = Number.isNaN(parsedId) ? id : parsedId;
+  const avatar = avatar_names[id2];
+  const override = avatar_overwrites[id2];
+
   return {
     characterId: id2,
-    avatarUrl: avatar_names[id2]?.link,
-    characterName: avatar_names[id2]?.name,
+    avatarUrl: override?.link || avatar?.link,
+    characterName: override?.name || avatar?.name,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes dialogue avatar rendering when a story defines a voice-only speaker override such as `speaker_6=nl-BE-Wavenet-B`.

The parser previously treated the presence of any avatar override as a full replacement, so `Speaker6` dialogue received an empty avatar URL when only the speaker voice was overridden. Cast rendering already fell back to the default avatar link, which is why the character appeared correctly there but not beside speech bubbles.

This changes avatar resolution to merge overrides field-by-field, preserving the default avatar link and character name unless an override explicitly supplies replacements.

## Validation

- `pnpm exec tsx --test src/components/editor/story/parser.test.ts`
- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm test`