### PR TITLE
Add mobile deep links

### DIFF
--- a/app-mobile/README.md
+++ b/app-mobile/README.md
@@ -48,13 +48,16 @@ pnpm run typecheck  # tsc --noEmit
   is computed locally from the course list.
 - **Profile tab**: account card with sign-in/register/sign-out actions,
   "hide story questions" preference, per-course progress stats, reset.
+- **Deep links**: `https://duostories.org/story/{id}` opens the reader and
+  `https://duostories.org/{course_short}` selects the course and opens Learn
+  after first-run gates. Native universal/app-link association currently matches
+  course shorts shaped like `xx-*`, which covers the existing public courses.
 
 ## Not yet implemented
 
 - **Accounts (M3)**: cloud progress sync after sign-in, password reset, and
   social login/Sign in with Apple.
-- **M4 polish**: audio prefetch to disk, dark mode, deep links, offline
-  story downloads.
+- **M4 polish**: audio prefetch to disk, dark mode, offline story downloads.
 
 ## Architecture notes
 

--- a/app-mobile/app.json
+++ b/app-mobile/app.json
@@ -11,6 +11,9 @@
       "supportsTablet": true,
       "bundleIdentifier": "org.duostories.app",
       "usesAppleSignIn": true,
+      "associatedDomains": [
+        "applinks:duostories.org"
+      ],
       "icon": "./assets/icon.png",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
@@ -28,6 +31,28 @@
         "backgroundImage": "./assets/android-icon-background.png",
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "https",
+              "host": "duostories.org",
+              "pathPrefix": "/story/"
+            },
+            {
+              "scheme": "https",
+              "host": "duostories.org",
+              "pathPattern": "/..-.*"
+            }
+          ],
+          "category": [
+            "BROWSABLE",
+            "DEFAULT"
+          ]
+        }
+      ],
       "predictiveBackGestureEnabled": false
     },
     "web": {

--- a/app-mobile/app/[course_short].tsx
+++ b/app-mobile/app/[course_short].tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { Redirect, useLocalSearchParams, useRouter } from "expo-router";
+import { useQuery } from "convex/react";
+import { api } from "../src/api";
+import { useAppState } from "../src/app-state";
+import { useNetworkStatus } from "../src/network";
+import { Button } from "../src/components/Button";
+import { Text } from "../src/components/Text";
+import { type ThemeColors, useTheme } from "../src/theme";
+
+function getCourseShortParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default function CourseDeepLinkScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const params = useLocalSearchParams<{ course_short?: string | string[] }>();
+  const linkedCourseShort = getCourseShortParam(params.course_short);
+  const {
+    ready,
+    hasSeenWelcome,
+    hasAcceptedDisclaimer,
+    setCourseShort,
+  } = useAppState();
+  const { isOffline } = useNetworkStatus();
+  const landingData = useQuery(api.landing.getPublicLandingPageData);
+  const [hasStartedCourseSelection, setHasStartedCourseSelection] =
+    React.useState(false);
+
+  const linkedCourse = React.useMemo(() => {
+    if (!landingData || !linkedCourseShort) return null;
+    for (const group of landingData.groups) {
+      const course = group.courses.find(
+        (candidate) => candidate.short === linkedCourseShort,
+      );
+      if (course) return course;
+    }
+    return null;
+  }, [landingData, linkedCourseShort]);
+
+  React.useEffect(() => {
+    if (!ready || !landingData || !linkedCourse || hasStartedCourseSelection) {
+      return;
+    }
+
+    setHasStartedCourseSelection(true);
+    void setCourseShort(linkedCourse.short).then(() => {
+      router.replace(
+        hasSeenWelcome && hasAcceptedDisclaimer ? "/(tabs)" : "/",
+      );
+    });
+  }, [
+    hasAcceptedDisclaimer,
+    hasSeenWelcome,
+    landingData,
+    linkedCourse,
+    ready,
+    router,
+    hasStartedCourseSelection,
+    setCourseShort,
+  ]);
+
+  if (!linkedCourseShort) return <Redirect href="/" />;
+
+  if (!ready || (!landingData && !isOffline) || linkedCourse) {
+    return (
+      <View style={styles.root}>
+        <ActivityIndicator color={colors.blue} />
+      </View>
+    );
+  }
+
+  if (isOffline && !landingData) {
+    return (
+      <View style={styles.root}>
+        <Text style={styles.title}>You're offline</Text>
+        <Text style={styles.body}>
+          Connect to the internet to open this course.
+        </Text>
+        <Button
+          title="Go home"
+          variant="secondary"
+          onPress={() => router.replace("/")}
+          style={styles.button}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.title}>Course not available</Text>
+      <Text style={styles.body}>
+        This link does not match an available Duostories course.
+      </Text>
+      <Button
+        title="Pick a course"
+        onPress={() => router.replace("/add-course")}
+        style={styles.button}
+      />
+    </View>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    root: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: colors.background,
+      paddingHorizontal: 28,
+    },
+    title: {
+      fontSize: 24,
+      fontWeight: "800",
+      color: colors.text,
+      textAlign: "center",
+    },
+    body: {
+      marginTop: 10,
+      fontSize: 16,
+      lineHeight: 24,
+      color: colors.textDim,
+      textAlign: "center",
+    },
+    button: {
+      marginTop: 18,
+      alignSelf: "stretch",
+    },
+  });
+}

--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,28 @@ module.exports = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  async headers() {
+    return [
+      {
+        source: "/.well-known/apple-app-site-association",
+        headers: [
+          {
+            key: "Content-Type",
+            value: "application/json",
+          },
+        ],
+      },
+      {
+        source: "/.well-known/assetlinks.json",
+        headers: [
+          {
+            key: "Content-Type",
+            value: "application/json",
+          },
+        ],
+      },
+    ];
+  },
   // PostHog reverse proxy to avoid ad blockers
   async rewrites() {
     return [

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,14 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "WLCA6C349S.org.duostories.app",
+        "paths": [
+          "/story/*",
+          "/??-*"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add iOS Universal Links and Android App Links config for `duostories.org`
- add a mobile course deep-link route for `/{course_short}`
- host the iOS `apple-app-site-association` file and ensure well-known JSON content types
- document current deep-link support in the mobile README

## Verification
- `pnpm run format`
- `pnpm typecheck`
- `pnpm --dir app-mobile typecheck`
- `pnpm run lint`
- `pnpm --dir app-mobile exec expo config --type public`
- parsed `public/.well-known/apple-app-site-association` and `public/.well-known/assetlinks.json` as JSON

## Adversarial Review Notes
- Android App Links depend on the existing `public/.well-known/assetlinks.json` fingerprints matching the production signing credentials for `org.duostories.twa`.
- Native course URL association currently matches the existing course-short shape `xx-*`; if future course IDs move outside that shape, the native association patterns will need updating.
- First-run users who open a course link still pass through the normal Welcome/Disclaimer gates before landing on Learn.
