### PR TITLE
Add mobile app review prompt

### DIFF
--- a/app-mobile/app/(tabs)/index.tsx
+++ b/app-mobile/app/(tabs)/index.tsx
@@ -15,6 +15,7 @@ import { captureMobileEventLater } from "../../src/analytics";
 import { useAuthSession } from "../../src/auth-client";
 import { useAppState } from "../../src/app-state";
 import { useNetworkStatus } from "../../src/network";
+import { maybeRequestAppReview } from "../../src/reviewPrompt";
 import {
   getDoneMap,
   getListeningMode,
@@ -49,10 +50,15 @@ export default function LearnTab() {
 
   const [doneMap, setDoneMap] = React.useState<DoneMap>({});
   const [listening, setListening] = React.useState(false);
+  const [localProgressLoaded, setLocalProgressLoaded] = React.useState(false);
   const serverDoneSet = React.useMemo(() => {
     if (!serverDoneIds) return null;
     return new Set(serverDoneIds);
   }, [serverDoneIds]);
+  const localDoneSet = React.useMemo(
+    () => new Set(Object.keys(doneMap).map(Number)),
+    [doneMap],
+  );
   const stories = React.useMemo(
     () => (course && course !== null ? (course.stories as StoryListItem[]) : []),
     [course],
@@ -68,6 +74,10 @@ export default function LearnTab() {
     () => stories.filter((story) => isStoryDone(story.id)).length,
     [isStoryDone, stories],
   );
+  const reviewCompletedStoryCount = React.useMemo(() => {
+    const ids = new Set([...(serverDoneSet ?? []), ...localDoneSet]);
+    return stories.filter((story) => ids.has(story.id)).length;
+  }, [localDoneSet, serverDoneSet, stories]);
   const isServerProgressPending =
     Boolean(session?.session) && serverDoneIds === undefined && !isOffline;
   const sets = React.useMemo(() => {
@@ -113,6 +123,7 @@ export default function LearnTab() {
   useFocusEffect(
     React.useCallback(() => {
       let cancelled = false;
+      setLocalProgressLoaded(false);
       if (!courseShort) return;
       void (async () => {
         const [done, listeningMode] = await Promise.all([
@@ -122,12 +133,28 @@ export default function LearnTab() {
         if (cancelled) return;
         setDoneMap(done);
         setListening(listeningMode);
+        setLocalProgressLoaded(true);
       })();
       return () => {
         cancelled = true;
       };
     }, [courseShort]),
   );
+
+  React.useEffect(() => {
+    if (!courseShort || !localProgressLoaded || isServerProgressPending) return;
+    void maybeRequestAppReview({
+      completedStoryCount: reviewCompletedStoryCount,
+      courseShort,
+      signedIn: Boolean(session?.session),
+    });
+  }, [
+    courseShort,
+    isServerProgressPending,
+    localProgressLoaded,
+    reviewCompletedStoryCount,
+    session?.session,
+  ]);
 
   if (!ready) return <Centered spinner styles={styles} colors={colors} />;
 

--- a/app-mobile/app/story/[id].tsx
+++ b/app-mobile/app/story/[id].tsx
@@ -12,6 +12,7 @@ import { captureMobileEventLater } from "../../src/analytics";
 import { useAuthSession } from "../../src/auth-client";
 import { useAppState } from "../../src/app-state";
 import { useNetworkStatus } from "../../src/network";
+import { markReviewPromptCompletionPending } from "../../src/reviewPrompt";
 import { getDoneMap, markStoryDone } from "../../src/storage";
 import { Reader } from "../../src/story/Reader";
 import { HintPopupHost } from "../../src/story/HintPopup";
@@ -119,16 +120,33 @@ export default function StoryScreen() {
 
   const onFinishedReached = React.useCallback(() => {
     if (!story) return;
+    const signedIn = Boolean(session?.session);
+    const knownCompletedLocally = Boolean(localDoneIds?.has(story.id));
+    const isServerProgressLoaded = !signedIn || serverDoneIds !== undefined;
+    const wasAlreadyDone = doneIds?.has(story.id) ?? true;
     if (!trackedStoryCompletion.current) {
       trackedStoryCompletion.current = true;
       captureStoryEvent("story_completed");
     }
+    if ((isServerProgressLoaded || knownCompletedLocally) && !wasAlreadyDone) {
+      void markReviewPromptCompletionPending({
+        courseShort: story.course_short,
+        storyId: story.id,
+      });
+    }
+    void markStoryDone(story.course_short, story.id);
     if (session?.session) {
       void recordStoryDone({ legacyStoryId: story.id });
-    } else {
-      void markStoryDone(story.course_short, story.id);
     }
-  }, [captureStoryEvent, recordStoryDone, session?.session, story]);
+  }, [
+    captureStoryEvent,
+    doneIds,
+    localDoneIds,
+    recordStoryDone,
+    serverDoneIds,
+    session?.session,
+    story,
+  ]);
 
   const leave = React.useCallback(() => {
     stopAudio();

--- a/app-mobile/package.json
+++ b/app-mobile/package.json
@@ -25,6 +25,7 @@
     "expo-secure-store": "~56.0.4",
     "expo-splash-screen": "~56.0.10",
     "expo-status-bar": "~56.0.4",
+    "expo-store-review": "~56.0.3",
     "expo-web-browser": "~56.0.5",
     "posthog-react-native": "^4.50.0",
     "react": "19.2.3",

--- a/app-mobile/pnpm-lock.yaml
+++ b/app-mobile/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       expo-status-bar:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      expo-store-review:
+        specifier: ~56.0.3
+        version: 56.0.3(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
       expo-web-browser:
         specifier: ~56.0.5
         version: 56.0.5(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
@@ -2105,6 +2108,12 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+      react-native: '*'
+
+  expo-store-review@56.0.3:
+    resolution: {integrity: sha512-pLlSmizlcXC3dYdydKpYtNslEEr1pyUMHH4YV/zc/HmnEIAIG752N0NadAQ+jxX5i5B8iDwOfYc9iJe9Qyc0UA==}
+    peerDependencies:
+      expo: '*'
       react-native: '*'
 
   expo-symbols@56.0.6:
@@ -5620,6 +5629,11 @@ snapshots:
     dependencies:
       expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.11)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.9.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+
+  expo-store-review@56.0.3(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)):
+    dependencies:
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.11)(react-dom@19.2.7(react@19.2.3))(react-native-worklets@0.9.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
 
   expo-symbols@56.0.6(expo-font@56.0.7)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):

--- a/app-mobile/src/reviewPrompt.ts
+++ b/app-mobile/src/reviewPrompt.ts
@@ -1,0 +1,144 @@
+import * as StoreReview from "expo-store-review";
+import { captureMobileEvent } from "./analytics";
+import { getString, removeKeys, setString, STORAGE_KEYS } from "./storage";
+
+const PROMPT_MILESTONES = [3, 10] as const;
+const COOLDOWN_MS = 75 * 24 * 60 * 60 * 1000;
+const PENDING_COMPLETION_TTL_MS = 10 * 60 * 1000;
+
+type ReviewPromptState = {
+  attemptedMilestones: number[];
+  lastAttemptedAt: number | null;
+};
+
+type PendingReviewPromptCompletion = {
+  courseShort: string;
+  storyId: number;
+  completedAt: number;
+};
+
+function parseJsonObject<T>(raw: string | null): T | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as T)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getReviewPromptState(): Promise<ReviewPromptState> {
+  const parsed = parseJsonObject<Partial<ReviewPromptState>>(
+    await getString(STORAGE_KEYS.reviewPromptState),
+  );
+  const lastAttemptedAt = parsed?.lastAttemptedAt;
+  return {
+    attemptedMilestones: Array.isArray(parsed?.attemptedMilestones)
+      ? parsed.attemptedMilestones.filter(Number.isFinite)
+      : [],
+    lastAttemptedAt:
+      typeof lastAttemptedAt === "number" && Number.isFinite(lastAttemptedAt)
+        ? lastAttemptedAt
+        : null,
+  };
+}
+
+async function setReviewPromptState(state: ReviewPromptState): Promise<void> {
+  await setString(STORAGE_KEYS.reviewPromptState, JSON.stringify(state));
+}
+
+export async function markReviewPromptCompletionPending({
+  courseShort,
+  storyId,
+}: {
+  courseShort: string;
+  storyId: number;
+}): Promise<void> {
+  await setString(
+    STORAGE_KEYS.pendingReviewPromptCompletion,
+    JSON.stringify({ courseShort, storyId, completedAt: Date.now() }),
+  );
+}
+
+function getNextMilestone(
+  completedStoryCount: number,
+  attemptedMilestones: number[],
+): number | null {
+  return (
+    PROMPT_MILESTONES.find(
+      (milestone) =>
+        completedStoryCount >= milestone && !attemptedMilestones.includes(milestone),
+    ) ?? null
+  );
+}
+
+export async function maybeRequestAppReview({
+  completedStoryCount,
+  courseShort,
+  signedIn,
+}: {
+  completedStoryCount: number;
+  courseShort: string;
+  signedIn: boolean;
+}): Promise<void> {
+  const pending = parseJsonObject<PendingReviewPromptCompletion>(
+    await getString(STORAGE_KEYS.pendingReviewPromptCompletion),
+  );
+  if (!pending || pending.courseShort !== courseShort) return;
+
+  await removeKeys([STORAGE_KEYS.pendingReviewPromptCompletion]);
+
+  const now = Date.now();
+  if (now - pending.completedAt > PENDING_COMPLETION_TTL_MS) return;
+
+  const state = await getReviewPromptState();
+  const milestone = getNextMilestone(
+    completedStoryCount,
+    state.attemptedMilestones,
+  );
+  if (!milestone) return;
+  if (state.lastAttemptedAt && now - state.lastAttemptedAt < COOLDOWN_MS) return;
+
+  const canRequestReview = await canRequestNativeReview();
+  if (!canRequestReview) {
+    await captureMobileEvent("mobile_app_review_prompt_unavailable", {
+      completed_story_count: completedStoryCount,
+      course_short: courseShort,
+      milestone,
+      signed_in: signedIn,
+    });
+    return;
+  }
+
+  try {
+    await StoreReview.requestReview();
+    await setReviewPromptState({
+      attemptedMilestones: [...state.attemptedMilestones, milestone],
+      lastAttemptedAt: now,
+    });
+    await captureMobileEvent("mobile_app_review_prompt_attempted", {
+      completed_story_count: completedStoryCount,
+      course_short: courseShort,
+      milestone,
+      signed_in: signedIn,
+    });
+  } catch (error) {
+    await captureMobileEvent("mobile_app_review_prompt_failed", {
+      completed_story_count: completedStoryCount,
+      course_short: courseShort,
+      error: error instanceof Error ? error.message : String(error),
+      milestone,
+      signed_in: signedIn,
+    });
+  }
+}
+
+async function canRequestNativeReview(): Promise<boolean> {
+  try {
+    return (await StoreReview.isAvailableAsync()) && (await StoreReview.hasAction());
+  } catch {
+    return false;
+  }
+}

--- a/app-mobile/src/storage.ts
+++ b/app-mobile/src/storage.ts
@@ -10,6 +10,8 @@ export const STORAGE_KEYS = {
   hideStoryQuestions: "hideStoryQuestions",
   themePreference: "themePreference",
   analyticsInstallationId: "analyticsInstallationId",
+  reviewPromptState: "reviewPromptState",
+  pendingReviewPromptCompletion: "pendingReviewPromptCompletion",
 };
 
 const doneKey = (courseShort: string) => `doneStories:${courseShort}`;


### PR DESCRIPTION
## Summary

Adds a native in-app review prompt to the Expo mobile app using `expo-store-review`.

The prompt is gated behind story-completion milestones: first at 3 completed stories, then again at 10 completed stories after a 75-day cooldown. It only runs after a newly completed mobile story and after the user returns to the course overview, so existing users with prior progress are not prompted on app open.

The eligibility count uses local mobile progress plus signed-in server progress, so stories completed on web count once the user completes a new story on mobile.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm --dir app-mobile typecheck`