### PR TITLE
Fix story SEO language direction

### DIFF
--- a/src/app/(stories)/story/[story_id]/StoryTranscript.tsx
+++ b/src/app/(stories)/story/[story_id]/StoryTranscript.tsx
@@ -38,7 +38,7 @@ export default function StoryTranscript({ story }: { story: StoryData }) {
     inLanguage: story.learning_language,
     about: [
       `${story.learning_language_long} learning`,
-      `${story.from_language_long} reading practice`,
+      `${story.learning_language_long} reading practice`,
     ],
     isPartOf: {
       "@type": "WebSite",

--- a/src/app/(stories)/story/[story_id]/story_seo.ts
+++ b/src/app/(stories)/story/[story_id]/story_seo.ts
@@ -69,7 +69,7 @@ export function getStoryDescription(story: StoryData) {
     .map((line) => line.text)
     .join(" ");
   const normalizedExcerpt = normalizeWhitespace(excerpt);
-  const baseDescription = `${story.from_language_name} is a Duostories lesson for ${story.learning_language_long} speakers learning ${story.from_language_long}.`;
+  const baseDescription = `${story.from_language_name} is a Duostories lesson for ${story.from_language_long} speakers learning ${story.learning_language_long}.`;
 
   if (!normalizedExcerpt) return baseDescription;
 


### PR DESCRIPTION
## Summary
- Fix story meta descriptions to describe speakers of the source language learning the target language
- Fix JSON-LD Article `about` reading-practice language to use the learning language

## Verification
- `biome format` on touched files: passed
- `tsc --noEmit --pretty false`: blocked by existing test-tooling type errors for `vitest`, `convex-test`, and `vite/client` in the isolated worktree