### PR TITLE
Add admin page for hidden published stories

### DIFF
--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -73,6 +73,13 @@ type NativeSegment = Token & {
   textStyle?: TextStyle;
 };
 
+type MeasurementItem = {
+  key: string;
+  text: string;
+  textStyle?: TextStyle;
+  segmentKeys: string[];
+};
+
 type NativeTextLayout = {
   x: number;
   y: number;
@@ -159,7 +166,7 @@ function getDisplayText(token: Token): string {
   return token.text.replace(/\s+/g, " ");
 }
 
-function shouldUseNativeTextLayout(lang?: string, rtl = false): boolean {
+export function shouldUseNativeTextLayout(lang?: string, rtl = false): boolean {
   return Boolean(lang) && !rtl;
 }
 
@@ -277,6 +284,34 @@ function buildNativeSegments(tokens: Token[]): NativeSegment[] {
   }
 
   return segments;
+}
+
+function getMeasurementKey(segment: NativeSegment): string {
+  return `${segment.text}:${JSON.stringify(segment.textStyle ?? {})}`;
+}
+
+function buildMeasurementItems(
+  measurementSegments: NativeSegment[],
+): MeasurementItem[] {
+  const itemByKey = new Map<string, MeasurementItem>();
+
+  for (const segment of measurementSegments) {
+    const key = getMeasurementKey(segment);
+    const existing = itemByKey.get(key);
+    if (existing) {
+      existing.segmentKeys.push(segment.key);
+      continue;
+    }
+
+    itemByKey.set(key, {
+      key,
+      text: segment.text,
+      textStyle: segment.textStyle,
+      segmentKeys: [segment.key],
+    });
+  }
+
+  return Array.from(itemByKey.values());
 }
 
 function getDebugColor(key?: string): { stroke: string; fill: string } {
@@ -1181,6 +1216,10 @@ function NativeHintText({
   const [segmentWidths, setSegmentWidths] = React.useState<
     Record<string, number>
   >({});
+  const measurementItems = React.useMemo(
+    () => buildMeasurementItems(measurementSegments),
+    [measurementSegments],
+  );
 
   const computedSegments = React.useMemo(
     () =>
@@ -1387,19 +1426,24 @@ function NativeHintText({
           flexWrap: "nowrap",
         }}
       >
-        {measurementSegments.map((segment) => (
+        {measurementItems.map((item) => (
           <Text
-            key={`measure:${segment.key}`}
+            key={`measure:${item.key}`}
             onLayout={(event) => {
               const width = event.nativeEvent.layout.width;
               setSegmentWidths((current) => {
-                if (current[segment.key] === width) return current;
-                return { ...current, [segment.key]: width };
+                let next: Record<string, number> | undefined;
+                for (const segmentKey of item.segmentKeys) {
+                  if (current[segmentKey] === width) continue;
+                  next ??= { ...current };
+                  next[segmentKey] = width;
+                }
+                return next ?? current;
               });
             }}
-            style={[flatStyle, { lineHeight: undefined }, segment.textStyle]}
+            style={[flatStyle, { lineHeight: undefined }, item.textStyle]}
           >
-            {segment.text}
+            {item.text}
           </Text>
         ))}
       </View>

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import { Image } from "expo-image";
 import { fontSizes, type ThemeColors, useTheme } from "../../theme";
-import { HintText } from "../HintText";
+import { HintText, shouldUseNativeTextLayout } from "../HintText";
 import { getLanguageTextStyle } from "../languageStyles";
 import { getStoryLineRtl } from "../textDirection";
 import { useLineAudio } from "../useLineAudio";
@@ -13,10 +13,6 @@ import type { StoryElementLine } from "../types";
 // corners except where the tail attaches, with a two-triangle tail (border
 // color under background color) pointing at the avatar.
 const TAIL_WIDTH = 12;
-
-function shouldUseNativeStoryText(lang?: string, rtl = false): boolean {
-  return Boolean(lang) && !rtl;
-}
 
 function BubbleTail({
   colors,
@@ -166,7 +162,7 @@ export function TextLine({
     fontSize: fontSizes.body,
     color: colors.text,
   };
-  const preferNativeText = shouldUseNativeStoryText(element.lang, lineRtl);
+  const preferNativeText = shouldUseNativeTextLayout(element.lang, lineRtl);
 
   if (element.line === undefined) return null;
 

--- a/convex/adminData.ts
+++ b/convex/adminData.ts
@@ -21,6 +21,10 @@ type AuthUserRow = {
   emailVerified?: boolean | null;
 };
 
+function isNonNull<T>(value: T | null): value is T {
+  return value !== null;
+}
+
 async function isAdmin(ctx: AuthCtx) {
   const identity = (await ctx.auth.getUserIdentity()) as {
     role?: string | null;
@@ -52,6 +56,17 @@ const adminCourseValidator = v.object({
   conlang: v.boolean(),
   short: v.union(v.string(), v.null()),
   tags: v.array(v.string()),
+});
+
+const adminCourseWithHiddenStoriesValidator = v.object({
+  id: v.number(),
+  short: v.union(v.string(), v.null()),
+  name: v.union(v.string(), v.null()),
+  learning_language_name: v.string(),
+  from_language_name: v.string(),
+  public: v.boolean(),
+  course_count: v.number(),
+  published_story_count: v.number(),
 });
 
 const adminApprovalValidator = v.object({
@@ -601,6 +616,68 @@ export const getAdminCourses = query({
       .sort((a, b) => a.id - b.id);
 
     return { courses, languages };
+  },
+});
+
+export const getAdminCoursesWithHiddenPublishedStories = query({
+  args: {},
+  returns: v.array(adminCourseWithHiddenStoriesValidator),
+  handler: async (ctx) => {
+    if (!(await isAdmin(ctx))) return [];
+
+    const stories = await ctx.db
+      .query("stories")
+      .withIndex("by_public", (q) => q.eq("public", true).eq("deleted", false))
+      .collect();
+
+    const countByCourseId = new Map<Id<"courses">, number>();
+    for (const story of stories) {
+      countByCourseId.set(
+        story.courseId,
+        (countByCourseId.get(story.courseId) ?? 0) + 1,
+      );
+    }
+
+    const courseIds = Array.from(countByCourseId.keys());
+    const courseRows = await Promise.all(
+      courseIds.map((courseId) => ctx.db.get(courseId)),
+    );
+    const languageIds = new Set<Id<"languages">>();
+    for (const course of courseRows) {
+      if (!course || course.public) continue;
+      languageIds.add(course.learningLanguageId);
+      languageIds.add(course.fromLanguageId);
+    }
+
+    const languageRows = await Promise.all(
+      Array.from(languageIds).map((languageId) => ctx.db.get(languageId)),
+    );
+    const languageNameById = new Map<Id<"languages">, string>();
+    for (const language of languageRows) {
+      if (!language) continue;
+      languageNameById.set(language._id, language.name);
+    }
+
+    return courseRows
+      .filter(isNonNull)
+      .filter((course) => !course.public)
+      .map((course) => ({
+        id: course.legacyId,
+        short: course.short ?? null,
+        name: course.name ?? null,
+        learning_language_name:
+          languageNameById.get(course.learningLanguageId) ?? "",
+        from_language_name: languageNameById.get(course.fromLanguageId) ?? "",
+        public: course.public,
+        course_count: course.count ?? 0,
+        published_story_count: countByCourseId.get(course._id) ?? 0,
+      }))
+      .sort((a, b) => {
+        if (b.published_story_count !== a.published_story_count) {
+          return b.published_story_count - a.published_story_count;
+        }
+        return a.learning_language_name.localeCompare(b.learning_language_name);
+      });
   },
 });
 

--- a/src/app/admin/AdminHeader.tsx
+++ b/src/app/admin/AdminHeader.tsx
@@ -40,6 +40,9 @@ export default async function AdminHeader() {
       <AdminButton href="/admin/users">Users</AdminButton>
       <AdminButton href="/admin/languages">Languages</AdminButton>
       <AdminButton href="/admin/courses">Courses</AdminButton>
+      <AdminButton href="/admin/unpublished-courses">
+        Hidden Stories
+      </AdminButton>
       <AdminButton href="/admin/story">Story</AdminButton>
 
       <div className="ml-auto flex items-center gap-2">

--- a/src/app/admin/unpublished-courses/page.tsx
+++ b/src/app/admin/unpublished-courses/page.tsx
@@ -1,0 +1,5 @@
+import UnpublishedCoursesClient from "./page_client";
+
+export default function Page() {
+  return <UnpublishedCoursesClient />;
+}

--- a/src/app/admin/unpublished-courses/page_client.tsx
+++ b/src/app/admin/unpublished-courses/page_client.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { api } from "@convex/_generated/api";
+import { Spinner } from "@/components/ui/spinner";
+import { useQuery } from "convex/react";
+import Link from "next/link";
+import {
+  adminTableContainerClass,
+  adminTableHeadCellClass,
+} from "../adminTableStyles";
+
+export default function UnpublishedCoursesClient() {
+  const courses = useQuery(
+    api.adminData.getAdminCoursesWithHiddenPublishedStories,
+    {},
+  );
+
+  if (courses === undefined) return <Spinner />;
+
+  const totalHiddenStories = courses.reduce(
+    (total, course) => total + course.published_story_count,
+    0,
+  );
+
+  return (
+    <div className="relative isolate mx-auto my-6 mb-9 box-border w-full max-w-[min(1040px,calc(100vw-48px))] rounded-2xl border border-[color:color-mix(in_srgb,var(--header-border)_70%,transparent)] bg-[var(--body-background)] p-5 shadow-[0_16px_38px_color-mix(in_srgb,#000_14%,transparent)]">
+      <div className="flex flex-wrap items-end justify-between gap-4 px-0.5 pb-3">
+        <div>
+          <h1 className="text-xl font-semibold">
+            Unpublished courses with published stories
+          </h1>
+          <p className="mt-1 text-sm text-[var(--text-color-dim)]">
+            {totalHiddenStories} published{" "}
+            {totalHiddenStories === 1 ? "story" : "stories"} hidden across{" "}
+            {courses.length} unpublished{" "}
+            {courses.length === 1 ? "course" : "courses"}.
+          </p>
+        </div>
+      </div>
+      <div className={adminTableContainerClass}>
+        <table className="w-full min-w-[760px] border-collapse">
+          <thead>
+            <tr>
+              <th className={adminTableHeadCellClass}>Course</th>
+              <th className={adminTableHeadCellClass}>From</th>
+              <th className={adminTableHeadCellClass}>Published stories</th>
+              <th className={adminTableHeadCellClass}>Course count</th>
+              <th className={`${adminTableHeadCellClass} text-right`}>
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {courses.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-4 py-8 text-center text-[var(--text-color-dim)]"
+                >
+                  No unpublished courses currently contain published stories.
+                </td>
+              </tr>
+            ) : (
+              courses.map((course) => (
+                <tr
+                  key={course.id}
+                  className="odd:bg-[var(--body-background)] even:bg-[color:color-mix(in_srgb,var(--body-background-faint)_74%,transparent)] hover:brightness-95"
+                >
+                  <td className="px-4 py-2.5">
+                    <div className="font-semibold">
+                      {course.learning_language_name}
+                    </div>
+                    <div className="text-sm text-[var(--text-color-dim)]">
+                      {course.name ? `${course.name} ` : ""}
+                      {course.short ? `/${course.short}` : `ID ${course.id}`}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2.5">{course.from_language_name}</td>
+                  <td className="px-3 py-2.5 font-semibold">
+                    {course.published_story_count}
+                  </td>
+                  <td className="px-3 py-2.5">{course.course_count}</td>
+                  <td className="px-4 py-2.5 text-right whitespace-nowrap">
+                    <div className="flex justify-end gap-3">
+                      {course.short ? (
+                        <Link href={`/editor/course/${course.short}`}>
+                          Editor
+                        </Link>
+                      ) : null}
+                      <Link href={`/admin/courses?editCourse=${course.id}`}>
+                        Edit course
+                      </Link>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add an admin query that dynamically groups published, non-deleted stories by non-public course
- Add /admin/unpublished-courses to show the hidden published-story counts and course links
- Add a Hidden Stories nav item in the admin header

## Verification
- pnpm run format
- pnpm typecheck
- pnpm run lint
- pnpm convex dev --once

## Notes
- Convex dev deployment verified against dev:compassionate-chinchilla-392.
- The page remains behind the existing admin layout/auth gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Hidden Stories** section to the admin navigation.
  * Added a page listing unpublished courses that contain published stories.
  * Displays course languages, course counts, and the number of hidden published stories.
  * Added links to edit each course where applicable.
  * Results are prioritized by the number of hidden stories.
  * Added loading and empty-state displays for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->