### PR TITLE
Hide native-path challenge ranges behind a continuous blank (#578)

### DIFF
--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -648,8 +648,14 @@ function NativeHintText({
       >
         {segments.map((segment) => {
           const interactive = Boolean(segment.hint) && !segment.hidden;
+          // Mirror the tokenized path: unrevealed hide-range glyphs take
+          // layout space but paint in the background color so they blend
+          // away (still measurable, underline geometry unchanged). A fully
+          // transparent color (alpha 0) is dropped by Android's nested-text
+          // renderer and leaves the text readable, so use the opaque
+          // background color like the tokenized HintTokenBox does.
           const color = segment.hidden
-            ? "transparent"
+            ? colors.background
             : segment.dimmed
               ? colors.disabled
               : (flatStyle.color ?? colors.text);

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -566,41 +566,30 @@ function NativeHintText({
             fill="rgba(255,77,79,0.08)"
           />
         ))}
-        {underlineSegments.map((segment) => (
-          <React.Fragment key={segment.key}>
-            {segment.dotted ? (
-              Array.from({
-                length: Math.max(
-                  1,
-                  Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
-                ),
-              }).map((_, index) => {
-                const cx = Math.min(
-                  segment.x2,
-                  segment.x1 + index * UNDERLINE_DOT_GAP,
-                );
-                return (
-                  <Circle
-                    key={`${segment.key}:${index}`}
-                    cx={cx}
-                    cy={segment.y}
-                    r={UNDERLINE_DOT_RADIUS}
-                    fill={segment.color}
-                  />
-                );
-              })
-            ) : (
-              <Line
-                x1={segment.x1}
-                x2={segment.x2}
-                y1={segment.y}
-                y2={segment.y}
-                stroke={segment.color}
-                strokeWidth={2}
-              />
-            )}
-          </React.Fragment>
-        ))}
+        {underlineSegments
+          .filter((segment) => segment.dotted)
+          .map((segment) =>
+            Array.from({
+              length: Math.max(
+                1,
+                Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
+              ),
+            }).map((_, index) => {
+              const cx = Math.min(
+                segment.x2,
+                segment.x1 + index * UNDERLINE_DOT_GAP,
+              );
+              return (
+                <Circle
+                  key={`${segment.key}:${index}`}
+                  cx={cx}
+                  cy={segment.y}
+                  r={UNDERLINE_DOT_RADIUS}
+                  fill={segment.color}
+                />
+              );
+            }),
+          )}
       </Svg>
       {leadingElement && (
         <View
@@ -690,6 +679,28 @@ function NativeHintText({
           );
         })}
       </Text>
+      {/* Solid hidden underlines paint AFTER the text: hidden glyphs are
+          drawn in the opaque background color, so a line behind the text
+          would get glyph-shaped bites erased out of it. Dotted hint
+          underlines stay in the pre-text Svg (behind descenders). */}
+      <Svg
+        pointerEvents="none"
+        style={StyleSheet.absoluteFill}
+      >
+        {underlineSegments
+          .filter((segment) => !segment.dotted)
+          .map((segment) => (
+            <Line
+              key={segment.key}
+              x1={segment.x1}
+              x2={segment.x2}
+              y1={segment.y}
+              y2={segment.y}
+              stroke={segment.color}
+              strokeWidth={2}
+            />
+          ))}
+      </Svg>
       <View
         pointerEvents="none"
         style={{

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -86,8 +86,13 @@ function buildNativeSegments(tokens: Token[]): NativeSegment[] {
         ...token,
         text: part,
         key: `${token.start}:${segments.length}`,
+        // All hidden tokens share one group: only hideRangesForChallenge[0]
+        // is ever consumed (see buildTokens), so the hidden phrase is a
+        // single contiguous range and must merge into one continuous solid
+        // line per wrapped line — per-token keys would leak the phrase's
+        // word boundaries as gaps in the underline.
         underlineGroupKey: token.hidden
-          ? `hidden:${token.start}`
+          ? "hidden"
           : token.revealed
             ? `revealed:${token.start}`
             : token.hintGroupKey,


### PR DESCRIPTION
Fixes #578.

Three commits:
1. Hidden segments in the native (CJK) text path now paint their glyphs in `colors.background` — RN Android's nested-text renderer drops fully transparent span colors, which is why the text stayed readable. Layout space and underline geometry are unchanged, and `unhide` reveal semantics mirror the tokenized path.
2. The solid hidden underline moved to a second SVG layered after the `<Text>`: background-painted glyphs previously erased glyph-shaped bites out of the line drawn behind them. Dotted hint underlines stay behind the text, unchanged.
3. Contiguous hidden segments share one underline group, so the blank renders as one continuous line per wrapped row instead of per-token dashes leaking word boundaries (consistent with #577).

### Proof (Android emulator, cases `lines-zh` / `lines-ja`)

![zoom](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/578/zoom-hidden-zh.png)

| Before | After | After (dark) |
|---|---|---|
| ![before](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/578/before-lines-zh.png) | ![after](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/578/after-lines-zh.png) | ![dark](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/578/after-lines-ja-dark.png) |

Korean (spaces inside the hidden phrase stay bridged) and `hint-ja`/`lines-es` regression cases checked. Stacked PRs: #579 dots offset, #580 Thai. Base is `agent/mobile-rendering-benchmark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)