### PR TITLE
Refine native story hint layout

### DIFF
--- a/app-mobile/app/_layout.tsx
+++ b/app-mobile/app/_layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import Constants from "expo-constants";
+import { Ionicons } from "@expo/vector-icons";
+import Constants, { ExecutionEnvironment } from "expo-constants";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
@@ -25,7 +26,7 @@ const nunitoExtraBoldFont = require("../assets/fonts/Nunito-ExtraBold.ttf");
 const nunitoLightFont = require("../assets/fonts/Nunito-Light.ttf");
 const sitelenPonaFont = require("../assets/fonts/linjalipamanka-normal.otf");
 
-if (Constants.appOwnership !== "expo") {
+if (Constants.executionEnvironment !== ExecutionEnvironment.StoreClient) {
   SplashScreen.setOptions({
     duration: 300,
     fade: true,
@@ -47,6 +48,7 @@ export default function RootLayout() {
     [NUNITO_EXTRA_BOLD_FONT_FAMILY]: nunitoExtraBoldFont,
     [NUNITO_LIGHT_FONT_FAMILY]: nunitoLightFont,
     [SITELEN_PONA_FONT_FAMILY]: sitelenPonaFont,
+    ...Ionicons.font,
   });
 
   React.useEffect(() => {

--- a/app-mobile/app/_layout.tsx
+++ b/app-mobile/app/_layout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Constants from "expo-constants";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
@@ -24,10 +25,12 @@ const nunitoExtraBoldFont = require("../assets/fonts/Nunito-ExtraBold.ttf");
 const nunitoLightFont = require("../assets/fonts/Nunito-Light.ttf");
 const sitelenPonaFont = require("../assets/fonts/linjalipamanka-normal.otf");
 
-SplashScreen.setOptions({
-  duration: 300,
-  fade: true,
-});
+if (Constants.appOwnership !== "expo") {
+  SplashScreen.setOptions({
+    duration: 300,
+    fade: true,
+  });
+}
 
 void SplashScreen.preventAutoHideAsync();
 
@@ -91,6 +94,7 @@ function ThemedStack() {
         <Stack.Screen name="onboarding" />
         <Stack.Screen name="add-course" />
         <Stack.Screen name="(tabs)" />
+        <Stack.Screen name="debug/story-shot" />
         <Stack.Screen
           name="story/[id]"
           options={{

--- a/app-mobile/app/debug/story-shot.tsx
+++ b/app-mobile/app/debug/story-shot.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { Text } from "../../src/components/Text";
+import { QuestionPrompt } from "../../src/story/elements/QuestionPrompt";
+import { SelectPhraseQuestion } from "../../src/story/elements/SelectPhraseQuestion";
+import { TextLine } from "../../src/story/elements/TextLine";
+import { HintPopupHost } from "../../src/story/HintPopup";
+import type {
+  ContentWithHints,
+  HideRange,
+  StoryElementLine,
+  StoryElementSelectPhrase,
+} from "../../src/story/types";
+import { useTheme } from "../../src/theme";
+
+function hiddenRange(text: string, phrase: string): HideRange {
+  const start = text.indexOf(phrase);
+  if (start === -1) {
+    throw new Error(`Missing fixture phrase: ${phrase}`);
+  }
+  return { start, end: start + phrase.length };
+}
+
+function content({
+  text,
+  hints = [],
+  ranges = [],
+}: {
+  text: string;
+  hints?: string[];
+  ranges?: Array<[number, number, number]>;
+}): ContentWithHints {
+  return {
+    text,
+    hintMap: ranges.map(([rangeFrom, rangeTo, hintIndex]) => ({
+      rangeFrom,
+      rangeTo,
+      hintIndex,
+    })),
+    hints,
+  };
+}
+
+const lucyAvatar =
+  "https://duostories.org/icon192.png";
+const eddyAvatar = "https://duostories.org/icon512.png";
+const blankText = "大学で英語の試験があるの。";
+
+const normalJapaneseLine: StoryElementLine = {
+  type: "LINE",
+  lang: "ja",
+  trackingProperties: { line_index: 0 },
+  line: {
+    type: "CHARACTER",
+    characterId: "lucy",
+    avatarUrl: lucyAvatar,
+    content: content({
+      text: "レポートをかかないといけないんだ。",
+      ranges: [
+        [0, 3, 0],
+        [5, 13, 1],
+      ],
+      hints: ["report", "have to write"],
+    }),
+  },
+};
+
+const normalLatinLine: StoryElementLine = {
+  type: "LINE",
+  lang: "sq",
+  trackingProperties: { line_index: 1 },
+  line: {
+    type: "CHARACTER",
+    characterId: "eddy",
+    avatarUrl: eddyAvatar,
+    content: content({
+      text: "Ku janë çelësat e mi?",
+      ranges: [
+        [0, 1, 0],
+        [3, 6, 1],
+        [8, 14, 2],
+        [16, 16, 3],
+        [18, 19, 4],
+      ],
+      hints: ["where", "are", "keys", "of", "mine"],
+    }),
+  },
+};
+
+const hiddenBlankLine: StoryElementLine = {
+  type: "LINE",
+  lang: "ja",
+  trackingProperties: { line_index: 2, challenge_type: "select-phrases" },
+  hideRangesForChallenge: [hiddenRange(blankText, "英語の試験")],
+  line: {
+    type: "CHARACTER",
+    characterId: "lucy",
+    avatarUrl: lucyAvatar,
+    content: content({ text: blankText }),
+  },
+};
+
+const hiddenLatinLine: StoryElementLine = {
+  type: "LINE",
+  lang: "en",
+  trackingProperties: { line_index: 3, challenge_type: "select-phrases" },
+  hideRangesForChallenge: [
+    hiddenRange(
+      "We have a very important language exam tomorrow.",
+      "very important language exam",
+    ),
+  ],
+  line: {
+    type: "PROSE",
+    content: content({
+      text: "We have a very important language exam tomorrow.",
+    }),
+  },
+};
+
+const answers: StoryElementSelectPhrase = {
+  type: "SELECT_PHRASE",
+  lang: "ja",
+  trackingProperties: { line_index: 4, challenge_type: "select-phrases" },
+  answers: ["英語の作品", "英語の試験", "映画の試験"],
+  correctAnswerIndex: 1,
+};
+
+function RealisticStoryFixture({ includeLatinBlank }: { includeLatinBlank: boolean }) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.storyCard}>
+      <Text style={[styles.title, { color: colors.text }]}>Story fixture</Text>
+      <TextLine element={normalJapaneseLine} active={false} rtl={false} autoPlay={false} />
+      <TextLine element={normalLatinLine} active={false} rtl={false} autoPlay={false} />
+      <QuestionPrompt
+        question={content({ text: "Select the missing phrase" })}
+        lang="en"
+      />
+      <TextLine
+        element={hiddenBlankLine}
+        active={false}
+        unhide={0}
+        rtl={false}
+        autoPlay={false}
+      />
+      {includeLatinBlank ? (
+        <TextLine
+          element={hiddenLatinLine}
+          active={false}
+          unhide={0}
+          rtl={false}
+          autoPlay={false}
+        />
+      ) : null}
+      <SelectPhraseQuestion element={answers} advance={() => {}} />
+    </View>
+  );
+}
+
+export default function StoryShotScreen() {
+  const { colors } = useTheme();
+  const params = useLocalSearchParams<{ case?: string }>();
+  const includeLatinBlank = params.case === "all" || params.case === "latin";
+
+  return (
+    <HintPopupHost>
+      <ScrollView
+        style={[styles.screen, { backgroundColor: colors.background }]}
+        contentContainerStyle={styles.content}
+      >
+        <RealisticStoryFixture includeLatinBlank={includeLatinBlank} />
+      </ScrollView>
+    </HintPopupHost>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  content: {
+    paddingTop: 28,
+    paddingHorizontal: 18,
+    paddingBottom: 48,
+  },
+  storyCard: {
+    gap: 2,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "800",
+    marginBottom: 2,
+  },
+});

--- a/app-mobile/app/debug/story-shot.tsx
+++ b/app-mobile/app/debug/story-shot.tsx
@@ -68,22 +68,21 @@ const normalJapaneseLine: StoryElementLine = {
 
 const normalLatinLine: StoryElementLine = {
   type: "LINE",
-  lang: "sq",
+  lang: "da",
   trackingProperties: { line_index: 1 },
   line: {
     type: "CHARACTER",
     characterId: "eddy",
     avatarUrl: eddyAvatar,
     content: content({
-      text: "Ku janë çelësat e mi?",
+      text: "Hvor   er   mine   nøgler?",
       ranges: [
-        [0, 1, 0],
-        [3, 6, 1],
-        [8, 14, 2],
-        [16, 16, 3],
-        [18, 19, 4],
+        [0, 3, 0],
+        [7, 8, 1],
+        [12, 15, 2],
+        [19, 24, 3],
       ],
-      hints: ["where", "are", "keys", "of", "mine"],
+      hints: ["where", "are", "my", "keys"],
     }),
   },
 };

--- a/app-mobile/app/debug/story-shot.tsx
+++ b/app-mobile/app/debug/story-shot.tsx
@@ -45,7 +45,7 @@ function content({
 const lucyAvatar =
   "https://duostories.org/icon192.png";
 const eddyAvatar = "https://duostories.org/icon512.png";
-const blankText = "大学で英語の試験があるの。";
+const blankText = "Potřebuji klíče od svého auta.";
 
 const normalJapaneseLine: StoryElementLine = {
   type: "LINE",
@@ -89,9 +89,9 @@ const normalLatinLine: StoryElementLine = {
 
 const hiddenBlankLine: StoryElementLine = {
   type: "LINE",
-  lang: "ja",
+  lang: "cs",
   trackingProperties: { line_index: 2, challenge_type: "select-phrases" },
-  hideRangesForChallenge: [hiddenRange(blankText, "英語の試験")],
+  hideRangesForChallenge: [hiddenRange(blankText, "klíče od svého auta")],
   line: {
     type: "CHARACTER",
     characterId: "lucy",
@@ -120,9 +120,9 @@ const hiddenLatinLine: StoryElementLine = {
 
 const answers: StoryElementSelectPhrase = {
   type: "SELECT_PHRASE",
-  lang: "ja",
+  lang: "cs",
   trackingProperties: { line_index: 4, challenge_type: "select-phrases" },
-  answers: ["英語の作品", "英語の試験", "映画の試験"],
+  answers: ["auta", "klíče", "svého", "od"],
   correctAnswerIndex: 1,
 };
 

--- a/app-mobile/app/debug/story-shot.tsx
+++ b/app-mobile/app/debug/story-shot.tsx
@@ -56,12 +56,9 @@ const normalJapaneseLine: StoryElementLine = {
     characterId: "lucy",
     avatarUrl: lucyAvatar,
     content: content({
-      text: "レポートをかかないといけないんだ。",
-      ranges: [
-        [0, 3, 0],
-        [5, 13, 1],
-      ],
-      hints: ["report", "have to write"],
+      text: "桜さんはコーヒーを飲みます。",
+      ranges: [[4, 7, 0]],
+      hints: ["coffee"],
     }),
   },
 };
@@ -126,7 +123,13 @@ const answers: StoryElementSelectPhrase = {
   correctAnswerIndex: 1,
 };
 
-function RealisticStoryFixture({ includeLatinBlank }: { includeLatinBlank: boolean }) {
+function RealisticStoryFixture({
+  includeLatinBlank,
+  showRevealedBlank,
+}: {
+  includeLatinBlank: boolean;
+  showRevealedBlank: boolean;
+}) {
   const { colors } = useTheme();
 
   return (
@@ -154,6 +157,15 @@ function RealisticStoryFixture({ includeLatinBlank }: { includeLatinBlank: boole
           autoPlay={false}
         />
       ) : null}
+      {showRevealedBlank ? (
+        <TextLine
+          element={hiddenBlankLine}
+          active={false}
+          unhide={-1}
+          rtl={false}
+          autoPlay={false}
+        />
+      ) : null}
       <SelectPhraseQuestion element={answers} advance={() => {}} />
     </View>
   );
@@ -163,6 +175,8 @@ export default function StoryShotScreen() {
   const { colors } = useTheme();
   const params = useLocalSearchParams<{ case?: string }>();
   const includeLatinBlank = params.case === "all" || params.case === "latin";
+  const showRevealedBlank =
+    params.case === "all" || params.case === "revealed";
 
   return (
     <HintPopupHost>
@@ -170,7 +184,10 @@ export default function StoryShotScreen() {
         style={[styles.screen, { backgroundColor: colors.background }]}
         contentContainerStyle={styles.content}
       >
-        <RealisticStoryFixture includeLatinBlank={includeLatinBlank} />
+        <RealisticStoryFixture
+          includeLatinBlank={includeLatinBlank}
+          showRevealedBlank={showRevealedBlank}
+        />
       </ScrollView>
     </HintPopupHost>
   );

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
-  Pressable,
   Platform,
+  Pressable,
   StyleSheet,
   type StyleProp,
   type TextStyle,
@@ -20,6 +20,9 @@ import type { ContentWithHints, HideRange } from "./types";
 // underlines are real (dashed) bottom borders.
 
 const WRAPPED_LINE_GAP = 3;
+const NATIVE_TEXT_AUDIO_PADDING = 32;
+
+type HintTextRenderMode = "auto" | "native" | "tokenized";
 
 function splitTextTokens(text: string): string[] {
   if (!text) return [];
@@ -49,6 +52,18 @@ type Token = {
 
 function getDisplayText(token: Token): string {
   return token.text.replace(/\s+/g, " ");
+}
+
+function shouldUseNativeTextLayout(lang?: string): boolean {
+  if (!lang) return false;
+  return /^(ja|zh|ko)(-|$)/i.test(lang);
+}
+
+function isLeadingPunctuationToken(text: string): boolean {
+  const normalized = text.replace(/[\u200b-\u200d\ufeff]/g, "");
+  return /^[,.:;!?%)}\]\u3001\u3002\u30fb\u30fc\uff01\uff1f\uff09\uff0c\uff0e]+$/u.test(
+    normalized,
+  );
 }
 
 function HintTokenBox({
@@ -233,42 +248,27 @@ function HintPhraseBox({
   );
 }
 
-export function HintText({
+function buildTokens({
   content,
   audioRange,
   hideRangesForChallenge,
+  showHints,
   unhide,
-  showHints = true,
-  style,
-  containerStyle,
-  leadingElement,
-  rtl = false,
-  centered = false,
-  fillLineWidth = false,
 }: {
   content: ContentWithHints;
-  /** Highest spoken character index during playback (99999 = idle). */
   audioRange?: number;
   hideRangesForChallenge?: HideRange[];
-  /** Progressive reveal for arrange/continuation (-1 reveals everything). */
+  showHints: boolean;
   unhide?: number;
-  showHints?: boolean;
-  style?: StyleProp<TextStyle>;
-  containerStyle?: ViewStyle;
-  leadingElement?: React.ReactNode;
-  rtl?: boolean;
-  centered?: boolean;
-  fillLineWidth?: boolean;
-}) {
-  const { colors } = useTheme();
-  const popup = React.useContext(HintPopupContext);
-  const onHintLookup = React.useContext(HintLookupContext);
-
-  if (!content) return null;
-
+}): Token[] {
   const visible: ContentWithHints = showHints
     ? content
-    : { ...content, hintMap: [], hints: undefined, hints_pronunciation: undefined };
+    : {
+        ...content,
+        hintMap: [],
+        hints: undefined,
+        hints_pronunciation: undefined,
+      };
 
   let entry: HideRange | undefined = hideRangesForChallenge?.[0];
   if (entry) {
@@ -287,7 +287,7 @@ export function HintText({
     const pieces = splitTextTokens(visible.text.substring(start, end));
     let position = start;
     for (const piece of pieces) {
-      // Separate whitespace from punctuation (e.g. ". " → "." + " ") so
+      // Separate whitespace from punctuation (e.g. ". " -> "." + " ") so
       // whitespace alone defines the wrap points.
       for (const sub of piece.split(/(\s+)/)) {
         if (!sub) continue;
@@ -331,7 +331,224 @@ export function HintText({
   }
   if (textPos < visible.text.length) pushRun(textPos, visible.text.length);
 
+  return tokens;
+}
+
+function NativeHintText({
+  tokens,
+  flatStyle,
+  containerStyle,
+  leadingElement,
+  rtl,
+  centered,
+  fillLineWidth,
+}: {
+  tokens: Token[];
+  flatStyle: TextStyle;
+  containerStyle?: ViewStyle;
+  leadingElement?: React.ReactNode;
+  rtl: boolean;
+  centered: boolean;
+  fillLineWidth: boolean;
+}) {
+  const { colors } = useTheme();
+  const popup = React.useContext(HintPopupContext);
+  const onHintLookup = React.useContext(HintLookupContext);
+
+  type InlineRun = {
+    key: string;
+    text: string;
+    hidden: boolean;
+    revealed: boolean;
+    dimmed: boolean;
+    hint?: Token["hint"];
+  };
+
+  const runs: InlineRun[] = [];
+  for (const token of tokens) {
+    const last = runs[runs.length - 1];
+    const sameHint =
+      last?.hint?.translation === token.hint?.translation &&
+      last?.hint?.pronunciation === token.hint?.pronunciation;
+    const shouldAttachToPrevious =
+      last !== undefined &&
+      !/^\s+$/.test(token.text) &&
+      isLeadingPunctuationToken(token.text);
+    if (
+      last &&
+      (shouldAttachToPrevious ||
+        (sameHint &&
+          last.hidden === token.hidden &&
+          last.revealed === token.revealed &&
+          last.dimmed === token.dimmed))
+    ) {
+      last.text += token.text;
+      continue;
+    }
+    runs.push({
+      key: `${token.start}:${runs.length}`,
+      text: token.text,
+      hidden: token.hidden,
+      revealed: token.revealed,
+      dimmed: token.dimmed,
+      hint: token.hint,
+    });
+  }
+
+  return (
+    <View
+      style={[
+        {
+          minWidth: 0,
+          alignSelf: fillLineWidth ? "stretch" : "flex-start",
+          width: fillLineWidth ? "100%" : undefined,
+        },
+        containerStyle,
+      ]}
+    >
+      {leadingElement && (
+        <View
+          style={[
+            {
+              position: "absolute",
+              top: 2,
+              zIndex: 1,
+            },
+            rtl ? { right: 0 } : { left: 0 },
+          ]}
+        >
+          {leadingElement}
+        </View>
+      )}
+      <Text
+        style={[
+          flatStyle,
+          {
+            minWidth: 0,
+            writingDirection: rtl ? "rtl" : "ltr",
+            textAlign: centered ? "center" : "auto",
+            alignSelf: fillLineWidth ? "stretch" : "flex-start",
+          },
+          leadingElement
+            ? rtl
+              ? { paddingRight: NATIVE_TEXT_AUDIO_PADDING }
+              : { paddingLeft: NATIVE_TEXT_AUDIO_PADDING }
+            : undefined,
+        ]}
+      >
+        {runs.map((run) => {
+          const interactive = Boolean(run.hint) && !run.hidden;
+          const underline = run.hidden
+            ? colors.hiddenUnderline
+            : run.revealed || interactive
+              ? colors.border
+              : undefined;
+          const color = run.hidden
+            ? "transparent"
+            : run.dimmed
+              ? colors.disabled
+              : (flatStyle.color ?? colors.text);
+
+          return (
+            <Text
+              key={run.key}
+              suppressHighlighting
+              onPress={
+                interactive
+                  ? (event) => {
+                      if (!run.hint) return;
+                      onHintLookup();
+                      popup.show({
+                        translation: run.hint.translation,
+                        pronunciation: run.hint.pronunciation,
+                        x: event.nativeEvent.pageX,
+                        y: event.nativeEvent.pageY,
+                      });
+                    }
+                  : undefined
+              }
+              style={[
+                flatStyle,
+                {
+                  color,
+                  textDecorationLine: underline ? "underline" : "none",
+                  textDecorationColor: underline,
+                  textDecorationStyle: run.hidden ? "solid" : "dotted",
+                },
+              ]}
+            >
+              {run.text}
+            </Text>
+          );
+        })}
+      </Text>
+    </View>
+  );
+}
+
+export function HintText({
+  content,
+  audioRange,
+  hideRangesForChallenge,
+  unhide,
+  showHints = true,
+  style,
+  containerStyle,
+  leadingElement,
+  lang,
+  rtl = false,
+  centered = false,
+  fillLineWidth = false,
+  renderMode = "auto",
+}: {
+  content: ContentWithHints;
+  /** Highest spoken character index during playback (99999 = idle). */
+  audioRange?: number;
+  hideRangesForChallenge?: HideRange[];
+  /** Progressive reveal for arrange/continuation (-1 reveals everything). */
+  unhide?: number;
+  showHints?: boolean;
+  style?: StyleProp<TextStyle>;
+  containerStyle?: ViewStyle;
+  leadingElement?: React.ReactNode;
+  lang?: string;
+  rtl?: boolean;
+  centered?: boolean;
+  fillLineWidth?: boolean;
+  renderMode?: HintTextRenderMode;
+}) {
+  const { colors } = useTheme();
+  const popup = React.useContext(HintPopupContext);
+  const onHintLookup = React.useContext(HintLookupContext);
+
+  if (!content) return null;
+
   const flatStyle = StyleSheet.flatten(style) ?? {};
+  const tokens = buildTokens({
+    content,
+    audioRange,
+    hideRangesForChallenge,
+    showHints,
+    unhide,
+  });
+  const resolvedRenderMode =
+    renderMode === "auto"
+      ? (shouldUseNativeTextLayout(lang) ? "native" : "tokenized")
+      : renderMode;
+
+  if (resolvedRenderMode === "native") {
+    return (
+      <NativeHintText
+        tokens={tokens}
+        flatStyle={flatStyle}
+        containerStyle={containerStyle}
+        leadingElement={leadingElement}
+        rtl={rtl}
+        centered={centered}
+        fillLineWidth={fillLineWidth}
+      />
+    );
+  }
 
   const renderBox = (token: Token, key: React.Key) => {
     // Story texts contain runs of spaces (HTML collapses them, RN

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -8,7 +8,7 @@ import {
   View,
   type ViewStyle,
 } from "react-native";
-import Svg, { Line, Rect } from "react-native-svg";
+import Svg, { Circle, Line, Rect } from "react-native-svg";
 import { Text } from "../components/Text";
 import { type ThemeColors, useTheme } from "../theme";
 import { HintLookupContext, HintPopupContext } from "./HintPopup";
@@ -24,6 +24,8 @@ const WRAPPED_LINE_GAP = 3;
 const NATIVE_TEXT_AUDIO_PADDING = 32;
 const SHOW_NATIVE_HINT_DEBUG = false;
 const UNDERLINE_EDGE_INSET = 2;
+const UNDERLINE_DOT_RADIUS = 1.2;
+const UNDERLINE_DOT_GAP = 7;
 
 type HintTextRenderMode = "auto" | "native" | "tokenized";
 
@@ -555,16 +557,37 @@ function NativeHintText({
         ))}
         {underlineSegments.map((segment) => (
           <React.Fragment key={segment.key}>
-            <Line
-              x1={segment.x1}
-              x2={segment.x2}
-              y1={segment.y}
-              y2={segment.y}
-              stroke={segment.color}
-              strokeWidth={segment.dotted ? 1.5 : 2}
-              strokeLinecap="round"
-              strokeDasharray={segment.dotted ? [1, 4] : undefined}
-            />
+            {segment.dotted ? (
+              Array.from({
+                length: Math.max(
+                  1,
+                  Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
+                ),
+              }).map((_, index) => {
+                const cx = Math.min(
+                  segment.x2,
+                  segment.x1 + index * UNDERLINE_DOT_GAP,
+                );
+                return (
+                  <Circle
+                    key={`${segment.key}:${index}`}
+                    cx={cx}
+                    cy={segment.y}
+                    r={UNDERLINE_DOT_RADIUS}
+                    fill={segment.color}
+                  />
+                );
+              })
+            ) : (
+              <Line
+                x1={segment.x1}
+                x2={segment.x2}
+                y1={segment.y}
+                y2={segment.y}
+                stroke={segment.color}
+                strokeWidth={2}
+              />
+            )}
           </React.Fragment>
         ))}
       </Svg>

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -23,6 +23,7 @@ import type { ContentWithHints, HideRange } from "./types";
 const WRAPPED_LINE_GAP = 3;
 const NATIVE_TEXT_AUDIO_PADDING = 32;
 const SHOW_NATIVE_HINT_DEBUG = false;
+const UNDERLINE_EDGE_INSET = 2;
 
 type HintTextRenderMode = "auto" | "native" | "tokenized";
 
@@ -50,10 +51,12 @@ type Token = {
   revealed: boolean;
   dimmed: boolean;
   hint?: { translation: string; pronunciation?: string };
+  hintGroupKey?: string;
 };
 
 type NativeSegment = Token & {
   key: string;
+  underlineGroupKey?: string;
 };
 
 function getDisplayText(token: Token): string {
@@ -71,28 +74,21 @@ function isWrapAnywhereToken(text: string): boolean {
   );
 }
 
-function isLeadingPunctuationToken(text: string): boolean {
-  const normalized = text.replace(/[\u200b-\u200d\ufeff]/g, "");
-  return /^[,.:;!?%)}\]\u3001\u3002\u30fb\u30fc\uff01\uff1f\uff09\uff0c\uff0e]+$/u.test(
-    normalized,
-  );
-}
-
 function buildNativeSegments(tokens: Token[]): NativeSegment[] {
   const segments: NativeSegment[] = [];
 
   for (const token of tokens) {
     const parts = isWrapAnywhereToken(token.text) ? Array.from(token.text) : [token.text];
     for (const part of parts) {
-      const last = segments[segments.length - 1];
-      if (last && isLeadingPunctuationToken(part)) {
-        last.text += part;
-        continue;
-      }
       segments.push({
         ...token,
         text: part,
         key: `${token.start}:${segments.length}`,
+        underlineGroupKey: token.hidden
+          ? `hidden:${token.start}`
+          : token.revealed
+            ? `revealed:${token.start}`
+            : token.hintGroupKey,
       });
     }
   }
@@ -317,6 +313,7 @@ function buildTokens({
     start: number,
     end: number,
     hint?: Token["hint"],
+    hintGroupKey?: string,
   ): void => {
     const pieces = splitTextTokens(visible.text.substring(start, end));
     let position = start;
@@ -346,6 +343,7 @@ function buildTokens({
             (audioRange === 0 ||
               (audioRange > 0 && audioRange < pieceStart)),
           hint,
+          hintGroupKey,
         });
       }
     }
@@ -356,10 +354,14 @@ function buildTokens({
     if (hint.rangeFrom > textPos) pushRun(textPos, hint.rangeFrom);
     const translation = visible.hints?.[hint.hintIndex];
     const pronunciation = visible.hints_pronunciation?.[hint.hintIndex];
+    const hintGroupKey = translation
+      ? `hint:${hint.rangeFrom}:${hint.rangeTo}:${hint.hintIndex}`
+      : undefined;
     pushRun(
       hint.rangeFrom,
       hint.rangeTo + 1,
       translation ? { translation, pronunciation } : undefined,
+      hintGroupKey,
     );
     textPos = hint.rangeTo + 1;
   }
@@ -402,9 +404,11 @@ function NativeHintText({
       y: number;
       width: number;
       height: number;
+      text: string;
       hidden: boolean;
       revealed: boolean;
       hint?: Token["hint"];
+      underlineGroupKey?: string;
     }> = [];
     let segmentIndex = 0;
 
@@ -424,9 +428,11 @@ function NativeHintText({
           y: textLayout.y + line.y,
           width,
           height: line.height,
+          text: segment.text,
           hidden: segment.hidden,
           revealed: segment.revealed,
           hint: segment.hint,
+          underlineGroupKey: segment.underlineGroupKey,
         });
 
         cursor += width;
@@ -446,6 +452,7 @@ function NativeHintText({
       y: number;
       color: string;
       dotted: boolean;
+      underlineGroupKey?: string;
       debugX: number;
       debugY: number;
       debugWidth: number;
@@ -461,13 +468,16 @@ function NativeHintText({
           ? colors.border
           : undefined;
       if (!underline) continue;
+      if (/^[,.:;!?%)}\]\u3001\u3002\u30fb\u30fc\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(segment.text))
+        continue;
       segmentsToDraw.push({
         key: segment.key,
-        x1: segment.x,
-        x2: segment.x + segment.width,
+        x1: segment.x + UNDERLINE_EDGE_INSET,
+        x2: segment.x + Math.max(segment.width - UNDERLINE_EDGE_INSET, UNDERLINE_EDGE_INSET * 2),
         y: segment.y + segment.height - 6,
         color: underline,
         dotted: !segment.hidden,
+        underlineGroupKey: segment.underlineGroupKey,
         debugX: segment.x,
         debugY: segment.y,
         debugWidth: segment.width,
@@ -488,7 +498,8 @@ function NativeHintText({
         Math.abs(last.y - segment.y) <= 2 &&
         Math.abs(last.x2 - segment.x1) <= 4 &&
         last.color === segment.color &&
-        last.dotted === segment.dotted
+        last.dotted === segment.dotted &&
+        last.underlineGroupKey === segment.underlineGroupKey
       ) {
         last.x2 = segment.x2;
         last.debugWidth = segment.debugX + segment.debugWidth - last.debugX;

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -8,6 +8,7 @@ import {
   View,
   type ViewStyle,
 } from "react-native";
+import Svg, { Line, Rect } from "react-native-svg";
 import { Text } from "../components/Text";
 import { type ThemeColors, useTheme } from "../theme";
 import { HintLookupContext, HintPopupContext } from "./HintPopup";
@@ -21,6 +22,7 @@ import type { ContentWithHints, HideRange } from "./types";
 
 const WRAPPED_LINE_GAP = 3;
 const NATIVE_TEXT_AUDIO_PADDING = 32;
+const SHOW_NATIVE_HINT_DEBUG = false;
 
 type HintTextRenderMode = "auto" | "native" | "tokenized";
 
@@ -50,6 +52,10 @@ type Token = {
   hint?: { translation: string; pronunciation?: string };
 };
 
+type NativeSegment = Token & {
+  key: string;
+};
+
 function getDisplayText(token: Token): string {
   return token.text.replace(/\s+/g, " ");
 }
@@ -59,11 +65,39 @@ function shouldUseNativeTextLayout(lang?: string): boolean {
   return /^(ja|zh|ko)(-|$)/i.test(lang);
 }
 
+function isWrapAnywhereToken(text: string): boolean {
+  return /^[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]+$/u.test(
+    text,
+  );
+}
+
 function isLeadingPunctuationToken(text: string): boolean {
   const normalized = text.replace(/[\u200b-\u200d\ufeff]/g, "");
   return /^[,.:;!?%)}\]\u3001\u3002\u30fb\u30fc\uff01\uff1f\uff09\uff0c\uff0e]+$/u.test(
     normalized,
   );
+}
+
+function buildNativeSegments(tokens: Token[]): NativeSegment[] {
+  const segments: NativeSegment[] = [];
+
+  for (const token of tokens) {
+    const parts = isWrapAnywhereToken(token.text) ? Array.from(token.text) : [token.text];
+    for (const part of parts) {
+      const last = segments[segments.length - 1];
+      if (last && isLeadingPunctuationToken(part)) {
+        last.text += part;
+        continue;
+      }
+      segments.push({
+        ...token,
+        text: part,
+        key: `${token.start}:${segments.length}`,
+      });
+    }
+  }
+
+  return segments;
 }
 
 function HintTokenBox({
@@ -354,46 +388,132 @@ function NativeHintText({
   const { colors } = useTheme();
   const popup = React.useContext(HintPopupContext);
   const onHintLookup = React.useContext(HintLookupContext);
+  const segments = React.useMemo(() => buildNativeSegments(tokens), [tokens]);
+  const [textLayout, setTextLayout] = React.useState({ x: 0, y: 0, width: 0, height: 0 });
+  const [lineLayouts, setLineLayouts] = React.useState<
+    { text: string; x: number; y: number; width: number; height: number }[]
+  >([]);
+  const [segmentWidths, setSegmentWidths] = React.useState<Record<string, number>>({});
 
-  type InlineRun = {
-    key: string;
-    text: string;
-    hidden: boolean;
-    revealed: boolean;
-    dimmed: boolean;
-    hint?: Token["hint"];
-  };
+  const computedSegments = React.useMemo(() => {
+    const rects: Array<{
+      key: string;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      hidden: boolean;
+      revealed: boolean;
+      hint?: Token["hint"];
+    }> = [];
+    let segmentIndex = 0;
 
-  const runs: InlineRun[] = [];
-  for (const token of tokens) {
-    const last = runs[runs.length - 1];
-    const sameHint =
-      last?.hint?.translation === token.hint?.translation &&
-      last?.hint?.pronunciation === token.hint?.pronunciation;
-    const shouldAttachToPrevious =
-      last !== undefined &&
-      !/^\s+$/.test(token.text) &&
-      isLeadingPunctuationToken(token.text);
-    if (
-      last &&
-      (shouldAttachToPrevious ||
-        (sameHint &&
-          last.hidden === token.hidden &&
-          last.revealed === token.revealed &&
-          last.dimmed === token.dimmed))
-    ) {
-      last.text += token.text;
-      continue;
+    for (const line of lineLayouts) {
+      let cursor = line.x;
+      let lineText = line.text;
+
+      while (lineText.length > 0 && segmentIndex < segments.length) {
+        const segment = segments[segmentIndex];
+        const width = segmentWidths[segment.key];
+        if (width === undefined) break;
+        if (!lineText.startsWith(segment.text)) break;
+
+        rects.push({
+          key: segment.key,
+          x: textLayout.x + cursor,
+          y: textLayout.y + line.y,
+          width,
+          height: line.height,
+          hidden: segment.hidden,
+          revealed: segment.revealed,
+          hint: segment.hint,
+        });
+
+        cursor += width;
+        lineText = lineText.slice(segment.text.length);
+        segmentIndex += 1;
+      }
     }
-    runs.push({
-      key: `${token.start}:${runs.length}`,
-      text: token.text,
-      hidden: token.hidden,
-      revealed: token.revealed,
-      dimmed: token.dimmed,
-      hint: token.hint,
+
+    return rects;
+  }, [lineLayouts, segmentWidths, segments, textLayout.x, textLayout.y]);
+
+  const underlineSegments = React.useMemo(() => {
+    type UnderlineSegment = {
+      key: string;
+      x1: number;
+      x2: number;
+      y: number;
+      color: string;
+      dotted: boolean;
+      debugX: number;
+      debugY: number;
+      debugWidth: number;
+      debugHeight: number;
+    };
+
+    const segmentsToDraw: UnderlineSegment[] = [];
+    for (const segment of computedSegments) {
+      const interactive = Boolean(segment.hint) && !segment.hidden;
+      const underline = segment.hidden
+        ? colors.hiddenUnderline
+        : segment.revealed || interactive
+          ? colors.border
+          : undefined;
+      if (!underline) continue;
+      segmentsToDraw.push({
+        key: segment.key,
+        x1: segment.x,
+        x2: segment.x + segment.width,
+        y: segment.y + segment.height - 6,
+        color: underline,
+        dotted: !segment.hidden,
+        debugX: segment.x,
+        debugY: segment.y,
+        debugWidth: segment.width,
+        debugHeight: segment.height,
+      });
+    }
+
+    segmentsToDraw.sort((a, b) => {
+      if (Math.abs(a.y - b.y) > 2) return a.y - b.y;
+      return a.x1 - b.x1;
     });
-  }
+
+    const merged: UnderlineSegment[] = [];
+    for (const segment of segmentsToDraw) {
+      const last = merged[merged.length - 1];
+      if (
+        last &&
+        Math.abs(last.y - segment.y) <= 2 &&
+        Math.abs(last.x2 - segment.x1) <= 4 &&
+        last.color === segment.color &&
+        last.dotted === segment.dotted
+      ) {
+        last.x2 = segment.x2;
+        last.debugWidth = segment.debugX + segment.debugWidth - last.debugX;
+        last.debugHeight = Math.max(last.debugHeight, segment.debugHeight);
+        continue;
+      }
+      merged.push(segment);
+    }
+
+    return merged;
+  }, [colors.border, colors.hiddenUnderline, computedSegments]);
+
+  const debugRects = React.useMemo(
+    () =>
+      SHOW_NATIVE_HINT_DEBUG
+        ? computedSegments.map((segment) => ({
+            key: segment.key,
+            x: segment.x,
+            y: segment.y,
+            width: segment.width,
+            height: segment.height,
+          }))
+        : [],
+    [computedSegments],
+  );
 
   return (
     <View
@@ -406,6 +526,37 @@ function NativeHintText({
         containerStyle,
       ]}
     >
+      <Svg
+        pointerEvents="none"
+        style={StyleSheet.absoluteFill}
+      >
+        {debugRects.map((segment) => (
+          <Rect
+            key={`debug:${segment.key}`}
+            x={segment.x}
+            y={segment.y}
+            width={segment.width}
+            height={segment.height}
+            stroke="#ff4d4f"
+            strokeWidth={1}
+            fill="rgba(255,77,79,0.08)"
+          />
+        ))}
+        {underlineSegments.map((segment) => (
+          <React.Fragment key={segment.key}>
+            <Line
+              x1={segment.x1}
+              x2={segment.x2}
+              y1={segment.y}
+              y2={segment.y}
+              stroke={segment.color}
+              strokeWidth={segment.dotted ? 1.5 : 2}
+              strokeLinecap="round"
+              strokeDasharray={segment.dotted ? [1, 4] : undefined}
+            />
+          </React.Fragment>
+        ))}
+      </Svg>
       {leadingElement && (
         <View
           style={[
@@ -421,6 +572,20 @@ function NativeHintText({
         </View>
       )}
       <Text
+        onLayout={(event) => {
+          setTextLayout(event.nativeEvent.layout);
+        }}
+        onTextLayout={(event) => {
+          setLineLayouts(
+            event.nativeEvent.lines.map((line) => ({
+              text: line.text,
+              x: line.x,
+              y: line.y,
+              width: line.width,
+              height: line.height,
+            })),
+          );
+        }}
         style={[
           flatStyle,
           {
@@ -436,31 +601,26 @@ function NativeHintText({
             : undefined,
         ]}
       >
-        {runs.map((run) => {
-          const interactive = Boolean(run.hint) && !run.hidden;
-          const underline = run.hidden
-            ? colors.hiddenUnderline
-            : run.revealed || interactive
-              ? colors.border
-              : undefined;
-          const color = run.hidden
+        {segments.map((segment) => {
+          const interactive = Boolean(segment.hint) && !segment.hidden;
+          const color = segment.hidden
             ? "transparent"
-            : run.dimmed
+            : segment.dimmed
               ? colors.disabled
               : (flatStyle.color ?? colors.text);
 
           return (
             <Text
-              key={run.key}
+              key={segment.key}
               suppressHighlighting
               onPress={
                 interactive
                   ? (event) => {
-                      if (!run.hint) return;
+                      if (!segment.hint) return;
                       onHintLookup();
                       popup.show({
-                        translation: run.hint.translation,
-                        pronunciation: run.hint.pronunciation,
+                        translation: segment.hint.translation,
+                        pronunciation: segment.hint.pronunciation,
                         x: event.nativeEvent.pageX,
                         y: event.nativeEvent.pageY,
                       });
@@ -471,17 +631,41 @@ function NativeHintText({
                 flatStyle,
                 {
                   color,
-                  textDecorationLine: underline ? "underline" : "none",
-                  textDecorationColor: underline,
-                  textDecorationStyle: run.hidden ? "solid" : "dotted",
                 },
               ]}
             >
-              {run.text}
+              {segment.text}
             </Text>
           );
         })}
       </Text>
+      <View
+        pointerEvents="none"
+        style={{
+          position: "absolute",
+          opacity: 0,
+          left: -10000,
+          top: 0,
+          flexDirection: "row",
+          flexWrap: "nowrap",
+        }}
+      >
+        {segments.map((segment) => (
+          <Text
+            key={`measure:${segment.key}`}
+            onLayout={(event) => {
+              const width = event.nativeEvent.layout.width;
+              setSegmentWidths((current) => {
+                if (current[segment.key] === width) return current;
+                return { ...current, [segment.key]: width };
+              });
+            }}
+            style={[flatStyle, { lineHeight: undefined }]}
+          >
+            {segment.text}
+          </Text>
+        ))}
+      </View>
     </View>
   );
 }

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -496,13 +496,23 @@ function NativeHintText({
     const merged: UnderlineSegment[] = [];
     for (const segment of segmentsToDraw) {
       const last = merged[merged.length - 1];
-      if (
+      const sameGroupOnSameLine =
         last &&
         Math.abs(last.y - segment.y) <= 2 &&
-        Math.abs(last.x2 - segment.x1) <= 4 &&
         last.color === segment.color &&
         last.dotted === segment.dotted &&
-        last.underlineGroupKey === segment.underlineGroupKey
+        last.underlineGroupKey !== undefined &&
+        last.underlineGroupKey === segment.underlineGroupKey;
+      if (
+        sameGroupOnSameLine ||
+        (
+          last &&
+          Math.abs(last.y - segment.y) <= 2 &&
+          Math.abs(last.x2 - segment.x1) <= 4 &&
+          last.color === segment.color &&
+          last.dotted === segment.dotted &&
+          last.underlineGroupKey === segment.underlineGroupKey
+        )
       ) {
         last.x2 = segment.x2;
         last.debugWidth = segment.debugX + segment.debugWidth - last.debugX;

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -729,6 +729,7 @@ function NativeHintText({
     }
 
     const segmentsToDraw: UnderlineSegment[] = [];
+    const hiddenGroupSpans = new Map<string, UnderlineSegment>();
     for (const segment of computedSegments) {
       const interactive = Boolean(segment.hint) && !segment.hidden;
       const underline = segment.hidden
@@ -737,6 +738,36 @@ function NativeHintText({
           ? colors.border
           : undefined;
       if (!underline) continue;
+
+      if (segment.hidden && segment.underlineGroupKey) {
+        const y = getUnderlineY(segment);
+        const lineKey = `${segment.underlineGroupKey}:${Math.round(y)}`;
+        const existing = hiddenGroupSpans.get(lineKey);
+        if (existing) {
+          const right = Math.max(existing.x2, segment.x + segment.width);
+          existing.x1 = Math.min(existing.x1, segment.x);
+          existing.x2 = right;
+          existing.debugX = Math.min(existing.debugX, segment.x);
+          existing.debugWidth = right - existing.debugX;
+          existing.debugHeight = Math.max(existing.debugHeight, segment.height);
+        } else {
+          hiddenGroupSpans.set(lineKey, {
+            key: lineKey,
+            x1: segment.x,
+            x2: segment.x + segment.width,
+            y,
+            color: underline,
+            dotted: false,
+            underlineGroupKey: segment.underlineGroupKey,
+            debugX: segment.x,
+            debugY: segment.y,
+            debugWidth: segment.width,
+            debugHeight: segment.height,
+          });
+        }
+        continue;
+      }
+
       if (/^\s+$/.test(segment.text) && !segment.underlineGroupKey) continue;
       if (/^[,.:;!?%)}\]\u3001\u3002\u30fb\u30fc\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(segment.text))
         continue;
@@ -752,6 +783,13 @@ function NativeHintText({
         debugY: segment.y,
         debugWidth: segment.width,
         debugHeight: segment.height,
+      });
+    }
+    for (const segment of hiddenGroupSpans.values()) {
+      segmentsToDraw.push({
+        ...segment,
+        x1: segment.x1 + UNDERLINE_EDGE_INSET,
+        x2: segment.x2 - UNDERLINE_EDGE_INSET,
       });
     }
 

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -769,7 +769,7 @@ function NativeHintText({
       }
 
       if (/^\s+$/.test(segment.text) && !segment.underlineGroupKey) continue;
-      if (/^[,.:;!?%)}\]\u3001\u3002\u30fb\u30fc\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(segment.text))
+      if (/^[,.:;!?%)}\]\u3001\u3002\u30fb\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(segment.text))
         continue;
       segmentsToDraw.push({
         key: segment.key,

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -470,6 +470,7 @@ function NativeHintText({
           ? colors.border
           : undefined;
       if (!underline) continue;
+      if (/^\s+$/.test(segment.text)) continue;
       if (/^[,.:;!?%)}\]\u3001\u3002\u30fb\u30fc\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(segment.text))
         continue;
       segmentsToDraw.push({

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -58,6 +58,7 @@ type Token = {
   text: string;
   start: number;
   hidden: boolean;
+  hiddenGroupKey?: string;
   revealed: boolean;
   dimmed: boolean;
   hint?: { translation: string; pronunciation?: string };
@@ -105,7 +106,7 @@ function buildNativeSegments(tokens: Token[]): NativeSegment[] {
         key: `${token.start}:${segments.length}`,
         tokenKey: `${token.start}:${token.text}`,
         underlineGroupKey: token.hidden
-          ? `hidden:${token.start}`
+          ? token.hiddenGroupKey
           : token.revealed
             ? `revealed:${token.start}`
             : token.hintGroupKey,
@@ -348,6 +349,7 @@ function buildTokens({
   }
 
   const tokens: Token[] = [];
+  const hiddenGroupKey = entry ? `hidden:${entry.start}:${entry.end}` : undefined;
 
   const pushRun = (
     start: number,
@@ -365,26 +367,49 @@ function buildTokens({
         const pieceStart = position;
         const pieceEnd = position + sub.length;
         position = pieceEnd;
-        const hidden =
-          entry !== undefined &&
-          getOverlap(pieceStart, pieceEnd, entry.start, entry.end);
-        const wasHidden = Boolean(
-          hideRangesForChallenge?.some((range) =>
-            getOverlap(pieceStart, pieceEnd, range.start, range.end),
-          ),
-        );
-        tokens.push({
-          text: sub,
-          start: pieceStart,
-          hidden,
-          revealed: wasHidden && !hidden,
-          dimmed:
-            audioRange !== undefined &&
-            (audioRange === 0 ||
-              (audioRange > 0 && audioRange < pieceStart)),
-          hint,
-          hintGroupKey,
-        });
+        const boundaries = new Set([pieceStart, pieceEnd]);
+
+        if (entry) {
+          if (entry.start > pieceStart && entry.start < pieceEnd)
+            boundaries.add(entry.start);
+          if (entry.end > pieceStart && entry.end < pieceEnd)
+            boundaries.add(entry.end);
+        }
+        for (const range of hideRangesForChallenge ?? []) {
+          if (range.start > pieceStart && range.start < pieceEnd)
+            boundaries.add(range.start);
+          if (range.end > pieceStart && range.end < pieceEnd)
+            boundaries.add(range.end);
+        }
+
+        const sortedBoundaries = Array.from(boundaries).sort((a, b) => a - b);
+        for (let index = 0; index < sortedBoundaries.length - 1; index += 1) {
+          const fragmentStart = sortedBoundaries[index];
+          const fragmentEnd = sortedBoundaries[index + 1];
+          if (fragmentStart === undefined || fragmentEnd === undefined) continue;
+
+          const hidden =
+            entry !== undefined &&
+            getOverlap(fragmentStart, fragmentEnd, entry.start, entry.end);
+          const wasHidden = Boolean(
+            hideRangesForChallenge?.some((range) =>
+              getOverlap(fragmentStart, fragmentEnd, range.start, range.end),
+            ),
+          );
+          tokens.push({
+            text: sub.slice(fragmentStart - pieceStart, fragmentEnd - pieceStart),
+            start: fragmentStart,
+            hidden,
+            hiddenGroupKey: hidden ? hiddenGroupKey : undefined,
+            revealed: wasHidden && !hidden,
+            dimmed:
+              audioRange !== undefined &&
+              (audioRange === 0 ||
+                (audioRange > 0 && audioRange < fragmentStart)),
+            hint,
+            hintGroupKey,
+          });
+        }
       }
     }
   };
@@ -590,6 +615,42 @@ function NativeHintText({
     return fragments;
   }, [computedSegments]);
 
+  const hiddenCovers = React.useMemo(() => {
+    type HiddenCover = {
+      key: string;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    };
+
+    const covers: HiddenCover[] = [];
+    for (const segment of computedSegments) {
+      if (!segment.hidden) continue;
+      const last = covers[covers.length - 1];
+      const x = segment.x - 1;
+      const width = segment.width + 2;
+      if (
+        last &&
+        Math.abs(last.y - segment.y) <= 2 &&
+        Math.abs(last.x + last.width - x) <= 2
+      ) {
+        last.width = x + width - last.x;
+        last.height = Math.max(last.height, segment.height);
+        continue;
+      }
+      covers.push({
+        key: `hidden:${segment.key}`,
+        x,
+        y: segment.y,
+        width,
+        height: segment.height,
+      });
+    }
+
+    return covers;
+  }, [computedSegments]);
+
   const showMeasuredHint = React.useCallback(
     (
       token: Token,
@@ -771,75 +832,6 @@ function NativeHintText({
         containerStyle,
       ]}
     >
-      <Svg
-        pointerEvents="none"
-        style={StyleSheet.absoluteFill}
-      >
-        {debugRects.map((segment) => (
-          <React.Fragment key={`debug:${segment.key}`}>
-            <Rect
-              x={segment.x}
-              y={segment.y}
-              width={segment.width}
-              height={segment.height}
-              stroke={segment.stroke}
-              strokeWidth={1}
-              fill={segment.fill}
-            />
-            <SvgText
-              x={segment.x}
-              y={segment.y - 2}
-              fontSize="10"
-              fill={segment.stroke}
-            >
-              {segment.groupLabel ?? "none"}
-            </SvgText>
-            <SvgText
-              x={segment.x + 1}
-              y={segment.y + segment.height - 10}
-              fontSize="8"
-              fill={segment.stroke}
-            >
-              {segment.text}
-            </SvgText>
-          </React.Fragment>
-        ))}
-        {underlineSegments.map((segment) => (
-          <React.Fragment key={segment.key}>
-            {segment.dotted ? (
-              Array.from({
-                length: Math.max(
-                  1,
-                  Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
-                ),
-              }).map((_, index) => {
-                const cx = Math.min(
-                  segment.x2,
-                  segment.x1 + index * UNDERLINE_DOT_GAP,
-                );
-                return (
-                  <Circle
-                    key={`${segment.key}:${index}`}
-                    cx={cx}
-                    cy={segment.y}
-                    r={UNDERLINE_DOT_RADIUS}
-                    fill={segment.color}
-                  />
-                );
-              })
-            ) : (
-              <Line
-                x1={segment.x1}
-                x2={segment.x2}
-                y1={segment.y}
-                y2={segment.y}
-                stroke={segment.color}
-                strokeWidth={2}
-              />
-            )}
-          </React.Fragment>
-        ))}
-      </Svg>
       <Text
         onLayout={(event) => {
           setTextLayout(event.nativeEvent.layout);
@@ -907,6 +899,7 @@ function NativeHintText({
                 flatStyle,
                 {
                   color,
+                  opacity: token.hidden ? 0 : 1,
                 },
               ]}
             >
@@ -915,6 +908,82 @@ function NativeHintText({
           );
         })}
       </Text>
+      <Svg pointerEvents="none" style={StyleSheet.absoluteFill}>
+        {hiddenCovers.map((cover) => (
+          <Rect
+            key={cover.key}
+            x={cover.x}
+            y={cover.y}
+            width={cover.width}
+            height={cover.height}
+            fill={colors.surface}
+          />
+        ))}
+        {debugRects.map((segment) => (
+          <React.Fragment key={`debug:${segment.key}`}>
+            <Rect
+              x={segment.x}
+              y={segment.y}
+              width={segment.width}
+              height={segment.height}
+              stroke={segment.stroke}
+              strokeWidth={1}
+              fill={segment.fill}
+            />
+            <SvgText
+              x={segment.x}
+              y={segment.y - 2}
+              fontSize="10"
+              fill={segment.stroke}
+            >
+              {segment.groupLabel ?? "none"}
+            </SvgText>
+            <SvgText
+              x={segment.x + 1}
+              y={segment.y + segment.height - 10}
+              fontSize="8"
+              fill={segment.stroke}
+            >
+              {segment.text}
+            </SvgText>
+          </React.Fragment>
+        ))}
+        {underlineSegments.map((segment) => (
+          <React.Fragment key={segment.key}>
+            {segment.dotted ? (
+              Array.from({
+                length: Math.max(
+                  1,
+                  Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
+                ),
+              }).map((_, index) => {
+                const cx = Math.min(
+                  segment.x2,
+                  segment.x1 + index * UNDERLINE_DOT_GAP,
+                );
+                return (
+                  <Circle
+                    key={`${segment.key}:${index}`}
+                    cx={cx}
+                    cy={segment.y}
+                    r={UNDERLINE_DOT_RADIUS}
+                    fill={segment.color}
+                  />
+                );
+              })
+            ) : (
+              <Line
+                x1={segment.x1}
+                x2={segment.x2}
+                y1={segment.y}
+                y2={segment.y}
+                stroke={segment.color}
+                strokeWidth={2}
+              />
+            )}
+          </React.Fragment>
+        ))}
+      </Svg>
       <View
         pointerEvents="none"
         style={{

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -5,12 +5,18 @@ import {
   StyleSheet,
   type StyleProp,
   type TextStyle,
+  type View as NativeView,
   View,
   type ViewStyle,
 } from "react-native";
-import Svg, { Circle, Line, Rect } from "react-native-svg";
+import Svg, { Circle, Line, Rect, Text as SvgText } from "react-native-svg";
 import { Text } from "../components/Text";
 import { type ThemeColors, useTheme } from "../theme";
+import {
+  PLAY_AUDIO_ICON_FONT_FAMILY,
+  PLAY_AUDIO_ICON_GLYPH,
+  PLAY_AUDIO_ICON_SIZE,
+} from "./elements/PlayAudioButton";
 import { HintLookupContext, HintPopupContext } from "./HintPopup";
 import type { ContentWithHints, HideRange } from "./types";
 
@@ -21,11 +27,13 @@ import type { ContentWithHints, HideRange } from "./types";
 // underlines are real (dashed) bottom borders.
 
 const WRAPPED_LINE_GAP = 3;
-const NATIVE_TEXT_AUDIO_PADDING = 32;
 const SHOW_NATIVE_HINT_DEBUG = false;
 const UNDERLINE_EDGE_INSET = 2;
 const UNDERLINE_DOT_RADIUS = 1.2;
 const UNDERLINE_DOT_GAP = 7;
+const INLINE_AUDIO_SPACE = "\u2002";
+const UNDERLINE_BASELINE_GAP = 2;
+const UNDERLINE_BOTTOM_INSET = 2;
 
 type HintTextRenderMode = "auto" | "native" | "tokenized";
 
@@ -58,7 +66,9 @@ type Token = {
 
 type NativeSegment = Token & {
   key: string;
+  tokenKey: string;
   underlineGroupKey?: string;
+  textStyle?: TextStyle;
 };
 
 function getDisplayText(token: Token): string {
@@ -66,26 +76,34 @@ function getDisplayText(token: Token): string {
 }
 
 function shouldUseNativeTextLayout(lang?: string): boolean {
-  if (!lang) return false;
-  return /^(ja|zh|ko)(-|$)/i.test(lang);
+  return Boolean(lang);
 }
 
-function isWrapAnywhereToken(text: string): boolean {
-  return /^[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]+$/u.test(
-    text,
-  );
+function splitIntoGraphemes(text: string): string[] {
+  if (!text) return [];
+  if (/^\s+$/.test(text)) return [text];
+
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    const segmenter = new Intl.Segmenter(undefined, {
+      granularity: "grapheme",
+    });
+    return Array.from(segmenter.segment(text), (part) => part.segment);
+  }
+
+  return Array.from(text);
 }
 
 function buildNativeSegments(tokens: Token[]): NativeSegment[] {
   const segments: NativeSegment[] = [];
 
   for (const token of tokens) {
-    const parts = isWrapAnywhereToken(token.text) ? Array.from(token.text) : [token.text];
+    const parts = splitIntoGraphemes(token.text);
     for (const part of parts) {
       segments.push({
         ...token,
         text: part,
         key: `${token.start}:${segments.length}`,
+        tokenKey: `${token.start}:${token.text}`,
         underlineGroupKey: token.hidden
           ? `hidden:${token.start}`
           : token.revealed
@@ -96,6 +114,26 @@ function buildNativeSegments(tokens: Token[]): NativeSegment[] {
   }
 
   return segments;
+}
+
+function getDebugColor(key?: string): { stroke: string; fill: string } {
+  if (!key) {
+    return {
+      stroke: "#8c8c8c",
+      fill: "rgba(140,140,140,0.12)",
+    };
+  }
+
+  let hash = 0;
+  for (let i = 0; i < key.length; i += 1) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+
+  const hue = hash % 360;
+  return {
+    stroke: `hsl(${hue} 80% 45%)`,
+    fill: `hsla(${hue} 80% 55% / 0.16)`,
+  };
 }
 
 function HintTokenBox({
@@ -376,7 +414,7 @@ function NativeHintText({
   tokens,
   flatStyle,
   containerStyle,
-  leadingElement,
+  inlineAudio,
   rtl,
   centered,
   fillLineWidth,
@@ -384,7 +422,7 @@ function NativeHintText({
   tokens: Token[];
   flatStyle: TextStyle;
   containerStyle?: ViewStyle;
-  leadingElement?: React.ReactNode;
+  inlineAudio?: { onPress: () => void; rtl: boolean; color: string };
   rtl: boolean;
   centered: boolean;
   fillLineWidth: boolean;
@@ -392,24 +430,70 @@ function NativeHintText({
   const { colors } = useTheme();
   const popup = React.useContext(HintPopupContext);
   const onHintLookup = React.useContext(HintLookupContext);
-  const segments = React.useMemo(() => buildNativeSegments(tokens), [tokens]);
+  const containerRef = React.useRef<NativeView>(null);
+  const measurementSegments = React.useMemo(() => {
+    const segments = buildNativeSegments(tokens);
+    if (!inlineAudio) return segments;
+
+    const prefix: NativeSegment[] = [
+      {
+        key: "audio:glyph",
+        text: PLAY_AUDIO_ICON_GLYPH,
+        start: -2,
+        hidden: false,
+        revealed: false,
+        dimmed: false,
+        tokenKey: "audio:glyph",
+        textStyle: {
+          fontFamily: PLAY_AUDIO_ICON_FONT_FAMILY,
+          fontSize: PLAY_AUDIO_ICON_SIZE,
+          color: inlineAudio.color,
+        },
+      },
+      {
+        key: "audio:space",
+        text: INLINE_AUDIO_SPACE,
+        start: -1,
+        hidden: false,
+        revealed: false,
+        dimmed: false,
+        tokenKey: "audio:space",
+      },
+    ];
+
+    return prefix.concat(segments);
+  }, [inlineAudio, tokens]);
   const [textLayout, setTextLayout] = React.useState({ x: 0, y: 0, width: 0, height: 0 });
   const [lineLayouts, setLineLayouts] = React.useState<
-    { text: string; x: number; y: number; width: number; height: number }[]
+    {
+      text: string;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      ascender: number;
+      descender: number;
+      capHeight: number;
+      xHeight: number;
+    }[]
   >([]);
   const [segmentWidths, setSegmentWidths] = React.useState<Record<string, number>>({});
 
   const computedSegments = React.useMemo(() => {
     const rects: Array<{
       key: string;
+      start: number;
       x: number;
       y: number;
       width: number;
       height: number;
+      ascender: number;
+      descender: number;
       text: string;
       hidden: boolean;
       revealed: boolean;
       hint?: Token["hint"];
+      tokenKey: string;
       underlineGroupKey?: string;
     }> = [];
     let segmentIndex = 0;
@@ -418,22 +502,26 @@ function NativeHintText({
       let cursor = line.x;
       let lineText = line.text;
 
-      while (lineText.length > 0 && segmentIndex < segments.length) {
-        const segment = segments[segmentIndex];
+      while (lineText.length > 0 && segmentIndex < measurementSegments.length) {
+        const segment = measurementSegments[segmentIndex];
         const width = segmentWidths[segment.key];
         if (width === undefined) break;
         if (!lineText.startsWith(segment.text)) break;
 
         rects.push({
           key: segment.key,
+          start: segment.start,
           x: textLayout.x + cursor,
           y: textLayout.y + line.y,
           width,
           height: line.height,
+          ascender: line.ascender,
+          descender: line.descender,
           text: segment.text,
           hidden: segment.hidden,
           revealed: segment.revealed,
           hint: segment.hint,
+          tokenKey: segment.tokenKey,
           underlineGroupKey: segment.underlineGroupKey,
         });
 
@@ -444,7 +532,117 @@ function NativeHintText({
     }
 
     return rects;
-  }, [lineLayouts, segmentWidths, segments, textLayout.x, textLayout.y]);
+  }, [lineLayouts, measurementSegments, segmentWidths, textLayout.x, textLayout.y]);
+  const loggedDebugRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!SHOW_NATIVE_HINT_DEBUG || loggedDebugRef.current) return;
+    if (!measurementSegments.some((segment) => segment.text.includes("çel"))) return;
+    if (computedSegments.length === 0) return;
+
+    console.log(
+      "HINT_DEBUG_SEGMENTS",
+      JSON.stringify(
+        computedSegments.map((segment) => ({
+          text: segment.text,
+          group: segment.underlineGroupKey ?? null,
+          x: Math.round(segment.x),
+          width: Math.round(segment.width),
+        })),
+      ),
+    );
+    loggedDebugRef.current = true;
+  }, [computedSegments, measurementSegments]);
+
+  const tokenFragments = React.useMemo(() => {
+    const fragments = new Map<
+      string,
+      Array<{ x1: number; x2: number; y: number; height: number }>
+    >();
+
+    for (const segment of computedSegments) {
+      if (segment.start < 0) continue;
+
+      const list = fragments.get(segment.tokenKey) ?? [];
+      const last = list[list.length - 1];
+      const x1 = segment.x;
+      const x2 = segment.x + segment.width;
+
+      if (
+        last &&
+        Math.abs(last.y - segment.y) <= 2 &&
+        Math.abs(last.x2 - x1) <= 2
+      ) {
+        last.x2 = x2;
+        last.height = Math.max(last.height, segment.height);
+      } else {
+        list.push({
+          x1,
+          x2,
+          y: segment.y,
+          height: segment.height,
+        });
+      }
+
+      fragments.set(segment.tokenKey, list);
+    }
+
+    return fragments;
+  }, [computedSegments]);
+
+  const showMeasuredHint = React.useCallback(
+    (
+      token: Token,
+      tokenKey: string,
+      event: { nativeEvent: { pageX: number; pageY: number } },
+    ) => {
+      if (!token.hint) return;
+
+      const fallbackX = event.nativeEvent.pageX;
+      const fallbackY = event.nativeEvent.pageY;
+      const fragments = tokenFragments.get(tokenKey);
+
+      const showAt = (x: number, y: number) => {
+        onHintLookup();
+        popup.show({
+          translation: token.hint!.translation,
+          pronunciation: token.hint!.pronunciation,
+          x,
+          y,
+        });
+      };
+
+      if (!fragments?.length || !containerRef.current?.measureInWindow) {
+        showAt(fallbackX, fallbackY);
+        return;
+      }
+
+      containerRef.current.measureInWindow((pageLeft, pageTop) => {
+        const localPageY = fallbackY - pageTop;
+        const fragment =
+          fragments.find(
+            (candidate) =>
+              localPageY >= candidate.y &&
+              localPageY <= candidate.y + candidate.height,
+          ) ??
+          fragments.reduce((best, candidate) => {
+            const bestDistance = Math.abs(
+              localPageY - (best.y + best.height / 2),
+            );
+            const candidateDistance = Math.abs(
+              localPageY - (candidate.y + candidate.height / 2),
+            );
+            return candidateDistance < bestDistance ? candidate : best;
+          });
+
+        showAt(
+          pageLeft + (fragment.x1 + fragment.x2) / 2,
+          pageTop + fragment.y,
+        );
+      });
+    },
+    [onHintLookup, popup, tokenFragments],
+  );
 
   const underlineSegments = React.useMemo(() => {
     type UnderlineSegment = {
@@ -460,6 +658,13 @@ function NativeHintText({
       debugWidth: number;
       debugHeight: number;
     };
+
+    function getUnderlineY(segment: (typeof computedSegments)[number]) {
+      const glyphBottom = segment.y + segment.ascender + segment.descender;
+      const preferredY = glyphBottom + UNDERLINE_BASELINE_GAP;
+      const maxY = segment.y + segment.height - UNDERLINE_BOTTOM_INSET;
+      return Math.min(preferredY, maxY);
+    }
 
     const segmentsToDraw: UnderlineSegment[] = [];
     for (const segment of computedSegments) {
@@ -477,7 +682,7 @@ function NativeHintText({
         key: segment.key,
         x1: segment.x + UNDERLINE_EDGE_INSET,
         x2: segment.x + Math.max(segment.width - UNDERLINE_EDGE_INSET, UNDERLINE_EDGE_INSET * 2),
-        y: segment.y + segment.height - 6,
+        y: getUnderlineY(segment),
         color: underline,
         dotted: !segment.hidden,
         underlineGroupKey: segment.underlineGroupKey,
@@ -526,21 +731,37 @@ function NativeHintText({
   }, [colors.border, colors.hiddenUnderline, computedSegments]);
 
   const debugRects = React.useMemo(
-    () =>
-      SHOW_NATIVE_HINT_DEBUG
-        ? computedSegments.map((segment) => ({
-            key: segment.key,
-            x: segment.x,
-            y: segment.y,
-            width: segment.width,
-            height: segment.height,
-          }))
-        : [],
+    () => {
+      if (!SHOW_NATIVE_HINT_DEBUG) return [];
+
+      const groupLabels = new Map<string, string>();
+      let nextGroup = 1;
+
+      return computedSegments.map((segment) => {
+        const groupKey = segment.underlineGroupKey;
+        if (groupKey && !groupLabels.has(groupKey)) {
+          groupLabels.set(groupKey, `g${nextGroup}`);
+          nextGroup += 1;
+        }
+
+        return {
+          key: segment.key,
+          x: segment.x,
+          y: segment.y,
+          width: segment.width,
+          height: segment.height,
+          text: /^\s+$/.test(segment.text) ? "sp" : segment.text,
+          groupLabel: groupKey ? groupLabels.get(groupKey) : undefined,
+          ...getDebugColor(groupKey),
+        };
+      });
+    },
     [computedSegments],
   );
 
   return (
     <View
+      ref={containerRef}
       style={[
         {
           minWidth: 0,
@@ -555,16 +776,33 @@ function NativeHintText({
         style={StyleSheet.absoluteFill}
       >
         {debugRects.map((segment) => (
-          <Rect
-            key={`debug:${segment.key}`}
-            x={segment.x}
-            y={segment.y}
-            width={segment.width}
-            height={segment.height}
-            stroke="#ff4d4f"
-            strokeWidth={1}
-            fill="rgba(255,77,79,0.08)"
-          />
+          <React.Fragment key={`debug:${segment.key}`}>
+            <Rect
+              x={segment.x}
+              y={segment.y}
+              width={segment.width}
+              height={segment.height}
+              stroke={segment.stroke}
+              strokeWidth={1}
+              fill={segment.fill}
+            />
+            <SvgText
+              x={segment.x}
+              y={segment.y - 2}
+              fontSize="10"
+              fill={segment.stroke}
+            >
+              {segment.groupLabel ?? "none"}
+            </SvgText>
+            <SvgText
+              x={segment.x + 1}
+              y={segment.y + segment.height - 10}
+              fontSize="8"
+              fill={segment.stroke}
+            >
+              {segment.text}
+            </SvgText>
+          </React.Fragment>
         ))}
         {underlineSegments.map((segment) => (
           <React.Fragment key={segment.key}>
@@ -602,20 +840,6 @@ function NativeHintText({
           </React.Fragment>
         ))}
       </Svg>
-      {leadingElement && (
-        <View
-          style={[
-            {
-              position: "absolute",
-              top: 2,
-              zIndex: 1,
-            },
-            rtl ? { right: 0 } : { left: 0 },
-          ]}
-        >
-          {leadingElement}
-        </View>
-      )}
       <Text
         onLayout={(event) => {
           setTextLayout(event.nativeEvent.layout);
@@ -628,6 +852,10 @@ function NativeHintText({
               y: line.y,
               width: line.width,
               height: line.height,
+              ascender: line.ascender,
+              descender: line.descender,
+              capHeight: line.capHeight,
+              xHeight: line.xHeight,
             })),
           );
         }}
@@ -639,36 +867,39 @@ function NativeHintText({
             textAlign: centered ? "center" : "auto",
             alignSelf: fillLineWidth ? "stretch" : "flex-start",
           },
-          leadingElement
-            ? rtl
-              ? { paddingRight: NATIVE_TEXT_AUDIO_PADDING }
-              : { paddingLeft: NATIVE_TEXT_AUDIO_PADDING }
-            : undefined,
         ]}
       >
-        {segments.map((segment) => {
-          const interactive = Boolean(segment.hint) && !segment.hidden;
-          const color = segment.hidden
+        {inlineAudio && (
+          <Text
+            suppressHighlighting
+            onPress={inlineAudio.onPress}
+            style={{
+              fontFamily: PLAY_AUDIO_ICON_FONT_FAMILY,
+              fontSize: PLAY_AUDIO_ICON_SIZE,
+              color: inlineAudio.color,
+            }}
+          >
+            {PLAY_AUDIO_ICON_GLYPH}
+          </Text>
+        )}
+        {inlineAudio && <Text>{INLINE_AUDIO_SPACE}</Text>}
+        {tokens.map((token) => {
+          const interactive = Boolean(token.hint) && !token.hidden;
+          const color = token.hidden
             ? "transparent"
-            : segment.dimmed
+            : token.dimmed
               ? colors.disabled
               : (flatStyle.color ?? colors.text);
+          const tokenKey = `${token.start}:${token.text}`;
 
           return (
             <Text
-              key={segment.key}
+              key={`display:${tokenKey}`}
               suppressHighlighting
               onPress={
                 interactive
                   ? (event) => {
-                      if (!segment.hint) return;
-                      onHintLookup();
-                      popup.show({
-                        translation: segment.hint.translation,
-                        pronunciation: segment.hint.pronunciation,
-                        x: event.nativeEvent.pageX,
-                        y: event.nativeEvent.pageY,
-                      });
+                      showMeasuredHint(token, tokenKey, event);
                     }
                   : undefined
               }
@@ -679,7 +910,7 @@ function NativeHintText({
                 },
               ]}
             >
-              {segment.text}
+              {token.text}
             </Text>
           );
         })}
@@ -695,7 +926,7 @@ function NativeHintText({
           flexWrap: "nowrap",
         }}
       >
-        {segments.map((segment) => (
+        {measurementSegments.map((segment) => (
           <Text
             key={`measure:${segment.key}`}
             onLayout={(event) => {
@@ -705,7 +936,7 @@ function NativeHintText({
                 return { ...current, [segment.key]: width };
               });
             }}
-            style={[flatStyle, { lineHeight: undefined }]}
+            style={[flatStyle, { lineHeight: undefined }, segment.textStyle]}
           >
             {segment.text}
           </Text>
@@ -724,6 +955,7 @@ export function HintText({
   style,
   containerStyle,
   leadingElement,
+  inlineAudio,
   lang,
   rtl = false,
   centered = false,
@@ -740,6 +972,7 @@ export function HintText({
   style?: StyleProp<TextStyle>;
   containerStyle?: ViewStyle;
   leadingElement?: React.ReactNode;
+  inlineAudio?: { onPress: () => void; rtl: boolean; color: string };
   lang?: string;
   rtl?: boolean;
   centered?: boolean;
@@ -771,7 +1004,7 @@ export function HintText({
         tokens={tokens}
         flatStyle={flatStyle}
         containerStyle={containerStyle}
-        leadingElement={leadingElement}
+        inlineAudio={inlineAudio}
         rtl={rtl}
         centered={centered}
         fillLineWidth={fillLineWidth}

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -235,12 +235,18 @@ function splitIntoGraphemes(text: string): string[] {
   return splitIntoGraphemesFallback(text);
 }
 
+function shouldMeasureTokenAsGraphemes(text: string): boolean {
+  return /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff\uac00-\ud7af]/u.test(text);
+}
+
 function buildNativeSegments(tokens: Token[]): NativeSegment[] {
   const segments: NativeSegment[] = [];
 
   for (const token of tokens) {
     const displayText = getDisplayText(token);
-    const parts = splitIntoGraphemes(displayText);
+    const parts = shouldMeasureTokenAsGraphemes(displayText)
+      ? splitIntoGraphemes(displayText)
+      : [displayText];
     for (const part of parts) {
       segments.push({
         ...token,
@@ -937,7 +943,7 @@ function NativeHintText({
   tokens: Token[];
   flatStyle: TextStyle;
   containerStyle?: ViewStyle;
-  inlineAudio?: { onPress: () => void; rtl: boolean; color: string };
+  inlineAudio?: { onPress: () => void; color: string };
   rtl: boolean;
   centered: boolean;
   fillLineWidth: boolean;
@@ -1243,7 +1249,7 @@ export function HintText({
   style?: StyleProp<TextStyle>;
   containerStyle?: ViewStyle;
   leadingElement?: React.ReactNode;
-  inlineAudio?: { onPress: () => void; rtl: boolean; color: string };
+  inlineAudio?: { onPress: () => void; color: string };
   lang?: string;
   rtl?: boolean;
   centered?: boolean;

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -98,7 +98,8 @@ function buildNativeSegments(tokens: Token[]): NativeSegment[] {
   const segments: NativeSegment[] = [];
 
   for (const token of tokens) {
-    const parts = splitIntoGraphemes(token.text);
+    const displayText = getDisplayText(token);
+    const parts = splitIntoGraphemes(displayText);
     for (const part of parts) {
       segments.push({
         ...token,
@@ -903,7 +904,7 @@ function NativeHintText({
                 },
               ]}
             >
-              {token.text}
+              {getDisplayText(token)}
             </Text>
           );
         })}

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -72,26 +72,167 @@ type NativeSegment = Token & {
   textStyle?: TextStyle;
 };
 
+type NativeTextLayout = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type NativeLineLayout = {
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  ascender: number;
+  descender: number;
+  capHeight: number;
+  xHeight: number;
+};
+
+type ComputedSegment = {
+  key: string;
+  start: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  ascender: number;
+  descender: number;
+  text: string;
+  hidden: boolean;
+  revealed: boolean;
+  hint?: Token["hint"];
+  tokenKey: string;
+  underlineGroupKey?: string;
+};
+
+type TokenFragment = { x1: number; x2: number; y: number; height: number };
+
+type HiddenCover = {
+  key: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type UnderlineSegment = {
+  key: string;
+  x1: number;
+  x2: number;
+  y: number;
+  color: string;
+  dotted: boolean;
+  underlineGroupKey?: string;
+  debugX: number;
+  debugY: number;
+  debugWidth: number;
+  debugHeight: number;
+};
+
+type DebugRect = {
+  key: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text: string;
+  groupLabel?: string;
+  stroke: string;
+  fill: string;
+};
+
 function getDisplayText(token: Token): string {
   return token.text.replace(/\s+/g, " ");
 }
 
-function shouldUseNativeTextLayout(lang?: string): boolean {
-  return Boolean(lang);
+function shouldUseNativeTextLayout(lang?: string, rtl = false): boolean {
+  return Boolean(lang) && !rtl;
+}
+
+let graphemeSegmenter: Intl.Segmenter | undefined;
+
+function getGraphemeSegmenter(): Intl.Segmenter | undefined {
+  if (graphemeSegmenter) return graphemeSegmenter;
+  if (typeof Intl === "undefined" || !("Segmenter" in Intl)) return undefined;
+  graphemeSegmenter = new Intl.Segmenter(undefined, {
+    granularity: "grapheme",
+  });
+  return graphemeSegmenter;
+}
+
+function isCombiningCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
+    (codePoint >= 0x3099 && codePoint <= 0x309a)
+  );
+}
+
+function isVariationSelector(codePoint: number): boolean {
+  return (
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+    (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+  );
+}
+
+function isEmojiModifier(codePoint: number): boolean {
+  return codePoint >= 0x1f3fb && codePoint <= 0x1f3ff;
+}
+
+function isRegionalIndicator(codePoint: number): boolean {
+  return codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff;
+}
+
+function splitIntoGraphemesFallback(text: string): string[] {
+  const codePoints = Array.from(text);
+  const graphemes: string[] = [];
+  let joinNext = false;
+  let regionalIndicatorRun = 0;
+
+  for (const char of codePoints) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    const lastIndex = graphemes.length - 1;
+    const last = lastIndex >= 0 ? graphemes[lastIndex] : undefined;
+    const appendToLast =
+      last !== undefined &&
+      (joinNext ||
+        codePoint === 0x200d ||
+        isCombiningCodePoint(codePoint) ||
+        isVariationSelector(codePoint) ||
+        isEmojiModifier(codePoint) ||
+        (isRegionalIndicator(codePoint) && regionalIndicatorRun % 2 === 1));
+
+    if (appendToLast) {
+      graphemes[lastIndex] = `${last}${char}`;
+    } else {
+      graphemes.push(char);
+    }
+
+    joinNext = codePoint === 0x200d;
+    regionalIndicatorRun = isRegionalIndicator(codePoint)
+      ? regionalIndicatorRun + 1
+      : 0;
+  }
+
+  return graphemes;
 }
 
 function splitIntoGraphemes(text: string): string[] {
   if (!text) return [];
   if (/^\s+$/.test(text)) return [text];
 
-  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
-    const segmenter = new Intl.Segmenter(undefined, {
-      granularity: "grapheme",
-    });
+  const segmenter = getGraphemeSegmenter();
+  if (segmenter) {
     return Array.from(segmenter.segment(text), (part) => part.segment);
   }
 
-  return Array.from(text);
+  return splitIntoGraphemesFallback(text);
 }
 
 function buildNativeSegments(tokens: Token[]): NativeSegment[] {
@@ -136,6 +277,263 @@ function getDebugColor(key?: string): { stroke: string; fill: string } {
     stroke: `hsl(${hue} 80% 45%)`,
     fill: `hsla(${hue} 80% 55% / 0.16)`,
   };
+}
+
+function buildComputedSegments({
+  lineLayouts,
+  measurementSegments,
+  segmentWidths,
+  textLayout,
+}: {
+  lineLayouts: NativeLineLayout[];
+  measurementSegments: NativeSegment[];
+  segmentWidths: Record<string, number>;
+  textLayout: NativeTextLayout;
+}): ComputedSegment[] {
+  const rects: ComputedSegment[] = [];
+  let segmentIndex = 0;
+
+  for (const line of lineLayouts) {
+    let cursor = line.x;
+    let lineText = line.text;
+
+    while (lineText.length > 0 && segmentIndex < measurementSegments.length) {
+      const segment = measurementSegments[segmentIndex];
+      const width = segmentWidths[segment.key];
+      if (width === undefined) break;
+      if (!lineText.startsWith(segment.text)) break;
+
+      rects.push({
+        key: segment.key,
+        start: segment.start,
+        x: textLayout.x + cursor,
+        y: textLayout.y + line.y,
+        width,
+        height: line.height,
+        ascender: line.ascender,
+        descender: line.descender,
+        text: segment.text,
+        hidden: segment.hidden,
+        revealed: segment.revealed,
+        hint: segment.hint,
+        tokenKey: segment.tokenKey,
+        underlineGroupKey: segment.underlineGroupKey,
+      });
+
+      cursor += width;
+      lineText = lineText.slice(segment.text.length);
+      segmentIndex += 1;
+    }
+  }
+
+  return rects;
+}
+
+function buildTokenFragments(computedSegments: ComputedSegment[]) {
+  const fragments = new Map<string, TokenFragment[]>();
+
+  for (const segment of computedSegments) {
+    if (segment.start < 0) continue;
+
+    const list = fragments.get(segment.tokenKey) ?? [];
+    const last = list[list.length - 1];
+    const x1 = segment.x;
+    const x2 = segment.x + segment.width;
+
+    if (
+      last &&
+      Math.abs(last.y - segment.y) <= 2 &&
+      Math.abs(last.x2 - x1) <= 2
+    ) {
+      last.x2 = x2;
+      last.height = Math.max(last.height, segment.height);
+    } else {
+      list.push({
+        x1,
+        x2,
+        y: segment.y,
+        height: segment.height,
+      });
+    }
+
+    fragments.set(segment.tokenKey, list);
+  }
+
+  return fragments;
+}
+
+function buildHiddenCovers(computedSegments: ComputedSegment[]): HiddenCover[] {
+  const covers: HiddenCover[] = [];
+  for (const segment of computedSegments) {
+    if (!segment.hidden) continue;
+    const last = covers[covers.length - 1];
+    const x = segment.x - 1;
+    const width = segment.width + 2;
+    if (
+      last &&
+      Math.abs(last.y - segment.y) <= 2 &&
+      Math.abs(last.x + last.width - x) <= 2
+    ) {
+      last.width = x + width - last.x;
+      last.height = Math.max(last.height, segment.height);
+      continue;
+    }
+    covers.push({
+      key: `hidden:${segment.key}`,
+      x,
+      y: segment.y,
+      width,
+      height: segment.height,
+    });
+  }
+
+  return covers;
+}
+
+function getUnderlineY(segment: ComputedSegment) {
+  const glyphBottom = segment.y + segment.ascender + segment.descender;
+  const preferredY = glyphBottom + UNDERLINE_BASELINE_GAP;
+  const maxY = segment.y + segment.height - UNDERLINE_BOTTOM_INSET;
+  return Math.min(preferredY, maxY);
+}
+
+function buildUnderlineSegments({
+  computedSegments,
+  colors,
+}: {
+  computedSegments: ComputedSegment[];
+  colors: ThemeColors;
+}): UnderlineSegment[] {
+  const segmentsToDraw: UnderlineSegment[] = [];
+  const hiddenGroupSpans = new Map<string, UnderlineSegment>();
+  for (const segment of computedSegments) {
+    const interactive = Boolean(segment.hint) && !segment.hidden;
+    const underline = segment.hidden
+      ? colors.hiddenUnderline
+      : segment.revealed || interactive
+        ? colors.border
+        : undefined;
+    if (!underline) continue;
+
+    if (segment.hidden && segment.underlineGroupKey) {
+      const y = getUnderlineY(segment);
+      const lineKey = `${segment.underlineGroupKey}:${Math.round(y)}`;
+      const existing = hiddenGroupSpans.get(lineKey);
+      if (existing) {
+        const right = Math.max(existing.x2, segment.x + segment.width);
+        existing.x1 = Math.min(existing.x1, segment.x);
+        existing.x2 = right;
+        existing.debugX = Math.min(existing.debugX, segment.x);
+        existing.debugWidth = right - existing.debugX;
+        existing.debugHeight = Math.max(existing.debugHeight, segment.height);
+      } else {
+        hiddenGroupSpans.set(lineKey, {
+          key: lineKey,
+          x1: segment.x,
+          x2: segment.x + segment.width,
+          y,
+          color: underline,
+          dotted: false,
+          underlineGroupKey: segment.underlineGroupKey,
+          debugX: segment.x,
+          debugY: segment.y,
+          debugWidth: segment.width,
+          debugHeight: segment.height,
+        });
+      }
+      continue;
+    }
+
+    if (/^\s+$/.test(segment.text) && !segment.underlineGroupKey) continue;
+    if (
+      /^[,.:;!?%)}\]\u3001\u3002\u30fb\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(
+        segment.text,
+      )
+    )
+      continue;
+    segmentsToDraw.push({
+      key: segment.key,
+      x1: segment.x + UNDERLINE_EDGE_INSET,
+      x2:
+        segment.x +
+        Math.max(segment.width - UNDERLINE_EDGE_INSET, UNDERLINE_EDGE_INSET * 2),
+      y: getUnderlineY(segment),
+      color: underline,
+      dotted: !segment.hidden,
+      underlineGroupKey: segment.underlineGroupKey,
+      debugX: segment.x,
+      debugY: segment.y,
+      debugWidth: segment.width,
+      debugHeight: segment.height,
+    });
+  }
+  for (const segment of hiddenGroupSpans.values()) {
+    segmentsToDraw.push({
+      ...segment,
+      x1: segment.x1 + UNDERLINE_EDGE_INSET,
+      x2: segment.x2 - UNDERLINE_EDGE_INSET,
+    });
+  }
+
+  segmentsToDraw.sort((a, b) => {
+    if (Math.abs(a.y - b.y) > 2) return a.y - b.y;
+    return a.x1 - b.x1;
+  });
+
+  const merged: UnderlineSegment[] = [];
+  for (const segment of segmentsToDraw) {
+    const last = merged[merged.length - 1];
+    const sameGroupOnSameLine =
+      last &&
+      Math.abs(last.y - segment.y) <= 2 &&
+      last.color === segment.color &&
+      last.dotted === segment.dotted &&
+      last.underlineGroupKey !== undefined &&
+      last.underlineGroupKey === segment.underlineGroupKey;
+    if (
+      sameGroupOnSameLine ||
+      (last &&
+        Math.abs(last.y - segment.y) <= 2 &&
+        Math.abs(last.x2 - segment.x1) <= 4 &&
+        last.color === segment.color &&
+        last.dotted === segment.dotted &&
+        last.underlineGroupKey === segment.underlineGroupKey)
+    ) {
+      last.x2 = segment.x2;
+      last.debugWidth = segment.debugX + segment.debugWidth - last.debugX;
+      last.debugHeight = Math.max(last.debugHeight, segment.debugHeight);
+      continue;
+    }
+    merged.push(segment);
+  }
+
+  return merged;
+}
+
+function buildDebugRects(computedSegments: ComputedSegment[]): DebugRect[] {
+  if (!SHOW_NATIVE_HINT_DEBUG) return [];
+
+  const groupLabels = new Map<string, string>();
+  let nextGroup = 1;
+
+  return computedSegments.map((segment) => {
+    const groupKey = segment.underlineGroupKey;
+    if (groupKey && !groupLabels.has(groupKey)) {
+      groupLabels.set(groupKey, `g${nextGroup}`);
+      nextGroup += 1;
+    }
+
+    return {
+      key: segment.key,
+      x: segment.x,
+      y: segment.y,
+      width: segment.width,
+      height: segment.height,
+      text: /^\s+$/.test(segment.text) ? "sp" : segment.text,
+      groupLabel: groupKey ? groupLabels.get(groupKey) : undefined,
+      ...getDebugColor(groupKey),
+    };
+  });
 }
 
 function HintTokenBox({
@@ -436,6 +834,97 @@ function buildTokens({
   return tokens;
 }
 
+function NativeHintOverlay({
+  hiddenCovers,
+  debugRects,
+  underlineSegments,
+  colors,
+}: {
+  hiddenCovers: HiddenCover[];
+  debugRects: DebugRect[];
+  underlineSegments: UnderlineSegment[];
+  colors: ThemeColors;
+}) {
+  return (
+    <Svg pointerEvents="none" style={StyleSheet.absoluteFill}>
+      {hiddenCovers.map((cover) => (
+        <Rect
+          key={cover.key}
+          x={cover.x}
+          y={cover.y}
+          width={cover.width}
+          height={cover.height}
+          fill={colors.surface}
+        />
+      ))}
+      {debugRects.map((segment) => (
+        <React.Fragment key={`debug:${segment.key}`}>
+          <Rect
+            x={segment.x}
+            y={segment.y}
+            width={segment.width}
+            height={segment.height}
+            stroke={segment.stroke}
+            strokeWidth={1}
+            fill={segment.fill}
+          />
+          <SvgText
+            x={segment.x}
+            y={segment.y - 2}
+            fontSize="10"
+            fill={segment.stroke}
+          >
+            {segment.groupLabel ?? "none"}
+          </SvgText>
+          <SvgText
+            x={segment.x + 1}
+            y={segment.y + segment.height - 10}
+            fontSize="8"
+            fill={segment.stroke}
+          >
+            {segment.text}
+          </SvgText>
+        </React.Fragment>
+      ))}
+      {underlineSegments.map((segment) => (
+        <React.Fragment key={segment.key}>
+          {segment.dotted ? (
+            Array.from({
+              length: Math.max(
+                1,
+                Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
+              ),
+            }).map((_, index) => {
+              const cx = Math.min(
+                segment.x2,
+                segment.x1 + index * UNDERLINE_DOT_GAP,
+              );
+              return (
+                <Circle
+                  key={`${segment.key}:${index}`}
+                  cx={cx}
+                  cy={segment.y}
+                  r={UNDERLINE_DOT_RADIUS}
+                  fill={segment.color}
+                />
+              );
+            })
+          ) : (
+            <Line
+              x1={segment.x1}
+              x2={segment.x2}
+              y1={segment.y}
+              y2={segment.y}
+              stroke={segment.color}
+              strokeWidth={2}
+            />
+          )}
+        </React.Fragment>
+      ))}
+    </Svg>
+  );
+}
+
 function NativeHintText({
   tokens,
   flatStyle,
@@ -489,76 +978,25 @@ function NativeHintText({
 
     return prefix.concat(segments);
   }, [inlineAudio, tokens]);
-  const [textLayout, setTextLayout] = React.useState({ x: 0, y: 0, width: 0, height: 0 });
-  const [lineLayouts, setLineLayouts] = React.useState<
-    {
-      text: string;
-      x: number;
-      y: number;
-      width: number;
-      height: number;
-      ascender: number;
-      descender: number;
-      capHeight: number;
-      xHeight: number;
-    }[]
-  >([]);
+  const [textLayout, setTextLayout] = React.useState<NativeTextLayout>({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  });
+  const [lineLayouts, setLineLayouts] = React.useState<NativeLineLayout[]>([]);
   const [segmentWidths, setSegmentWidths] = React.useState<Record<string, number>>({});
 
-  const computedSegments = React.useMemo(() => {
-    const rects: Array<{
-      key: string;
-      start: number;
-      x: number;
-      y: number;
-      width: number;
-      height: number;
-      ascender: number;
-      descender: number;
-      text: string;
-      hidden: boolean;
-      revealed: boolean;
-      hint?: Token["hint"];
-      tokenKey: string;
-      underlineGroupKey?: string;
-    }> = [];
-    let segmentIndex = 0;
-
-    for (const line of lineLayouts) {
-      let cursor = line.x;
-      let lineText = line.text;
-
-      while (lineText.length > 0 && segmentIndex < measurementSegments.length) {
-        const segment = measurementSegments[segmentIndex];
-        const width = segmentWidths[segment.key];
-        if (width === undefined) break;
-        if (!lineText.startsWith(segment.text)) break;
-
-        rects.push({
-          key: segment.key,
-          start: segment.start,
-          x: textLayout.x + cursor,
-          y: textLayout.y + line.y,
-          width,
-          height: line.height,
-          ascender: line.ascender,
-          descender: line.descender,
-          text: segment.text,
-          hidden: segment.hidden,
-          revealed: segment.revealed,
-          hint: segment.hint,
-          tokenKey: segment.tokenKey,
-          underlineGroupKey: segment.underlineGroupKey,
-        });
-
-        cursor += width;
-        lineText = lineText.slice(segment.text.length);
-        segmentIndex += 1;
-      }
-    }
-
-    return rects;
-  }, [lineLayouts, measurementSegments, segmentWidths, textLayout.x, textLayout.y]);
+  const computedSegments = React.useMemo(
+    () =>
+      buildComputedSegments({
+        lineLayouts,
+        measurementSegments,
+        segmentWidths,
+        textLayout,
+      }),
+    [lineLayouts, measurementSegments, segmentWidths, textLayout],
+  );
   const loggedDebugRef = React.useRef(false);
 
   React.useEffect(() => {
@@ -580,77 +1018,15 @@ function NativeHintText({
     loggedDebugRef.current = true;
   }, [computedSegments, measurementSegments]);
 
-  const tokenFragments = React.useMemo(() => {
-    const fragments = new Map<
-      string,
-      Array<{ x1: number; x2: number; y: number; height: number }>
-    >();
+  const tokenFragments = React.useMemo(
+    () => buildTokenFragments(computedSegments),
+    [computedSegments],
+  );
 
-    for (const segment of computedSegments) {
-      if (segment.start < 0) continue;
-
-      const list = fragments.get(segment.tokenKey) ?? [];
-      const last = list[list.length - 1];
-      const x1 = segment.x;
-      const x2 = segment.x + segment.width;
-
-      if (
-        last &&
-        Math.abs(last.y - segment.y) <= 2 &&
-        Math.abs(last.x2 - x1) <= 2
-      ) {
-        last.x2 = x2;
-        last.height = Math.max(last.height, segment.height);
-      } else {
-        list.push({
-          x1,
-          x2,
-          y: segment.y,
-          height: segment.height,
-        });
-      }
-
-      fragments.set(segment.tokenKey, list);
-    }
-
-    return fragments;
-  }, [computedSegments]);
-
-  const hiddenCovers = React.useMemo(() => {
-    type HiddenCover = {
-      key: string;
-      x: number;
-      y: number;
-      width: number;
-      height: number;
-    };
-
-    const covers: HiddenCover[] = [];
-    for (const segment of computedSegments) {
-      if (!segment.hidden) continue;
-      const last = covers[covers.length - 1];
-      const x = segment.x - 1;
-      const width = segment.width + 2;
-      if (
-        last &&
-        Math.abs(last.y - segment.y) <= 2 &&
-        Math.abs(last.x + last.width - x) <= 2
-      ) {
-        last.width = x + width - last.x;
-        last.height = Math.max(last.height, segment.height);
-        continue;
-      }
-      covers.push({
-        key: `hidden:${segment.key}`,
-        x,
-        y: segment.y,
-        width,
-        height: segment.height,
-      });
-    }
-
-    return covers;
-  }, [computedSegments]);
+  const hiddenCovers = React.useMemo(
+    () => buildHiddenCovers(computedSegments),
+    [computedSegments],
+  );
 
   const showMeasuredHint = React.useCallback(
     (
@@ -706,156 +1082,13 @@ function NativeHintText({
     [onHintLookup, popup, tokenFragments],
   );
 
-  const underlineSegments = React.useMemo(() => {
-    type UnderlineSegment = {
-      key: string;
-      x1: number;
-      x2: number;
-      y: number;
-      color: string;
-      dotted: boolean;
-      underlineGroupKey?: string;
-      debugX: number;
-      debugY: number;
-      debugWidth: number;
-      debugHeight: number;
-    };
-
-    function getUnderlineY(segment: (typeof computedSegments)[number]) {
-      const glyphBottom = segment.y + segment.ascender + segment.descender;
-      const preferredY = glyphBottom + UNDERLINE_BASELINE_GAP;
-      const maxY = segment.y + segment.height - UNDERLINE_BOTTOM_INSET;
-      return Math.min(preferredY, maxY);
-    }
-
-    const segmentsToDraw: UnderlineSegment[] = [];
-    const hiddenGroupSpans = new Map<string, UnderlineSegment>();
-    for (const segment of computedSegments) {
-      const interactive = Boolean(segment.hint) && !segment.hidden;
-      const underline = segment.hidden
-        ? colors.hiddenUnderline
-        : segment.revealed || interactive
-          ? colors.border
-          : undefined;
-      if (!underline) continue;
-
-      if (segment.hidden && segment.underlineGroupKey) {
-        const y = getUnderlineY(segment);
-        const lineKey = `${segment.underlineGroupKey}:${Math.round(y)}`;
-        const existing = hiddenGroupSpans.get(lineKey);
-        if (existing) {
-          const right = Math.max(existing.x2, segment.x + segment.width);
-          existing.x1 = Math.min(existing.x1, segment.x);
-          existing.x2 = right;
-          existing.debugX = Math.min(existing.debugX, segment.x);
-          existing.debugWidth = right - existing.debugX;
-          existing.debugHeight = Math.max(existing.debugHeight, segment.height);
-        } else {
-          hiddenGroupSpans.set(lineKey, {
-            key: lineKey,
-            x1: segment.x,
-            x2: segment.x + segment.width,
-            y,
-            color: underline,
-            dotted: false,
-            underlineGroupKey: segment.underlineGroupKey,
-            debugX: segment.x,
-            debugY: segment.y,
-            debugWidth: segment.width,
-            debugHeight: segment.height,
-          });
-        }
-        continue;
-      }
-
-      if (/^\s+$/.test(segment.text) && !segment.underlineGroupKey) continue;
-      if (/^[,.:;!?%)}\]\u3001\u3002\u30fb\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(segment.text))
-        continue;
-      segmentsToDraw.push({
-        key: segment.key,
-        x1: segment.x + UNDERLINE_EDGE_INSET,
-        x2: segment.x + Math.max(segment.width - UNDERLINE_EDGE_INSET, UNDERLINE_EDGE_INSET * 2),
-        y: getUnderlineY(segment),
-        color: underline,
-        dotted: !segment.hidden,
-        underlineGroupKey: segment.underlineGroupKey,
-        debugX: segment.x,
-        debugY: segment.y,
-        debugWidth: segment.width,
-        debugHeight: segment.height,
-      });
-    }
-    for (const segment of hiddenGroupSpans.values()) {
-      segmentsToDraw.push({
-        ...segment,
-        x1: segment.x1 + UNDERLINE_EDGE_INSET,
-        x2: segment.x2 - UNDERLINE_EDGE_INSET,
-      });
-    }
-
-    segmentsToDraw.sort((a, b) => {
-      if (Math.abs(a.y - b.y) > 2) return a.y - b.y;
-      return a.x1 - b.x1;
-    });
-
-    const merged: UnderlineSegment[] = [];
-    for (const segment of segmentsToDraw) {
-      const last = merged[merged.length - 1];
-      const sameGroupOnSameLine =
-        last &&
-        Math.abs(last.y - segment.y) <= 2 &&
-        last.color === segment.color &&
-        last.dotted === segment.dotted &&
-        last.underlineGroupKey !== undefined &&
-        last.underlineGroupKey === segment.underlineGroupKey;
-      if (
-        sameGroupOnSameLine ||
-        (
-          last &&
-          Math.abs(last.y - segment.y) <= 2 &&
-          Math.abs(last.x2 - segment.x1) <= 4 &&
-          last.color === segment.color &&
-          last.dotted === segment.dotted &&
-          last.underlineGroupKey === segment.underlineGroupKey
-        )
-      ) {
-        last.x2 = segment.x2;
-        last.debugWidth = segment.debugX + segment.debugWidth - last.debugX;
-        last.debugHeight = Math.max(last.debugHeight, segment.debugHeight);
-        continue;
-      }
-      merged.push(segment);
-    }
-
-    return merged;
-  }, [colors.border, colors.hiddenUnderline, computedSegments]);
+  const underlineSegments = React.useMemo(
+    () => buildUnderlineSegments({ computedSegments, colors }),
+    [colors, computedSegments],
+  );
 
   const debugRects = React.useMemo(
-    () => {
-      if (!SHOW_NATIVE_HINT_DEBUG) return [];
-
-      const groupLabels = new Map<string, string>();
-      let nextGroup = 1;
-
-      return computedSegments.map((segment) => {
-        const groupKey = segment.underlineGroupKey;
-        if (groupKey && !groupLabels.has(groupKey)) {
-          groupLabels.set(groupKey, `g${nextGroup}`);
-          nextGroup += 1;
-        }
-
-        return {
-          key: segment.key,
-          x: segment.x,
-          y: segment.y,
-          width: segment.width,
-          height: segment.height,
-          text: /^\s+$/.test(segment.text) ? "sp" : segment.text,
-          groupLabel: groupKey ? groupLabels.get(groupKey) : undefined,
-          ...getDebugColor(groupKey),
-        };
-      });
-    },
+    () => buildDebugRects(computedSegments),
     [computedSegments],
   );
 
@@ -947,82 +1180,12 @@ function NativeHintText({
           );
         })}
       </Text>
-      <Svg pointerEvents="none" style={StyleSheet.absoluteFill}>
-        {hiddenCovers.map((cover) => (
-          <Rect
-            key={cover.key}
-            x={cover.x}
-            y={cover.y}
-            width={cover.width}
-            height={cover.height}
-            fill={colors.surface}
-          />
-        ))}
-        {debugRects.map((segment) => (
-          <React.Fragment key={`debug:${segment.key}`}>
-            <Rect
-              x={segment.x}
-              y={segment.y}
-              width={segment.width}
-              height={segment.height}
-              stroke={segment.stroke}
-              strokeWidth={1}
-              fill={segment.fill}
-            />
-            <SvgText
-              x={segment.x}
-              y={segment.y - 2}
-              fontSize="10"
-              fill={segment.stroke}
-            >
-              {segment.groupLabel ?? "none"}
-            </SvgText>
-            <SvgText
-              x={segment.x + 1}
-              y={segment.y + segment.height - 10}
-              fontSize="8"
-              fill={segment.stroke}
-            >
-              {segment.text}
-            </SvgText>
-          </React.Fragment>
-        ))}
-        {underlineSegments.map((segment) => (
-          <React.Fragment key={segment.key}>
-            {segment.dotted ? (
-              Array.from({
-                length: Math.max(
-                  1,
-                  Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
-                ),
-              }).map((_, index) => {
-                const cx = Math.min(
-                  segment.x2,
-                  segment.x1 + index * UNDERLINE_DOT_GAP,
-                );
-                return (
-                  <Circle
-                    key={`${segment.key}:${index}`}
-                    cx={cx}
-                    cy={segment.y}
-                    r={UNDERLINE_DOT_RADIUS}
-                    fill={segment.color}
-                  />
-                );
-              })
-            ) : (
-              <Line
-                x1={segment.x1}
-                x2={segment.x2}
-                y1={segment.y}
-                y2={segment.y}
-                stroke={segment.color}
-                strokeWidth={2}
-              />
-            )}
-          </React.Fragment>
-        ))}
-      </Svg>
+      <NativeHintOverlay
+        hiddenCovers={hiddenCovers}
+        debugRects={debugRects}
+        underlineSegments={underlineSegments}
+        colors={colors}
+      />
       <View
         pointerEvents="none"
         style={{
@@ -1103,7 +1266,7 @@ export function HintText({
   });
   const resolvedRenderMode =
     renderMode === "auto"
-      ? (shouldUseNativeTextLayout(lang) ? "native" : "tokenized")
+      ? (shouldUseNativeTextLayout(lang, rtl) ? "native" : "tokenized")
       : renderMode;
 
   if (resolvedRenderMode === "native") {

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -470,7 +470,7 @@ function NativeHintText({
           ? colors.border
           : undefined;
       if (!underline) continue;
-      if (/^\s+$/.test(segment.text)) continue;
+      if (/^\s+$/.test(segment.text) && !segment.underlineGroupKey) continue;
       if (/^[,.:;!?%)}\]\u3001\u3002\u30fb\u30fc\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(segment.text))
         continue;
       segmentsToDraw.push({

--- a/app-mobile/src/story/elements/Header.tsx
+++ b/app-mobile/src/story/elements/Header.tsx
@@ -48,6 +48,7 @@ export function Header({
         <HintText
           content={element.learningLanguageTitleContent}
           audioRange={audioRange}
+          lang={element.lang}
           rtl={rtl}
           centered
           style={[

--- a/app-mobile/src/story/elements/MultipleChoiceQuestion.tsx
+++ b/app-mobile/src/story/elements/MultipleChoiceQuestion.tsx
@@ -77,7 +77,7 @@ export function MultipleChoiceQuestion({
               {typeof answer === "string" ? (
                 <Text style={answerStyle}>{answer}</Text>
               ) : (
-                <HintText content={answer} style={answerStyle} />
+                <HintText content={answer} lang={element.lang} style={answerStyle} />
               )}
             </View>
           </Pressable>

--- a/app-mobile/src/story/elements/PlayAudioButton.tsx
+++ b/app-mobile/src/story/elements/PlayAudioButton.tsx
@@ -3,6 +3,13 @@ import { Pressable, StyleSheet } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../../theme";
 
+export const PLAY_AUDIO_ICON_NAME = "volume-medium";
+export const PLAY_AUDIO_ICON_SIZE = 22;
+export const PLAY_AUDIO_ICON_FONT_FAMILY = "ionicons";
+export const PLAY_AUDIO_ICON_GLYPH = String.fromCodePoint(
+  Number(Ionicons.getRawGlyphMap()[PLAY_AUDIO_ICON_NAME]),
+);
+
 export function PlayAudioButton({
   onPress,
   rtl = false,
@@ -25,8 +32,8 @@ export function PlayAudioButton({
       ]}
     >
       <Ionicons
-        name="volume-medium"
-        size={22}
+        name={PLAY_AUDIO_ICON_NAME}
+        size={PLAY_AUDIO_ICON_SIZE}
         color={colors.blue}
         style={rtl && styles.iconRtl}
       />

--- a/app-mobile/src/story/elements/QuestionPrompt.tsx
+++ b/app-mobile/src/story/elements/QuestionPrompt.tsx
@@ -24,6 +24,7 @@ export function QuestionPrompt({
     <View style={styles.root}>
       <HintText
         content={content}
+        lang={lang}
         style={[styles.text, getLanguageTextStyle(lang, styles.text)]}
       />
     </View>

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -191,7 +191,7 @@ export function TextLine({
             renderMode={preferNativeText ? "native" : "tokenized"}
             inlineAudio={
               preferNativeText && lineAudio.hasAudio
-                ? { onPress: handlePlay, rtl: lineRtl, color: colors.blue }
+                ? { onPress: handlePlay, color: colors.blue }
                 : undefined
             }
             rtl={lineRtl}
@@ -247,7 +247,7 @@ export function TextLine({
                 renderMode={preferNativeText ? "native" : "tokenized"}
                 inlineAudio={
                   preferNativeText && lineAudio.hasAudio
-                    ? { onPress: handlePlay, rtl: lineRtl, color: colors.blue }
+                    ? { onPress: handlePlay, color: colors.blue }
                     : undefined
                 }
                 rtl={lineRtl}
@@ -288,7 +288,7 @@ export function TextLine({
           renderMode={preferNativeText ? "native" : "tokenized"}
           inlineAudio={
             preferNativeText && lineAudio.hasAudio
-              ? { onPress: handlePlay, rtl: lineRtl, color: colors.blue }
+              ? { onPress: handlePlay, color: colors.blue }
               : undefined
           }
           rtl={lineRtl}

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -14,6 +14,11 @@ import type { StoryElementLine } from "../types";
 // color under background color) pointing at the avatar.
 const TAIL_WIDTH = 12;
 
+function shouldUseNativeStoryText(lang?: string): boolean {
+  if (!lang) return false;
+  return /^(ja|zh|ko)(-|$)/i.test(lang);
+}
+
 function BubbleTail({
   colors,
   rtl,
@@ -165,6 +170,7 @@ export function TextLine({
     fontSize: fontSizes.body,
     color: colors.text,
   };
+  const preferNativeText = shouldUseNativeStoryText(element.lang);
 
   if (element.line === undefined) return null;
 
@@ -182,6 +188,8 @@ export function TextLine({
             audioRange={audioRange}
             hideRangesForChallenge={hideRanges}
             unhide={unhide}
+            lang={element.lang}
+            renderMode={preferNativeText ? "native" : "tokenized"}
             rtl={lineRtl}
             style={[
               styles.title,
@@ -220,21 +228,23 @@ export function TextLine({
             ]}
           >
             <LineBody
-              hasAudio={false}
+              hasAudio={preferNativeText ? lineAudio.hasAudio : false}
               onPlay={handlePlay}
               rtl={lineRtl}
               styles={styles}
-              naturalWidth
+              naturalWidth={!preferNativeText}
             >
               <HintText
                 content={element.line.content}
                 audioRange={audioRange}
                 hideRangesForChallenge={hideRanges}
                 unhide={unhide}
+                lang={element.lang}
+                renderMode={preferNativeText ? "native" : "tokenized"}
                 rtl={lineRtl}
                 containerStyle={lineRtl ? styles.rtlBubbleText : undefined}
                 leadingElement={
-                  lineAudio.hasAudio ? (
+                  !preferNativeText && lineAudio.hasAudio ? (
                     <PlayAudioButton onPress={handlePlay} rtl={lineRtl} />
                   ) : undefined
                 }
@@ -265,6 +275,8 @@ export function TextLine({
           audioRange={audioRange}
           hideRangesForChallenge={hideRanges}
           unhide={unhide}
+          lang={element.lang}
+          renderMode={preferNativeText ? "native" : "tokenized"}
           rtl={lineRtl}
           containerStyle={lineRtl ? styles.rtlProseText : undefined}
           fillLineWidth={lineRtl}

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -15,8 +15,7 @@ import type { StoryElementLine } from "../types";
 const TAIL_WIDTH = 12;
 
 function shouldUseNativeStoryText(lang?: string): boolean {
-  if (!lang) return false;
-  return /^(ja|zh|ko)(-|$)/i.test(lang);
+  return Boolean(lang);
 }
 
 function BubbleTail({
@@ -178,7 +177,7 @@ export function TextLine({
     return (
       <View style={[styles.row, lineRtl && styles.rowRtl]}>
         <LineBody
-          hasAudio={lineAudio.hasAudio}
+          hasAudio={preferNativeText ? false : lineAudio.hasAudio}
           onPlay={handlePlay}
           rtl={lineRtl}
           styles={styles}
@@ -190,6 +189,11 @@ export function TextLine({
             unhide={unhide}
             lang={element.lang}
             renderMode={preferNativeText ? "native" : "tokenized"}
+            inlineAudio={
+              preferNativeText && lineAudio.hasAudio
+                ? { onPress: handlePlay, rtl: lineRtl, color: colors.blue }
+                : undefined
+            }
             rtl={lineRtl}
             style={[
               styles.title,
@@ -228,7 +232,7 @@ export function TextLine({
             ]}
           >
             <LineBody
-              hasAudio={preferNativeText ? lineAudio.hasAudio : false}
+              hasAudio={false}
               onPlay={handlePlay}
               rtl={lineRtl}
               styles={styles}
@@ -241,6 +245,11 @@ export function TextLine({
                 unhide={unhide}
                 lang={element.lang}
                 renderMode={preferNativeText ? "native" : "tokenized"}
+                inlineAudio={
+                  preferNativeText && lineAudio.hasAudio
+                    ? { onPress: handlePlay, rtl: lineRtl, color: colors.blue }
+                    : undefined
+                }
                 rtl={lineRtl}
                 containerStyle={lineRtl ? styles.rtlBubbleText : undefined}
                 leadingElement={
@@ -265,7 +274,7 @@ export function TextLine({
   return (
     <View style={[styles.row, lineRtl && styles.rowRtl]}>
       <LineBody
-        hasAudio={lineAudio.hasAudio}
+        hasAudio={preferNativeText ? false : lineAudio.hasAudio}
         onPlay={handlePlay}
         rtl={lineRtl}
         styles={styles}
@@ -277,6 +286,11 @@ export function TextLine({
           unhide={unhide}
           lang={element.lang}
           renderMode={preferNativeText ? "native" : "tokenized"}
+          inlineAudio={
+            preferNativeText && lineAudio.hasAudio
+              ? { onPress: handlePlay, rtl: lineRtl, color: colors.blue }
+              : undefined
+          }
           rtl={lineRtl}
           containerStyle={lineRtl ? styles.rtlProseText : undefined}
           fillLineWidth={lineRtl}

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -14,8 +14,8 @@ import type { StoryElementLine } from "../types";
 // color under background color) pointing at the avatar.
 const TAIL_WIDTH = 12;
 
-function shouldUseNativeStoryText(lang?: string): boolean {
-  return Boolean(lang);
+function shouldUseNativeStoryText(lang?: string, rtl = false): boolean {
+  return Boolean(lang) && !rtl;
 }
 
 function BubbleTail({
@@ -169,7 +169,7 @@ export function TextLine({
     fontSize: fontSizes.body,
     color: colors.text,
   };
-  const preferNativeText = shouldUseNativeStoryText(element.lang);
+  const preferNativeText = shouldUseNativeStoryText(element.lang, lineRtl);
 
   if (element.line === undefined) return null;
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "knip": "pnpm dlx knip --production",
     "optimize:flags": "pnpm dlx svgo -f flags --multipass",
     "audit:missing-story-images": "pnpm exec tsx scripts/find-missing-story-images.ts",
+    "mobile:screenshot": "scripts/mobile-screenshot.sh",
     "backfill:discord-avatars": "pnpm exec tsx scripts/backfill-discord-avatars.ts",
     "backfill:course-contributors": "pnpm exec tsx scripts/backfill-course-contributors.ts",
     "audio:join-story": "tsx scripts/generate-joined-story-audio.ts",

--- a/scripts/mobile-screenshot.sh
+++ b/scripts/mobile-screenshot.sh
@@ -26,7 +26,10 @@ fi
 
 adb "${adb_args[@]}" reverse tcp:8081 tcp:8081 >/dev/null 2>&1 || true
 
-route="/--/debug/story-shot?case=${case_name}"
+encoded_case_name="$(
+  node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$case_name"
+)"
+route="/--/debug/story-shot?case=${encoded_case_name}"
 uri="exp://${expo_host}${route}"
 
 adb "${adb_args[@]}" shell am start \

--- a/scripts/mobile-screenshot.sh
+++ b/scripts/mobile-screenshot.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case_name="${1:-all}"
+expo_host="${EXPO_HOST:-127.0.0.1:8081}"
+wait_seconds="${SCREENSHOT_WAIT:-10}"
+out_dir="${SCREENSHOT_DIR:-/tmp/duo-shots}"
+device="${ANDROID_SERIAL:-}"
+
+if ! command -v adb >/dev/null 2>&1; then
+  echo "adb is required on PATH" >&2
+  exit 1
+fi
+
+adb_args=()
+if [[ -n "$device" ]]; then
+  adb_args=(-s "$device")
+fi
+
+mkdir -p "$out_dir"
+
+if ! adb "${adb_args[@]}" get-state >/dev/null 2>&1; then
+  echo "No adb device is available. Start an emulator or connect a device first." >&2
+  exit 1
+fi
+
+adb "${adb_args[@]}" reverse tcp:8081 tcp:8081 >/dev/null 2>&1 || true
+
+route="/--/debug/story-shot?case=${case_name}"
+uri="exp://${expo_host}${route}"
+
+adb "${adb_args[@]}" shell am start \
+  -a android.intent.action.VIEW \
+  -d "$uri" >/dev/null
+
+sleep "$wait_seconds"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+out_file="${out_dir}/${timestamp}-${case_name}.png"
+adb "${adb_args[@]}" exec-out screencap -p > "$out_file"
+
+echo "$out_file"
+if command -v share-artifact >/dev/null 2>&1; then
+  share-artifact "$out_file"
+fi


### PR DESCRIPTION
## What changed

- expand the native story text layout path beyond CJK so all story languages use native wrapping and measurement
- render hint underlines from measured native text geometry, grouped by hint range with visible gaps between groups
- keep underline spans continuous across grouped spaces while skipping standalone punctuation-only spans
- move the inline audio icon into the text flow so wrapped lines can flow under it instead of reserving a fixed left gutter
- center hint popups over the tapped measured text fragment, including wrapped tokens
- anchor dotted underlines from native line metrics so vertical spacing is more consistent around descenders

## Why

Android was mis-wrapping some story lines on physical devices, especially in cases where the tokenized layout path differed from the native text engine. After switching to native layout, the hint underlines and popup anchors also needed to follow the real rendered text geometry so bubbles, gaps, and wrapped lines stayed correct.

## Impact

- story text wrapping should now match the native Android text engine across languages
- underline grouping should more clearly show hint boundaries
- wrapped lines can continue under the speaker icon inside speech bubbles
- tapped hint translations should stay centered over the actual word or fragment that was pressed

## Validation

- `cd app-mobile && pnpm -s typecheck`
- `pnpm run lint`
- verified on Android emulator with wrapped Albanian story lines and inline-audio speech bubbles

## Notes

- `pnpm run typecheck` at the repo root still fails because of a pre-existing `.next/types/app/api/auth/[...nextauth]/route.js` missing-module error unrelated to this mobile change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new debug “story-shot” screen to preview story fixtures and select-phrase interactions.
  * Enhanced mobile story text rendering with native SVG-based hinting, improved hint grouping, and inline audio support (language-aware).
  * Added a `mobile:screenshot` script to capture screenshots from the debug story-shot screen.
* **Bug Fixes**
  * Updated splash-screen behavior to apply correctly based on the Expo environment.
* **Refactor**
  * Improved consistency of language-aware rendering across story text and question elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->