### PR TITLE
Route Thai through the native text-layout path (#580)

### DIFF
--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -648,8 +648,14 @@ function NativeHintText({
       >
         {segments.map((segment) => {
           const interactive = Boolean(segment.hint) && !segment.hidden;
+          // Mirror the tokenized path: unrevealed hide-range glyphs take
+          // layout space but paint in the background color so they blend
+          // away (still measurable, underline geometry unchanged). A fully
+          // transparent color (alpha 0) is dropped by Android's nested-text
+          // renderer and leaves the text readable, so use the opaque
+          // background color like the tokenized HintTokenBox does.
           const color = segment.hidden
-            ? "transparent"
+            ? colors.background
             : segment.dimmed
               ? colors.disabled
               : (flatStyle.color ?? colors.text);

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -12,6 +12,7 @@ import Svg, { Circle, Line, Rect } from "react-native-svg";
 import { Text } from "../components/Text";
 import { type ThemeColors, useTheme } from "../theme";
 import { HintLookupContext, HintPopupContext } from "./HintPopup";
+import { shouldUseNativeTextLayout } from "./nativeTextLayout";
 import type { ContentWithHints, HideRange } from "./types";
 
 // Web-parity text renderer (StoryLineHints): hinted words get a dashed
@@ -71,22 +72,49 @@ function getDisplayText(token: Token): string {
   return token.text.replace(/\s+/g, " ");
 }
 
-function shouldUseNativeTextLayout(lang?: string): boolean {
-  if (!lang) return false;
-  return /^(ja|zh|ko)(-|$)/i.test(lang);
-}
-
 function isWrapAnywhereToken(text: string): boolean {
   return /^[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]+$/u.test(
     text,
   );
 }
 
+// Thai has no spaces between words and no per-character wrap unit like CJK:
+// combining vowels/tone marks (U+0E31, U+0E34\u20133A, U+0E47\u20134E) stack on the
+// preceding consonant, so splitting by code point (as CJK does) would strip
+// marks off their base and mis-measure them in isolation. Split Thai runs into
+// grapheme clusters (base + following marks) instead: each cluster is a
+// self-contained, correctly-measured unit that never straddles a line break,
+// so the native line-box \u2192 segment matching stays aligned wherever the
+// platform engine chooses to break.
+const THAI_COMBINING_MARK = /[\u0e31\u0e34-\u0e3a\u0e47-\u0e4e]/;
+
+function isThaiToken(text: string): boolean {
+  return /[\u0e00-\u0e7f]/.test(text);
+}
+
+function splitThaiClusters(text: string): string[] {
+  const clusters: string[] = [];
+  for (const ch of text) {
+    if (clusters.length > 0 && THAI_COMBINING_MARK.test(ch)) {
+      clusters[clusters.length - 1] += ch;
+    } else {
+      clusters.push(ch);
+    }
+  }
+  return clusters;
+}
+
+function splitLayoutUnits(text: string): string[] {
+  if (isWrapAnywhereToken(text)) return Array.from(text);
+  if (isThaiToken(text)) return splitThaiClusters(text);
+  return [text];
+}
+
 function buildNativeSegments(tokens: Token[]): NativeSegment[] {
   const segments: NativeSegment[] = [];
 
   for (const token of tokens) {
-    const parts = isWrapAnywhereToken(token.text) ? Array.from(token.text) : [token.text];
+    const parts = splitLayoutUnits(token.text);
     for (const part of parts) {
       segments.push({
         ...token,

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -566,41 +566,30 @@ function NativeHintText({
             fill="rgba(255,77,79,0.08)"
           />
         ))}
-        {underlineSegments.map((segment) => (
-          <React.Fragment key={segment.key}>
-            {segment.dotted ? (
-              Array.from({
-                length: Math.max(
-                  1,
-                  Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
-                ),
-              }).map((_, index) => {
-                const cx = Math.min(
-                  segment.x2,
-                  segment.x1 + index * UNDERLINE_DOT_GAP,
-                );
-                return (
-                  <Circle
-                    key={`${segment.key}:${index}`}
-                    cx={cx}
-                    cy={segment.y}
-                    r={UNDERLINE_DOT_RADIUS}
-                    fill={segment.color}
-                  />
-                );
-              })
-            ) : (
-              <Line
-                x1={segment.x1}
-                x2={segment.x2}
-                y1={segment.y}
-                y2={segment.y}
-                stroke={segment.color}
-                strokeWidth={2}
-              />
-            )}
-          </React.Fragment>
-        ))}
+        {underlineSegments
+          .filter((segment) => segment.dotted)
+          .map((segment) =>
+            Array.from({
+              length: Math.max(
+                1,
+                Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
+              ),
+            }).map((_, index) => {
+              const cx = Math.min(
+                segment.x2,
+                segment.x1 + index * UNDERLINE_DOT_GAP,
+              );
+              return (
+                <Circle
+                  key={`${segment.key}:${index}`}
+                  cx={cx}
+                  cy={segment.y}
+                  r={UNDERLINE_DOT_RADIUS}
+                  fill={segment.color}
+                />
+              );
+            }),
+          )}
       </Svg>
       {leadingElement && (
         <View
@@ -690,6 +679,28 @@ function NativeHintText({
           );
         })}
       </Text>
+      {/* Solid hidden underlines paint AFTER the text: hidden glyphs are
+          drawn in the opaque background color, so a line behind the text
+          would get glyph-shaped bites erased out of it. Dotted hint
+          underlines stay in the pre-text Svg (behind descenders). */}
+      <Svg
+        pointerEvents="none"
+        style={StyleSheet.absoluteFill}
+      >
+        {underlineSegments
+          .filter((segment) => !segment.dotted)
+          .map((segment) => (
+            <Line
+              key={segment.key}
+              x1={segment.x1}
+              x2={segment.x2}
+              y1={segment.y}
+              y2={segment.y}
+              stroke={segment.color}
+              strokeWidth={2}
+            />
+          ))}
+      </Svg>
       <View
         pointerEvents="none"
         style={{

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -86,8 +86,13 @@ function buildNativeSegments(tokens: Token[]): NativeSegment[] {
         ...token,
         text: part,
         key: `${token.start}:${segments.length}`,
+        // All hidden tokens share one group: only hideRangesForChallenge[0]
+        // is ever consumed (see buildTokens), so the hidden phrase is a
+        // single contiguous range and must merge into one continuous solid
+        // line per wrapped line — per-token keys would leak the phrase's
+        // word boundaries as gaps in the underline.
         underlineGroupKey: token.hidden
-          ? `hidden:${token.start}`
+          ? "hidden"
           : token.revealed
             ? `revealed:${token.start}`
             : token.hintGroupKey,

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -26,6 +26,12 @@ const SHOW_NATIVE_HINT_DEBUG = false;
 const UNDERLINE_EDGE_INSET = 2;
 const UNDERLINE_DOT_RADIUS = 1.2;
 const UNDERLINE_DOT_GAP = 7;
+// Distance (px) from the measured line-box bottom up to the underline row.
+// The tokenized HintTokenBox draws its dotted/solid border ~1px above the
+// text box bottom, which lands in the descender gap below the glyphs. The
+// native path measures the full line box, so use the same small inset to
+// leave an equivalent gap instead of drawing on the glyph bottoms.
+const UNDERLINE_BOTTOM_OFFSET = 1;
 
 type HintTextRenderMode = "auto" | "native" | "tokenized";
 
@@ -482,7 +488,7 @@ function NativeHintText({
         key: segment.key,
         x1: segment.x + UNDERLINE_EDGE_INSET,
         x2: segment.x + Math.max(segment.width - UNDERLINE_EDGE_INSET, UNDERLINE_EDGE_INSET * 2),
-        y: segment.y + segment.height - 6,
+        y: segment.y + segment.height - UNDERLINE_BOTTOM_OFFSET,
         color: underline,
         dotted: !segment.hidden,
         underlineGroupKey: segment.underlineGroupKey,

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -4,6 +4,7 @@ import { Image } from "expo-image";
 import { fontSizes, type ThemeColors, useTheme } from "../../theme";
 import { HintText } from "../HintText";
 import { getLanguageTextStyle } from "../languageStyles";
+import { shouldUseNativeTextLayout } from "../nativeTextLayout";
 import { getStoryLineRtl } from "../textDirection";
 import { useLineAudio } from "../useLineAudio";
 import { PlayAudioButton } from "./PlayAudioButton";
@@ -13,11 +14,6 @@ import type { StoryElementLine } from "../types";
 // corners except where the tail attaches, with a two-triangle tail (border
 // color under background color) pointing at the avatar.
 const TAIL_WIDTH = 12;
-
-function shouldUseNativeStoryText(lang?: string): boolean {
-  if (!lang) return false;
-  return /^(ja|zh|ko)(-|$)/i.test(lang);
-}
 
 function BubbleTail({
   colors,
@@ -170,7 +166,7 @@ export function TextLine({
     fontSize: fontSizes.body,
     color: colors.text,
   };
-  const preferNativeText = shouldUseNativeStoryText(element.lang);
+  const preferNativeText = shouldUseNativeTextLayout(element.lang);
 
   if (element.line === undefined) return null;
 

--- a/app-mobile/src/story/nativeTextLayout.ts
+++ b/app-mobile/src/story/nativeTextLayout.ts
@@ -1,0 +1,16 @@
+// Single source of truth for which languages render through the native
+// text-layout path (HintText renderMode="native") instead of the
+// whitespace-based tokenizer.
+//
+// The tokenizer splits on whitespace and treats each run as an unbreakable
+// atom, which is fine for space-delimited scripts but wrong for scripts that
+// don't put spaces between words: CJK (ja/zh/ko) and Thai (th). Thai in
+// particular writes whole clauses without spaces, so a tokenized line becomes
+// one atom wider than the bubble and overflows (#580). The native path hands
+// the text to the platform engine, which performs script-aware line breaking.
+const NATIVE_TEXT_LAYOUT_LANGS = /^(ja|zh|ko|th)(-|$)/i;
+
+export function shouldUseNativeTextLayout(lang?: string): boolean {
+  if (!lang) return false;
+  return NATIVE_TEXT_LAYOUT_LANGS.test(lang);
+}

--- a/docs/mobile-rendering-benchmark.md
+++ b/docs/mobile-rendering-benchmark.md
@@ -11,9 +11,10 @@ Text rendering is the highest-risk surface of the reader:
 
 - Android and iOS use different text engines (Minikin vs Core Text) — line
   height, glyph clipping, and underline metrics differ per platform.
-- CJK languages (`ja`, `zh`, `ko`) take a separate native-layout render path
-  (`HintText renderMode="native"`) where hint underlines are drawn as SVG dots
-  from measured text — a path with its own failure modes.
+- No-space scripts — CJK (`ja`, `zh`, `ko`) and Thai (`th`) — take a separate
+  native-layout render path (`HintText renderMode="native"`) where the platform
+  engine does line breaking and hint underlines are drawn as SVG dots from
+  measured text — a path with its own failure modes.
 - Indic scripts (Telugu especially) have a history of vertical clipping in
   this app (see `agent/fix-telugu-*` branches).
 - Hidden-challenge ranges, hint underlines, audio word-dimming, and the chip
@@ -65,7 +66,7 @@ mid-audio word dimming (`audioRangeOverride`).
 | `lines-ko` | Hangul (native path) | syllable blocks | none published (code path exists) |
 | `lines-hi` | Devanagari | conjuncts, matras, headstroke | hi-en |
 | `lines-te` | Telugu | below-base forms, **known clipping regressions** | tel-en |
-| `lines-th` | Thai | no spaces, stacked vowels/tone marks | th-en |
+| `lines-th` | Thai (native path) | no spaces (engine line-breaks), stacked vowels/tone marks | th-en |
 | `lines-dv` | Thaana | RTL non-Arabic script (smoke level) | dv-en |
 | `lines-tok2` | sitelen pona | custom font path in `languageStyles.ts` | tok-en |
 


### PR DESCRIPTION
Fixes #580. Stacked on #584 and #585 (Thai inherits the native path's fixed hide-blanking and dot offset).

Thai has no spaces, so the tokenized path's whitespace-split tokens made long runs unbreakable and they overflowed the bubble. Changes:
- New shared `shouldUseNativeTextLayout` helper (`src/story/nativeTextLayout.ts`) — single source of truth for TextLine and HintText, regex now `ja|zh|ko|th`.
- Native segmentation splits Thai runs into grapheme clusters (base + combining vowel/tone marks) instead of per code point, so marks are never torn off their base and measured segments stay aligned with engine line breaks.
- Lao/Khmer/Myanmar intentionally not included: their cluster rules (coeng/subscripts/medials) need more than the simple base+mark splitter, and there are no benchmark fixtures to validate against yet.

### Proof (Android emulator, case `lines-th`)

![side by side](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/580/side-by-side-th.png)

Hint popup over Thai: [after-hint-th.png](https://raw.githubusercontent.com/rgerum/unofficial-duolingo-stories/benchmark-proof/pr-proof/580/after-hint-th.png) — `lines-ja`/`lines-zh` regression re-checked on this tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)