### PR TITLE
Restore iOS liquid glass tab behavior

### DIFF
--- a/app-mobile/app/(tabs)/_layout.tsx
+++ b/app-mobile/app/(tabs)/_layout.tsx
@@ -6,6 +6,15 @@ import { useTheme } from "../../src/theme";
 
 export default function TabsLayout() {
   const { colors } = useTheme();
+  const iosMajorVersion =
+    Platform.OS === "ios"
+      ? Number.parseInt(String(Platform.Version), 10)
+      : undefined;
+  const usesLiquidGlassTabs =
+    Platform.OS === "ios" && (iosMajorVersion ?? 0) >= 26;
+  const tabBarBackgroundColor = usesLiquidGlassTabs
+    ? undefined
+    : colors.background;
   const glassAdaptiveColor =
     Platform.OS === "ios"
       ? DynamicColorIOS({
@@ -16,8 +25,11 @@ export default function TabsLayout() {
 
   return (
     <NativeTabs
-      backgroundColor={Platform.OS === "ios" ? undefined : colors.background}
-      blurEffect="systemDefault"
+      backgroundColor={tabBarBackgroundColor}
+      blurEffect={usesLiquidGlassTabs ? "systemDefault" : "none"}
+      disableTransparentOnScrollEdge={
+        Platform.OS === "ios" && !usesLiquidGlassTabs ? true : undefined
+      }
       iconColor={{
         default: colors.disabled,
         selected: glassAdaptiveColor,
@@ -35,7 +47,7 @@ export default function TabsLayout() {
           fontWeight: "400",
         },
       }}
-      minimizeBehavior="automatic"
+      minimizeBehavior={usesLiquidGlassTabs ? "automatic" : undefined}
       shadowColor={Platform.OS === "ios" ? "transparent" : colors.border}
       tintColor={glassAdaptiveColor}
     >

--- a/app-mobile/app/(tabs)/_layout.tsx
+++ b/app-mobile/app/(tabs)/_layout.tsx
@@ -18,7 +18,6 @@ export default function TabsLayout() {
     <NativeTabs
       backgroundColor={Platform.OS === "ios" ? undefined : colors.background}
       blurEffect="systemDefault"
-      disableTransparentOnScrollEdge
       iconColor={{
         default: colors.disabled,
         selected: glassAdaptiveColor,
@@ -36,7 +35,7 @@ export default function TabsLayout() {
           fontWeight: "400",
         },
       }}
-      minimizeBehavior="never"
+      minimizeBehavior="automatic"
       shadowColor={Platform.OS === "ios" ? "transparent" : colors.border}
       tintColor={glassAdaptiveColor}
     >

--- a/app-mobile/app/(tabs)/courses.tsx
+++ b/app-mobile/app/(tabs)/courses.tsx
@@ -516,7 +516,6 @@ function createStyles(colors: ThemeColors) {
   },
   listContent: {
     paddingHorizontal: 16,
-    paddingBottom: 30,
   },
   card: {
     borderWidth: 2,

--- a/app-mobile/app/(tabs)/courses.tsx
+++ b/app-mobile/app/(tabs)/courses.tsx
@@ -29,12 +29,10 @@ import {
   getAllCourseProgress,
   type CourseProgress,
 } from "../../src/storage";
-import { TAB_BAR_CONTENT_BOTTOM_INSET } from "../../src/tabBarInsets";
 import { type ThemeColors, useTheme } from "../../src/theme";
+import { useTabContentInsets } from "../../src/useTabContentInsets";
 
-type LandingData = FunctionReturnType<
-  typeof api.landing.getPublicLandingPageData
->;
+type LandingData = FunctionReturnType<typeof api.landing.getPublicLandingPageData>;
 type LandingGroup = LandingData["groups"][number];
 type CourseItem = LandingGroup["courses"][number] & {
   fromLanguageName: string;
@@ -44,6 +42,7 @@ export default function CoursesTab() {
   const router = useRouter();
   const { colors } = useTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const tabContentInsets = useTabContentInsets();
   const { courseShort, activeCourseShorts, removeCourseShort, setCourseShort } =
     useAppState();
   const { data: session } = useAuthSession();
@@ -106,7 +105,9 @@ export default function CoursesTab() {
     }
     return activeShorts
       .map((short) => byShort.get(short))
-      .filter((course): course is NonNullable<typeof course> => Boolean(course))
+      .filter((course): course is NonNullable<typeof course> =>
+        Boolean(course),
+      )
       .sort((a, b) => {
         if (a.short === courseShort) return -1;
         if (b.short === courseShort) return 1;
@@ -372,7 +373,7 @@ export default function CoursesTab() {
           data={courses}
           keyExtractor={(course) => course.short}
           renderItem={renderCourse}
-          contentContainerStyle={styles.listContent}
+          contentContainerStyle={[styles.listContent, tabContentInsets]}
           ListHeaderComponent={
             isOffline ? (
               <OfflineNotice detail="Connect to the internet to switch or add courses." />
@@ -463,194 +464,194 @@ export default function CoursesTab() {
 
 function createStyles(colors: ThemeColors) {
   return StyleSheet.create({
-    root: {
-      flex: 1,
-      backgroundColor: colors.background,
-    },
-    header: {
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "space-between",
-      gap: 16,
-      paddingHorizontal: 16,
-      paddingTop: 8,
-      paddingBottom: 10,
-    },
-    title: {
-      fontSize: 28,
-      fontWeight: "800",
-      color: colors.text,
-    },
-    subtitle: {
-      fontSize: 15,
-      color: colors.textDim,
-      marginTop: 2,
-    },
-    loading: {
-      flex: 1,
-      alignItems: "center",
-      justifyContent: "center",
-    },
-    empty: {
-      flex: 1,
-      alignItems: "center",
-      justifyContent: "center",
-      paddingHorizontal: 28,
-    },
-    emptyTitle: {
-      fontSize: 22,
-      fontWeight: "800",
-      color: colors.text,
-      textAlign: "center",
-    },
-    emptyText: {
-      marginTop: 8,
-      fontSize: 16,
-      color: colors.textDim,
-      textAlign: "center",
-    },
-    emptyButton: {
-      marginTop: 18,
-      alignSelf: "stretch",
-    },
-    listContent: {
-      paddingHorizontal: 16,
-      paddingBottom: TAB_BAR_CONTENT_BOTTOM_INSET,
-    },
-    card: {
-      borderWidth: 2,
-      borderColor: colors.border,
-      borderRadius: 14,
-      padding: 16,
-      marginTop: 12,
-      backgroundColor: colors.surface,
-    },
-    cardSelected: {
-      borderColor: colors.blue,
-      backgroundColor: colors.blueLight,
-    },
-    cardDisabled: {
-      opacity: 0.55,
-    },
-    cardContent: {
-      flexDirection: "row",
-      alignItems: "flex-start",
-      gap: 14,
-    },
-    cardBody: {
-      flex: 1,
-    },
-    cardTop: {
-      flexDirection: "row",
-      alignItems: "flex-start",
-      justifyContent: "space-between",
-      gap: 12,
-    },
-    cardTitleWrap: {
-      flex: 1,
-    },
-    cardActions: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 8,
-    },
-    cardActionButton: {
-      width: 32,
-      height: 32,
-      borderRadius: 16,
-      alignItems: "center",
-      justifyContent: "center",
-      borderWidth: 2,
-      borderColor: colors.border,
-      backgroundColor: colors.surface,
-    },
-    courseName: {
-      fontSize: 20,
-      fontWeight: "800",
-      color: colors.text,
-    },
-    courseMeta: {
-      fontSize: 14,
-      color: colors.textDim,
-      marginTop: 2,
-    },
-    currentBadge: {
-      overflow: "hidden",
-      borderRadius: 999,
-      paddingHorizontal: 10,
-      paddingVertical: 4,
-      backgroundColor: colors.greenLight,
-      color: colors.greenDark,
-      fontSize: 12,
-      fontWeight: "800",
-      textTransform: "uppercase",
-    },
-    progressTrack: {
-      height: 10,
-      borderRadius: 5,
-      backgroundColor: colors.border,
-      overflow: "hidden",
-      marginTop: 14,
-    },
-    progressFill: {
-      height: "100%",
-      borderRadius: 5,
-      backgroundColor: colors.gold,
-    },
-    progressText: {
-      fontSize: 14,
-      color: colors.textDim,
-      marginTop: 8,
-    },
-    sheetBackdrop: {
-      flex: 1,
-      justifyContent: "flex-end",
-      backgroundColor: "rgba(0, 0, 0, 0.35)",
-    },
-    sheet: {
-      paddingHorizontal: 20,
-      paddingTop: 18,
-      paddingBottom: 28,
-      borderTopLeftRadius: 24,
-      borderTopRightRadius: 24,
-      backgroundColor: colors.surface,
-    },
-    sheetTitle: {
-      fontSize: 18,
-      fontWeight: "800",
-      color: colors.text,
-      marginBottom: 12,
-    },
-    sheetAction: {
-      minHeight: 54,
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 12,
-      borderRadius: 14,
-    },
-    sheetDestructiveText: {
-      fontSize: 18,
-      fontWeight: "700",
-      color: colors.red,
-    },
-    sheetActionText: {
-      fontSize: 18,
-      fontWeight: "700",
-      color: colors.text,
-    },
-    sheetCancel: {
-      minHeight: 54,
-      alignItems: "center",
-      justifyContent: "center",
-      marginTop: 8,
-      borderRadius: 14,
-      borderWidth: 2,
-      borderColor: colors.border,
-    },
-    sheetCancelText: {
-      fontSize: 17,
-      fontWeight: "800",
-      color: colors.text,
-    },
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 16,
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 10,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  subtitle: {
+    fontSize: 15,
+    color: colors.textDim,
+    marginTop: 2,
+  },
+  loading: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  empty: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 28,
+  },
+  emptyTitle: {
+    fontSize: 22,
+    fontWeight: "800",
+    color: colors.text,
+    textAlign: "center",
+  },
+  emptyText: {
+    marginTop: 8,
+    fontSize: 16,
+    color: colors.textDim,
+    textAlign: "center",
+  },
+  emptyButton: {
+    marginTop: 18,
+    alignSelf: "stretch",
+  },
+  listContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 30,
+  },
+  card: {
+    borderWidth: 2,
+    borderColor: colors.border,
+    borderRadius: 14,
+    padding: 16,
+    marginTop: 12,
+    backgroundColor: colors.surface,
+  },
+  cardSelected: {
+    borderColor: colors.blue,
+    backgroundColor: colors.blueLight,
+  },
+  cardDisabled: {
+    opacity: 0.55,
+  },
+  cardContent: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 14,
+  },
+  cardBody: {
+    flex: 1,
+  },
+  cardTop: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  cardTitleWrap: {
+    flex: 1,
+  },
+  cardActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  cardActionButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 2,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  courseName: {
+    fontSize: 20,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  courseMeta: {
+    fontSize: 14,
+    color: colors.textDim,
+    marginTop: 2,
+  },
+  currentBadge: {
+    overflow: "hidden",
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    backgroundColor: colors.greenLight,
+    color: colors.greenDark,
+    fontSize: 12,
+    fontWeight: "800",
+    textTransform: "uppercase",
+  },
+  progressTrack: {
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: colors.border,
+    overflow: "hidden",
+    marginTop: 14,
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 5,
+    backgroundColor: colors.gold,
+  },
+  progressText: {
+    fontSize: 14,
+    color: colors.textDim,
+    marginTop: 8,
+  },
+  sheetBackdrop: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0, 0, 0, 0.35)",
+  },
+  sheet: {
+    paddingHorizontal: 20,
+    paddingTop: 18,
+    paddingBottom: 28,
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    backgroundColor: colors.surface,
+  },
+  sheetTitle: {
+    fontSize: 18,
+    fontWeight: "800",
+    color: colors.text,
+    marginBottom: 12,
+  },
+  sheetAction: {
+    minHeight: 54,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderRadius: 14,
+  },
+  sheetDestructiveText: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: colors.red,
+  },
+  sheetActionText: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  sheetCancel: {
+    minHeight: 54,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 8,
+    borderRadius: 14,
+    borderWidth: 2,
+    borderColor: colors.border,
+  },
+  sheetCancelText: {
+    fontSize: 17,
+    fontWeight: "800",
+    color: colors.text,
+  },
   });
 }

--- a/app-mobile/app/(tabs)/courses.tsx
+++ b/app-mobile/app/(tabs)/courses.tsx
@@ -29,9 +29,12 @@ import {
   getAllCourseProgress,
   type CourseProgress,
 } from "../../src/storage";
+import { TAB_BAR_CONTENT_BOTTOM_INSET } from "../../src/tabBarInsets";
 import { type ThemeColors, useTheme } from "../../src/theme";
 
-type LandingData = FunctionReturnType<typeof api.landing.getPublicLandingPageData>;
+type LandingData = FunctionReturnType<
+  typeof api.landing.getPublicLandingPageData
+>;
 type LandingGroup = LandingData["groups"][number];
 type CourseItem = LandingGroup["courses"][number] & {
   fromLanguageName: string;
@@ -103,9 +106,7 @@ export default function CoursesTab() {
     }
     return activeShorts
       .map((short) => byShort.get(short))
-      .filter((course): course is NonNullable<typeof course> =>
-        Boolean(course),
-      )
+      .filter((course): course is NonNullable<typeof course> => Boolean(course))
       .sort((a, b) => {
         if (a.short === courseShort) return -1;
         if (b.short === courseShort) return 1;
@@ -462,194 +463,194 @@ export default function CoursesTab() {
 
 function createStyles(colors: ThemeColors) {
   return StyleSheet.create({
-  root: {
-    flex: 1,
-    backgroundColor: colors.background,
-  },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 16,
-    paddingHorizontal: 16,
-    paddingTop: 8,
-    paddingBottom: 10,
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: "800",
-    color: colors.text,
-  },
-  subtitle: {
-    fontSize: 15,
-    color: colors.textDim,
-    marginTop: 2,
-  },
-  loading: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  empty: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 28,
-  },
-  emptyTitle: {
-    fontSize: 22,
-    fontWeight: "800",
-    color: colors.text,
-    textAlign: "center",
-  },
-  emptyText: {
-    marginTop: 8,
-    fontSize: 16,
-    color: colors.textDim,
-    textAlign: "center",
-  },
-  emptyButton: {
-    marginTop: 18,
-    alignSelf: "stretch",
-  },
-  listContent: {
-    paddingHorizontal: 16,
-    paddingBottom: 30,
-  },
-  card: {
-    borderWidth: 2,
-    borderColor: colors.border,
-    borderRadius: 14,
-    padding: 16,
-    marginTop: 12,
-    backgroundColor: colors.surface,
-  },
-  cardSelected: {
-    borderColor: colors.blue,
-    backgroundColor: colors.blueLight,
-  },
-  cardDisabled: {
-    opacity: 0.55,
-  },
-  cardContent: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 14,
-  },
-  cardBody: {
-    flex: 1,
-  },
-  cardTop: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    justifyContent: "space-between",
-    gap: 12,
-  },
-  cardTitleWrap: {
-    flex: 1,
-  },
-  cardActions: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
-  cardActionButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    alignItems: "center",
-    justifyContent: "center",
-    borderWidth: 2,
-    borderColor: colors.border,
-    backgroundColor: colors.surface,
-  },
-  courseName: {
-    fontSize: 20,
-    fontWeight: "800",
-    color: colors.text,
-  },
-  courseMeta: {
-    fontSize: 14,
-    color: colors.textDim,
-    marginTop: 2,
-  },
-  currentBadge: {
-    overflow: "hidden",
-    borderRadius: 999,
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    backgroundColor: colors.greenLight,
-    color: colors.greenDark,
-    fontSize: 12,
-    fontWeight: "800",
-    textTransform: "uppercase",
-  },
-  progressTrack: {
-    height: 10,
-    borderRadius: 5,
-    backgroundColor: colors.border,
-    overflow: "hidden",
-    marginTop: 14,
-  },
-  progressFill: {
-    height: "100%",
-    borderRadius: 5,
-    backgroundColor: colors.gold,
-  },
-  progressText: {
-    fontSize: 14,
-    color: colors.textDim,
-    marginTop: 8,
-  },
-  sheetBackdrop: {
-    flex: 1,
-    justifyContent: "flex-end",
-    backgroundColor: "rgba(0, 0, 0, 0.35)",
-  },
-  sheet: {
-    paddingHorizontal: 20,
-    paddingTop: 18,
-    paddingBottom: 28,
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    backgroundColor: colors.surface,
-  },
-  sheetTitle: {
-    fontSize: 18,
-    fontWeight: "800",
-    color: colors.text,
-    marginBottom: 12,
-  },
-  sheetAction: {
-    minHeight: 54,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    borderRadius: 14,
-  },
-  sheetDestructiveText: {
-    fontSize: 18,
-    fontWeight: "700",
-    color: colors.red,
-  },
-  sheetActionText: {
-    fontSize: 18,
-    fontWeight: "700",
-    color: colors.text,
-  },
-  sheetCancel: {
-    minHeight: 54,
-    alignItems: "center",
-    justifyContent: "center",
-    marginTop: 8,
-    borderRadius: 14,
-    borderWidth: 2,
-    borderColor: colors.border,
-  },
-  sheetCancelText: {
-    fontSize: 17,
-    fontWeight: "800",
-    color: colors.text,
-  },
+    root: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: 16,
+      paddingHorizontal: 16,
+      paddingTop: 8,
+      paddingBottom: 10,
+    },
+    title: {
+      fontSize: 28,
+      fontWeight: "800",
+      color: colors.text,
+    },
+    subtitle: {
+      fontSize: 15,
+      color: colors.textDim,
+      marginTop: 2,
+    },
+    loading: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    empty: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      paddingHorizontal: 28,
+    },
+    emptyTitle: {
+      fontSize: 22,
+      fontWeight: "800",
+      color: colors.text,
+      textAlign: "center",
+    },
+    emptyText: {
+      marginTop: 8,
+      fontSize: 16,
+      color: colors.textDim,
+      textAlign: "center",
+    },
+    emptyButton: {
+      marginTop: 18,
+      alignSelf: "stretch",
+    },
+    listContent: {
+      paddingHorizontal: 16,
+      paddingBottom: TAB_BAR_CONTENT_BOTTOM_INSET,
+    },
+    card: {
+      borderWidth: 2,
+      borderColor: colors.border,
+      borderRadius: 14,
+      padding: 16,
+      marginTop: 12,
+      backgroundColor: colors.surface,
+    },
+    cardSelected: {
+      borderColor: colors.blue,
+      backgroundColor: colors.blueLight,
+    },
+    cardDisabled: {
+      opacity: 0.55,
+    },
+    cardContent: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: 14,
+    },
+    cardBody: {
+      flex: 1,
+    },
+    cardTop: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+      gap: 12,
+    },
+    cardTitleWrap: {
+      flex: 1,
+    },
+    cardActions: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+    },
+    cardActionButton: {
+      width: 32,
+      height: 32,
+      borderRadius: 16,
+      alignItems: "center",
+      justifyContent: "center",
+      borderWidth: 2,
+      borderColor: colors.border,
+      backgroundColor: colors.surface,
+    },
+    courseName: {
+      fontSize: 20,
+      fontWeight: "800",
+      color: colors.text,
+    },
+    courseMeta: {
+      fontSize: 14,
+      color: colors.textDim,
+      marginTop: 2,
+    },
+    currentBadge: {
+      overflow: "hidden",
+      borderRadius: 999,
+      paddingHorizontal: 10,
+      paddingVertical: 4,
+      backgroundColor: colors.greenLight,
+      color: colors.greenDark,
+      fontSize: 12,
+      fontWeight: "800",
+      textTransform: "uppercase",
+    },
+    progressTrack: {
+      height: 10,
+      borderRadius: 5,
+      backgroundColor: colors.border,
+      overflow: "hidden",
+      marginTop: 14,
+    },
+    progressFill: {
+      height: "100%",
+      borderRadius: 5,
+      backgroundColor: colors.gold,
+    },
+    progressText: {
+      fontSize: 14,
+      color: colors.textDim,
+      marginTop: 8,
+    },
+    sheetBackdrop: {
+      flex: 1,
+      justifyContent: "flex-end",
+      backgroundColor: "rgba(0, 0, 0, 0.35)",
+    },
+    sheet: {
+      paddingHorizontal: 20,
+      paddingTop: 18,
+      paddingBottom: 28,
+      borderTopLeftRadius: 24,
+      borderTopRightRadius: 24,
+      backgroundColor: colors.surface,
+    },
+    sheetTitle: {
+      fontSize: 18,
+      fontWeight: "800",
+      color: colors.text,
+      marginBottom: 12,
+    },
+    sheetAction: {
+      minHeight: 54,
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      borderRadius: 14,
+    },
+    sheetDestructiveText: {
+      fontSize: 18,
+      fontWeight: "700",
+      color: colors.red,
+    },
+    sheetActionText: {
+      fontSize: 18,
+      fontWeight: "700",
+      color: colors.text,
+    },
+    sheetCancel: {
+      minHeight: 54,
+      alignItems: "center",
+      justifyContent: "center",
+      marginTop: 8,
+      borderRadius: 14,
+      borderWidth: 2,
+      borderColor: colors.border,
+    },
+    sheetCancelText: {
+      fontSize: 17,
+      fontWeight: "800",
+      color: colors.text,
+    },
   });
 }

--- a/app-mobile/app/(tabs)/index.tsx
+++ b/app-mobile/app/(tabs)/index.tsx
@@ -22,10 +22,14 @@ import {
   setListeningMode,
   type DoneMap,
 } from "../../src/storage";
-import { StoryButton, type StoryListItem } from "../../src/components/StoryButton";
+import {
+  StoryButton,
+  type StoryListItem,
+} from "../../src/components/StoryButton";
 import { Button } from "../../src/components/Button";
 import { OfflineNotice } from "../../src/components/OfflineNotice";
 import { Text } from "../../src/components/Text";
+import { TAB_BAR_CONTENT_BOTTOM_INSET } from "../../src/tabBarInsets";
 import { type ThemeColors, useTheme } from "../../src/theme";
 
 type StorySet = { setId: number; stories: StoryListItem[] };
@@ -60,7 +64,8 @@ export default function LearnTab() {
     [doneMap],
   );
   const stories = React.useMemo(
-    () => (course && course !== null ? (course.stories as StoryListItem[]) : []),
+    () =>
+      course && course !== null ? (course.stories as StoryListItem[]) : [],
     [course],
   );
   const isStoryDone = React.useCallback(
@@ -284,11 +289,7 @@ function Centered({
   return (
     <SafeAreaView style={activeStyles.root} edges={["top"]}>
       <View style={activeStyles.centered}>
-        {spinner ? (
-          <ActivityIndicator color={activeColors.blue} />
-        ) : (
-          children
-        )}
+        {spinner ? <ActivityIndicator color={activeColors.blue} /> : children}
       </View>
     </SafeAreaView>
   );
@@ -322,6 +323,7 @@ function createStyles(colors: ThemeColors) {
     scrollContent: {
       paddingHorizontal: 12,
       paddingTop: 8,
+      paddingBottom: TAB_BAR_CONTENT_BOTTOM_INSET,
     },
     offlineWrap: {
       paddingHorizontal: 8,

--- a/app-mobile/app/(tabs)/index.tsx
+++ b/app-mobile/app/(tabs)/index.tsx
@@ -22,15 +22,12 @@ import {
   setListeningMode,
   type DoneMap,
 } from "../../src/storage";
-import {
-  StoryButton,
-  type StoryListItem,
-} from "../../src/components/StoryButton";
+import { StoryButton, type StoryListItem } from "../../src/components/StoryButton";
 import { Button } from "../../src/components/Button";
 import { OfflineNotice } from "../../src/components/OfflineNotice";
 import { Text } from "../../src/components/Text";
-import { TAB_BAR_CONTENT_BOTTOM_INSET } from "../../src/tabBarInsets";
 import { type ThemeColors, useTheme } from "../../src/theme";
+import { useTabContentInsets } from "../../src/useTabContentInsets";
 
 type StorySet = { setId: number; stories: StoryListItem[] };
 
@@ -39,6 +36,7 @@ export default function LearnTab() {
   const router = useRouter();
   const { colors } = useTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const tabContentInsets = useTabContentInsets();
   const { ready, courseShort } = useAppState();
   const { data: session } = useAuthSession();
   const { isOffline } = useNetworkStatus();
@@ -64,8 +62,7 @@ export default function LearnTab() {
     [doneMap],
   );
   const stories = React.useMemo(
-    () =>
-      course && course !== null ? (course.stories as StoryListItem[]) : [],
+    () => (course && course !== null ? (course.stories as StoryListItem[]) : []),
     [course],
   );
   const isStoryDone = React.useCallback(
@@ -252,7 +249,7 @@ export default function LearnTab() {
         data={sets}
         keyExtractor={(set) => String(set.setId)}
         renderItem={renderStorySet}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[styles.scrollContent, tabContentInsets]}
         ListHeaderComponent={
           isOffline ? (
             <View style={styles.offlineWrap}>
@@ -260,7 +257,6 @@ export default function LearnTab() {
             </View>
           ) : null
         }
-        ListFooterComponent={<View style={styles.listFooter} />}
         initialNumToRender={3}
         maxToRenderPerBatch={3}
         removeClippedSubviews={Platform.OS === "android"}
@@ -289,7 +285,11 @@ function Centered({
   return (
     <SafeAreaView style={activeStyles.root} edges={["top"]}>
       <View style={activeStyles.centered}>
-        {spinner ? <ActivityIndicator color={activeColors.blue} /> : children}
+        {spinner ? (
+          <ActivityIndicator color={activeColors.blue} />
+        ) : (
+          children
+        )}
       </View>
     </SafeAreaView>
   );
@@ -323,7 +323,6 @@ function createStyles(colors: ThemeColors) {
     scrollContent: {
       paddingHorizontal: 12,
       paddingTop: 8,
-      paddingBottom: TAB_BAR_CONTENT_BOTTOM_INSET,
     },
     offlineWrap: {
       paddingHorizontal: 8,
@@ -384,9 +383,6 @@ function createStyles(colors: ThemeColors) {
       flexDirection: "row",
       flexWrap: "wrap",
       justifyContent: "center",
-    },
-    listFooter: {
-      height: 40,
     },
   });
 }

--- a/app-mobile/app/(tabs)/profile.tsx
+++ b/app-mobile/app/(tabs)/profile.tsx
@@ -22,12 +22,12 @@ import { useAppState } from "../../src/app-state";
 import { clearAllProgress, getAllProgress } from "../../src/storage";
 import { Button } from "../../src/components/Button";
 import { Text } from "../../src/components/Text";
-import { TAB_BAR_CONTENT_BOTTOM_INSET } from "../../src/tabBarInsets";
 import {
   type ThemeColors,
   type ThemePreference,
   useTheme,
 } from "../../src/theme";
+import { useTabContentInsets } from "../../src/useTabContentInsets";
 
 export default function ProfileTab() {
   const router = useRouter();
@@ -38,6 +38,7 @@ export default function ProfileTab() {
     setPreference: setThemePreference,
   } = useTheme();
   const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const tabContentInsets = useTabContentInsets();
   const { hideStoryQuestions, resetToFirstRun, setHideStoryQuestions } =
     useAppState();
   const { data: session, isPending: isSessionPending } = useAuthSession();
@@ -144,7 +145,9 @@ export default function ProfileTab() {
 
   return (
     <SafeAreaView style={styles.root} edges={["top"]}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ScrollView
+        contentContainerStyle={[styles.scrollContent, tabContentInsets]}
+      >
         <Text style={styles.title}>Profile</Text>
 
         <View style={styles.card}>
@@ -320,121 +323,120 @@ export default function ProfileTab() {
 
 function createStyles(colors: ThemeColors) {
   return StyleSheet.create({
-    root: {
-      flex: 1,
-      backgroundColor: colors.background,
-    },
-    scrollContent: {
-      paddingHorizontal: 16,
-      paddingBottom: TAB_BAR_CONTENT_BOTTOM_INSET,
-    },
-    title: {
-      fontSize: 28,
-      fontWeight: "800",
-      color: colors.text,
-      marginTop: 8,
-    },
-    card: {
-      backgroundColor: colors.blueLight,
-      borderRadius: 18,
-      padding: 18,
-      marginTop: 16,
-    },
-    cardTitle: {
-      fontSize: 18,
-      fontWeight: "800",
-      color: colors.text,
-    },
-    cardBody: {
-      fontSize: 15,
-      lineHeight: 22,
-      color: colors.textDim,
-      marginTop: 6,
-    },
-    cardActions: {
-      marginTop: 14,
-      gap: 10,
-    },
-    sectionTitle: {
-      fontSize: 20,
-      fontWeight: "800",
-      color: colors.text,
-      marginTop: 28,
-      marginBottom: 10,
-    },
-    settingRow: {
-      flexDirection: "row",
-      alignItems: "center",
-      gap: 12,
-    },
-    settingBlock: {
-      gap: 10,
-      marginBottom: 16,
-    },
-    settingText: {
-      flex: 1,
-    },
-    themeOptions: {
-      flexDirection: "row",
-      gap: 8,
-    },
-    themeOption: {
-      flex: 1,
-      alignItems: "center",
-      justifyContent: "center",
-      borderRadius: 12,
-      borderWidth: 2,
-      borderColor: colors.border,
-      backgroundColor: colors.surface,
-      paddingVertical: 10,
-    },
-    themeOptionSelected: {
-      borderColor: colors.blue,
-      backgroundColor: colors.blueLight,
-    },
-    themeOptionText: {
-      color: colors.textDim,
-      fontSize: 13,
-      fontWeight: "800",
-      textTransform: "uppercase",
-    },
-    themeOptionTextSelected: {
-      color: colors.blue,
-    },
-    settingLabel: {
-      fontSize: 16,
-      fontWeight: "700",
-      color: colors.text,
-    },
-    settingHint: {
-      fontSize: 13,
-      color: colors.textDim,
-      marginTop: 2,
-    },
-    progressRow: {
-      flexDirection: "row",
-      justifyContent: "space-between",
-      alignItems: "center",
-      paddingVertical: 8,
-      borderBottomWidth: 1,
-      borderBottomColor: colors.border,
-    },
-    progressCourse: {
-      fontSize: 15,
-      fontWeight: "600",
-      color: colors.text,
-      flexShrink: 1,
-    },
-    progressCount: {
-      fontSize: 15,
-      color: colors.textDim,
-      marginLeft: 10,
-    },
-    version: {
-      fontSize: 13,
-      color: colors.textDim,
-      marginTop: 16,
-      lineHeight: 19,
-    },
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "800",
+    color: colors.text,
+    marginTop: 8,
+  },
+  card: {
+    backgroundColor: colors.blueLight,
+    borderRadius: 18,
+    padding: 18,
+    marginTop: 16,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  cardBody: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: colors.textDim,
+    marginTop: 6,
+  },
+  cardActions: {
+    marginTop: 14,
+    gap: 10,
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: "800",
+    color: colors.text,
+    marginTop: 28,
+    marginBottom: 10,
+  },
+  settingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  settingBlock: {
+    gap: 10,
+    marginBottom: 16,
+  },
+  settingText: {
+    flex: 1,
+  },
+  themeOptions: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  themeOption: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    paddingVertical: 10,
+  },
+  themeOptionSelected: {
+    borderColor: colors.blue,
+    backgroundColor: colors.blueLight,
+  },
+  themeOptionText: {
+    color: colors.textDim,
+    fontSize: 13,
+    fontWeight: "800",
+    textTransform: "uppercase",
+  },
+  themeOptionTextSelected: {
+    color: colors.blue,
+  },
+  settingLabel: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  settingHint: {
+    fontSize: 13,
+    color: colors.textDim,
+    marginTop: 2,
+  },
+  progressRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  progressCourse: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.text,
+    flexShrink: 1,
+  },
+  progressCount: {
+    fontSize: 15,
+    color: colors.textDim,
+    marginLeft: 10,
+  },
+  version: {
+    fontSize: 13,
+    color: colors.textDim,
+    marginTop: 16,
+    lineHeight: 19,
+  },
   });
 }

--- a/app-mobile/app/(tabs)/profile.tsx
+++ b/app-mobile/app/(tabs)/profile.tsx
@@ -22,6 +22,7 @@ import { useAppState } from "../../src/app-state";
 import { clearAllProgress, getAllProgress } from "../../src/storage";
 import { Button } from "../../src/components/Button";
 import { Text } from "../../src/components/Text";
+import { TAB_BAR_CONTENT_BOTTOM_INSET } from "../../src/tabBarInsets";
 import {
   type ThemeColors,
   type ThemePreference,
@@ -319,120 +320,121 @@ export default function ProfileTab() {
 
 function createStyles(colors: ThemeColors) {
   return StyleSheet.create({
-  root: {
-    flex: 1,
-    backgroundColor: colors.background,
-  },
-  scrollContent: {
-    paddingHorizontal: 16,
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: "800",
-    color: colors.text,
-    marginTop: 8,
-  },
-  card: {
-    backgroundColor: colors.blueLight,
-    borderRadius: 18,
-    padding: 18,
-    marginTop: 16,
-  },
-  cardTitle: {
-    fontSize: 18,
-    fontWeight: "800",
-    color: colors.text,
-  },
-  cardBody: {
-    fontSize: 15,
-    lineHeight: 22,
-    color: colors.textDim,
-    marginTop: 6,
-  },
-  cardActions: {
-    marginTop: 14,
-    gap: 10,
-  },
-  sectionTitle: {
-    fontSize: 20,
-    fontWeight: "800",
-    color: colors.text,
-    marginTop: 28,
-    marginBottom: 10,
-  },
-  settingRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-  },
-  settingBlock: {
-    gap: 10,
-    marginBottom: 16,
-  },
-  settingText: {
-    flex: 1,
-  },
-  themeOptions: {
-    flexDirection: "row",
-    gap: 8,
-  },
-  themeOption: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 12,
-    borderWidth: 2,
-    borderColor: colors.border,
-    backgroundColor: colors.surface,
-    paddingVertical: 10,
-  },
-  themeOptionSelected: {
-    borderColor: colors.blue,
-    backgroundColor: colors.blueLight,
-  },
-  themeOptionText: {
-    color: colors.textDim,
-    fontSize: 13,
-    fontWeight: "800",
-    textTransform: "uppercase",
-  },
-  themeOptionTextSelected: {
-    color: colors.blue,
-  },
-  settingLabel: {
-    fontSize: 16,
-    fontWeight: "700",
-    color: colors.text,
-  },
-  settingHint: {
-    fontSize: 13,
-    color: colors.textDim,
-    marginTop: 2,
-  },
-  progressRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-  },
-  progressCourse: {
-    fontSize: 15,
-    fontWeight: "600",
-    color: colors.text,
-    flexShrink: 1,
-  },
-  progressCount: {
-    fontSize: 15,
-    color: colors.textDim,
-    marginLeft: 10,
-  },
-  version: {
-    fontSize: 13,
-    color: colors.textDim,
-    marginTop: 16,
-    lineHeight: 19,
-  },
+    root: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    scrollContent: {
+      paddingHorizontal: 16,
+      paddingBottom: TAB_BAR_CONTENT_BOTTOM_INSET,
+    },
+    title: {
+      fontSize: 28,
+      fontWeight: "800",
+      color: colors.text,
+      marginTop: 8,
+    },
+    card: {
+      backgroundColor: colors.blueLight,
+      borderRadius: 18,
+      padding: 18,
+      marginTop: 16,
+    },
+    cardTitle: {
+      fontSize: 18,
+      fontWeight: "800",
+      color: colors.text,
+    },
+    cardBody: {
+      fontSize: 15,
+      lineHeight: 22,
+      color: colors.textDim,
+      marginTop: 6,
+    },
+    cardActions: {
+      marginTop: 14,
+      gap: 10,
+    },
+    sectionTitle: {
+      fontSize: 20,
+      fontWeight: "800",
+      color: colors.text,
+      marginTop: 28,
+      marginBottom: 10,
+    },
+    settingRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+    },
+    settingBlock: {
+      gap: 10,
+      marginBottom: 16,
+    },
+    settingText: {
+      flex: 1,
+    },
+    themeOptions: {
+      flexDirection: "row",
+      gap: 8,
+    },
+    themeOption: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      borderRadius: 12,
+      borderWidth: 2,
+      borderColor: colors.border,
+      backgroundColor: colors.surface,
+      paddingVertical: 10,
+    },
+    themeOptionSelected: {
+      borderColor: colors.blue,
+      backgroundColor: colors.blueLight,
+    },
+    themeOptionText: {
+      color: colors.textDim,
+      fontSize: 13,
+      fontWeight: "800",
+      textTransform: "uppercase",
+    },
+    themeOptionTextSelected: {
+      color: colors.blue,
+    },
+    settingLabel: {
+      fontSize: 16,
+      fontWeight: "700",
+      color: colors.text,
+    },
+    settingHint: {
+      fontSize: 13,
+      color: colors.textDim,
+      marginTop: 2,
+    },
+    progressRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+      paddingVertical: 8,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+    },
+    progressCourse: {
+      fontSize: 15,
+      fontWeight: "600",
+      color: colors.text,
+      flexShrink: 1,
+    },
+    progressCount: {
+      fontSize: 15,
+      color: colors.textDim,
+      marginLeft: 10,
+    },
+    version: {
+      fontSize: 13,
+      color: colors.textDim,
+      marginTop: 16,
+      lineHeight: 19,
+    },
   });
 }

--- a/app-mobile/src/tabBarInsets.ts
+++ b/app-mobile/src/tabBarInsets.ts
@@ -1,1 +1,0 @@
-export const TAB_BAR_CONTENT_BOTTOM_INSET = 140;

--- a/app-mobile/src/tabBarInsets.ts
+++ b/app-mobile/src/tabBarInsets.ts
@@ -1,0 +1,1 @@
+export const TAB_BAR_CONTENT_BOTTOM_INSET = 140;

--- a/app-mobile/src/useTabContentInsets.ts
+++ b/app-mobile/src/useTabContentInsets.ts
@@ -1,0 +1,17 @@
+import { Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+const IOS_TAB_BAR_CLEARANCE = 96;
+const DEFAULT_TAB_BAR_CLEARANCE = 24;
+
+export function useTabContentInsets() {
+  const insets = useSafeAreaInsets();
+
+  return {
+    paddingBottom:
+      insets.bottom +
+      (Platform.OS === "ios"
+        ? IOS_TAB_BAR_CLEARANCE
+        : DEFAULT_TAB_BAR_CLEARANCE),
+  };
+}


### PR DESCRIPTION
## Summary

- Restores the iOS NativeTabs config from the earlier Liquid Glass implementation.
- Removes `disableTransparentOnScrollEdge` and returns `minimizeBehavior` to `automatic`.

## Root cause

The follow-up Telugu/tab PR changed NativeTabs to disable transparent scroll-edge behavior and prevent minimization. On iOS 26 that suppresses the Liquid Glass-style floating tab behavior.

## Validation

- `npx prettier --check 'app/(tabs)/_layout.tsx'`
- `node_modules/.bin/tsc --noEmit`
- Captured iOS 26.4 simulator screenshot: `/tmp/ios26-tabs-liquid-restored.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabbed screens now automatically apply safe-area bottom spacing for a cleaner, more consistent layout.
  * The tab bar now supports “liquid glass” styling on newer iOS versions, with updated background/blur and automatic minimize behavior while scrolling.

* **Bug Fixes**
  * Courses, Learn, and Profile content better respects tab insets, reducing cases where the bottom of lists or screens could be cut off or obscured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->