### PR TITLE
Fix mobile hint tap handoff

### DIFF
--- a/app-mobile/src/story/HintPopup.tsx
+++ b/app-mobile/src/story/HintPopup.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Pressable, StyleSheet, View } from "react-native";
+import { Dimensions, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "../components/Text";
 import { type ThemeColors, useTheme } from "../theme";
@@ -93,34 +93,37 @@ export function HintPopupHost({ children }: { children: React.ReactNode }) {
 
   return (
     <HintPopupContext.Provider value={api}>
-      <View style={styles.root}>
+      <View
+        onStartShouldSetResponderCapture={() => {
+          if (hint) hide();
+          return false;
+        }}
+        style={styles.root}
+      >
         {children}
         {hint && (
-          <>
-            <Pressable style={styles.dismissLayer} onPress={hide} />
-            <View
-              pointerEvents="none"
-              onLayout={(event) => {
-                const height = event.nativeEvent.layout.height;
-                if (height > 0 && Math.abs(height - bubbleHeight) > 0.5) {
-                  setBubbleHeight(height);
-                }
-              }}
-              style={[
-                styles.bubble,
-                {
-                  left: bubbleLeft,
-                  top: bubbleTop,
-                  width: estimatedBubbleWidth,
-                },
-              ]}
-            >
-              <Text style={styles.translation}>{hint.translation}</Text>
-              {hint.pronunciation ? (
-                <Text style={styles.pronunciation}>{hint.pronunciation}</Text>
-              ) : null}
-            </View>
-          </>
+          <View
+            pointerEvents="none"
+            onLayout={(event) => {
+              const height = event.nativeEvent.layout.height;
+              if (height > 0 && Math.abs(height - bubbleHeight) > 0.5) {
+                setBubbleHeight(height);
+              }
+            }}
+            style={[
+              styles.bubble,
+              {
+                left: bubbleLeft,
+                top: bubbleTop,
+                width: estimatedBubbleWidth,
+              },
+            ]}
+          >
+            <Text style={styles.translation}>{hint.translation}</Text>
+            {hint.pronunciation ? (
+              <Text style={styles.pronunciation}>{hint.pronunciation}</Text>
+            ) : null}
+          </View>
         )}
       </View>
     </HintPopupContext.Provider>
@@ -131,14 +134,6 @@ function createStyles(colors: ThemeColors) {
   return StyleSheet.create({
   root: {
     flex: 1,
-  },
-  dismissLayer: {
-    position: "absolute",
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-    zIndex: 99,
   },
   bubble: {
     position: "absolute",


### PR DESCRIPTION
## Summary

Fixes the Expo story hint popup so tapping a second hinted word opens that hint immediately instead of first dismissing the previous popup.

## Root cause

`HintPopupHost` rendered a full-screen `Pressable` dismiss layer above the story whenever a hint was open. On mobile, that layer consumed the next tap, so the intended hint word never received the press event.

## Change

The host now dismisses an existing hint during responder capture and returns `false`, allowing the same touch to continue to the underlying word. The popup bubble remains `pointerEvents="none"`.

## Validation

- `corepack pnpm run format`
- `corepack pnpm typecheck`
- `corepack pnpm run lint`
- `cd app-mobile && corepack pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated hint popup dismissal so it closes more reliably when users interact with the screen.
  * Kept the popup’s content, layout, and pronunciation display behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->