### PR TITLE
Fix Telugu hidden underline layout

### DIFF
--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -250,7 +250,9 @@ function splitIntoGraphemes(text: string): string[] {
 }
 
 function shouldMeasureTokenAsGraphemes(text: string): boolean {
-  return /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff\uac00-\ud7af]/u.test(text);
+  return /[\u0c00-\u0c7f\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff\uac00-\ud7af]/u.test(
+    text,
+  );
 }
 
 function buildNativeSegments(tokens: Token[]): NativeSegment[] {
@@ -1260,6 +1262,14 @@ function NativeHintText({
     () => buildUnderlineSegments({ computedSegments, colors }),
     [colors, computedSegments],
   );
+  const visibleUnderlineSegments = React.useMemo(
+    () => underlineSegments.filter((segment) => segment.dotted),
+    [underlineSegments],
+  );
+  const hiddenUnderlineSegments = React.useMemo(
+    () => underlineSegments.filter((segment) => !segment.dotted),
+    [underlineSegments],
+  );
 
   const debugRects = React.useMemo(
     () => buildDebugRects(computedSegments, debugNativeLayout),
@@ -1287,7 +1297,7 @@ function NativeHintText({
         hiddenCovers={[]}
         debugRects={[]}
         debugBaselines={[]}
-        underlineSegments={underlineSegments}
+        underlineSegments={visibleUnderlineSegments}
         colors={colors}
         drawCovers={false}
       />
@@ -1371,9 +1381,11 @@ function NativeHintText({
         hiddenCovers={hiddenCovers}
         debugRects={debugRects}
         debugBaselines={debugBaselines}
-        underlineSegments={debugNativeLayout ? underlineSegments : []}
+        underlineSegments={
+          debugNativeLayout ? underlineSegments : hiddenUnderlineSegments
+        }
         colors={colors}
-        drawUnderlines={false}
+        drawUnderlines
         drawRangeDebug={debugNativeLayout}
       />
       <View
@@ -1541,7 +1553,12 @@ export function HintText({
       afterWhitespace = false;
       continue;
     }
-    if (/^\s+$/.test(token.text) && !token.hint) {
+    if (
+      /^\s+$/.test(token.text) &&
+      !token.hint &&
+      !token.hidden &&
+      !token.revealed
+    ) {
       appendTrailingSpace(token);
       continue;
     }

--- a/app-mobile/src/story/languageStyles.ts
+++ b/app-mobile/src/story/languageStyles.ts
@@ -14,7 +14,7 @@ export const TELUGU_FONT_FAMILY = Platform.select({
   default: undefined,
 });
 // Telugu vowel marks can extend below iOS' measured line box.
-const TELUGU_LINE_HEIGHT_MULTIPLIER = 1.9;
+const TELUGU_LINE_HEIGHT_MULTIPLIER = 1.95;
 
 export function getLanguageTextStyle(
   lang?: string,


### PR DESCRIPTION
## Summary
- increase the Telugu-only line-height from 1.9 to 1.95, the next rounded pixel step for 19px body text
- measure Telugu native text by grapheme clusters, matching how other complex scripts are measured
- draw hidden solid underlines after hidden covers in the native renderer so covers do not hide the underline
- keep hidden/revealed whitespace as renderable tokens so whitespace inside hidden ranges can be underlined

## Verification
- `cd app-mobile && node_modules/.bin/tsc --noEmit`
- `cd app-mobile && npx prettier --check src/story/languageStyles.ts src/story/HintText.tsx`
- visual hidden range check: `/tmp/telugu-current-main-followup/ios26-all-hidden-spaces-overlay-fix.png`

Note: Expo Go showed loading/sticky route behavior during verification, so if the simulator still appears unchanged after pulling main, restart Metro with cache cleared and relaunch Expo Go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hint rendering for scripts that use grapheme clusters, helping text display more accurately in native overlays.
  * Refined underline display so visible and hidden underline segments render more consistently.
  * Fixed spacing behavior for wrapped text so whitespace is handled more reliably in hint layouts.
  * Increased Telugu line spacing slightly for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->