### PR TITLE
Drop native-path hint underlines into the descender gap (#579)

### DIFF
--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -648,8 +648,14 @@ function NativeHintText({
       >
         {segments.map((segment) => {
           const interactive = Boolean(segment.hint) && !segment.hidden;
+          // Mirror the tokenized path: unrevealed hide-range glyphs take
+          // layout space but paint in the background color so they blend
+          // away (still measurable, underline geometry unchanged). A fully
+          // transparent color (alpha 0) is dropped by Android's nested-text
+          // renderer and leaves the text readable, so use the opaque
+          // background color like the tokenized HintTokenBox does.
           const color = segment.hidden
-            ? "transparent"
+            ? colors.background
             : segment.dimmed
               ? colors.disabled
               : (flatStyle.color ?? colors.text);

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -566,41 +566,30 @@ function NativeHintText({
             fill="rgba(255,77,79,0.08)"
           />
         ))}
-        {underlineSegments.map((segment) => (
-          <React.Fragment key={segment.key}>
-            {segment.dotted ? (
-              Array.from({
-                length: Math.max(
-                  1,
-                  Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
-                ),
-              }).map((_, index) => {
-                const cx = Math.min(
-                  segment.x2,
-                  segment.x1 + index * UNDERLINE_DOT_GAP,
-                );
-                return (
-                  <Circle
-                    key={`${segment.key}:${index}`}
-                    cx={cx}
-                    cy={segment.y}
-                    r={UNDERLINE_DOT_RADIUS}
-                    fill={segment.color}
-                  />
-                );
-              })
-            ) : (
-              <Line
-                x1={segment.x1}
-                x2={segment.x2}
-                y1={segment.y}
-                y2={segment.y}
-                stroke={segment.color}
-                strokeWidth={2}
-              />
-            )}
-          </React.Fragment>
-        ))}
+        {underlineSegments
+          .filter((segment) => segment.dotted)
+          .map((segment) =>
+            Array.from({
+              length: Math.max(
+                1,
+                Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
+              ),
+            }).map((_, index) => {
+              const cx = Math.min(
+                segment.x2,
+                segment.x1 + index * UNDERLINE_DOT_GAP,
+              );
+              return (
+                <Circle
+                  key={`${segment.key}:${index}`}
+                  cx={cx}
+                  cy={segment.y}
+                  r={UNDERLINE_DOT_RADIUS}
+                  fill={segment.color}
+                />
+              );
+            }),
+          )}
       </Svg>
       {leadingElement && (
         <View
@@ -690,6 +679,28 @@ function NativeHintText({
           );
         })}
       </Text>
+      {/* Solid hidden underlines paint AFTER the text: hidden glyphs are
+          drawn in the opaque background color, so a line behind the text
+          would get glyph-shaped bites erased out of it. Dotted hint
+          underlines stay in the pre-text Svg (behind descenders). */}
+      <Svg
+        pointerEvents="none"
+        style={StyleSheet.absoluteFill}
+      >
+        {underlineSegments
+          .filter((segment) => !segment.dotted)
+          .map((segment) => (
+            <Line
+              key={segment.key}
+              x1={segment.x1}
+              x2={segment.x2}
+              y1={segment.y}
+              y2={segment.y}
+              stroke={segment.color}
+              strokeWidth={2}
+            />
+          ))}
+      </Svg>
       <View
         pointerEvents="none"
         style={{

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -86,8 +86,13 @@ function buildNativeSegments(tokens: Token[]): NativeSegment[] {
         ...token,
         text: part,
         key: `${token.start}:${segments.length}`,
+        // All hidden tokens share one group: only hideRangesForChallenge[0]
+        // is ever consumed (see buildTokens), so the hidden phrase is a
+        // single contiguous range and must merge into one continuous solid
+        // line per wrapped line — per-token keys would leak the phrase's
+        // word boundaries as gaps in the underline.
         underlineGroupKey: token.hidden
-          ? `hidden:${token.start}`
+          ? "hidden"
           : token.revealed
             ? `revealed:${token.start}`
             : token.hintGroupKey,

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -26,6 +26,12 @@ const SHOW_NATIVE_HINT_DEBUG = false;
 const UNDERLINE_EDGE_INSET = 2;
 const UNDERLINE_DOT_RADIUS = 1.2;
 const UNDERLINE_DOT_GAP = 7;
+// Distance (px) from the measured line-box bottom up to the underline row.
+// The tokenized HintTokenBox draws its dotted/solid border ~1px above the
+// text box bottom, which lands in the descender gap below the glyphs. The
+// native path measures the full line box, so use the same small inset to
+// leave an equivalent gap instead of drawing on the glyph bottoms.
+const UNDERLINE_BOTTOM_OFFSET = 1;
 
 type HintTextRenderMode = "auto" | "native" | "tokenized";
 
@@ -482,7 +488,7 @@ function NativeHintText({
         key: segment.key,
         x1: segment.x + UNDERLINE_EDGE_INSET,
         x2: segment.x + Math.max(segment.width - UNDERLINE_EDGE_INSET, UNDERLINE_EDGE_INSET * 2),
-        y: segment.y + segment.height - 6,
+        y: segment.y + segment.height - UNDERLINE_BOTTOM_OFFSET,
         color: underline,
         dotted: !segment.hidden,
         underlineGroupKey: segment.underlineGroupKey,


### PR DESCRIPTION
Fixes #579. Stacked on #584.

The native path drew its SVG underline rows at `segment.y + segment.height - 6`, landing on the glyph bottoms. The tokenized path's border sits ~1px above its text-box bottom, in the font's descender gap. New `UNDERLINE_BOTTOM_OFFSET = 1` feeds the shared `y` for both the dotted rows and the solid hidden line, matching the tokenized spacing (single knob if pixel-nudging is ever needed).

### Proof (Android emulator, case `lines-zh`)

![zoom](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/579/zoom-dots-zh.png)

Full screens: [after-lines-zh.png](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/579/after-lines-zh.png), [after-lines-ja.png](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/579/after-lines-ja.png) — `lines-ko` and the continuous hidden line from #584 re-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)