### PR TITLE
Show transcript on story start page

### DIFF
--- a/src/components/StoryTitlePage/StoryTitlePage.tsx
+++ b/src/components/StoryTitlePage/StoryTitlePage.tsx
@@ -1,38 +1,62 @@
 import React from "react";
 import Button from "@/components/ui/button";
 import { useLocalisation } from "../LocalisationProvider/LocalisationProviderContext";
-import { StoryType } from "@/components/editor/story/syntax_parser_new";
+import type { StoryData } from "@/app/(stories)/story/[story_id]/getStory";
+import { getStoryTranscript } from "@/app/(stories)/story/[story_id]/story_seo";
+import { cn } from "@/lib/utils";
 
 function StoryTitlePage({
   story,
   next,
 }: {
-  story: StoryType;
+  story: StoryData;
   next: () => void;
 }) {
   const header = story.elements[0];
   const localisation = useLocalisation();
+  const transcript = getStoryTranscript(story);
 
   if (header.type != "HEADER")
     throw new Error("story needs to start with header");
 
   return (
-    <div className="pointer-events-none fixed inset-0 flex w-full flex-col items-center justify-center">
-      <div className="w-full text-center">
-        <img
-          width="180"
-          className="mx-auto block"
-          src={header.illustrationUrl}
-          alt={"title image"}
-        />
-      </div>
-      <div className="mt-[18px] mb-9 w-full text-center text-[25px] font-bold text-[#4b4b4b]">
-        {header.learningLanguageTitleContent.text}
-      </div>
-      <div className="pointer-events-auto w-full text-center">
-        <Button variant="primary" onClick={next}>
-          {localisation("button_start_story") || "Start the Story"}
-        </Button>
+    <div className="pointer-events-none fixed inset-0 w-full overflow-y-auto">
+      <div className="flex min-h-screen flex-col items-center justify-center px-4 py-[72px]">
+        <div className="w-full text-center">
+          <img
+            width="180"
+            className="mx-auto block"
+            src={header.illustrationUrl}
+            alt={"title image"}
+          />
+        </div>
+        <div className="mt-[18px] mb-9 w-full text-center text-[25px] font-bold text-[#4b4b4b]">
+          {header.learningLanguageTitleContent.text}
+        </div>
+        <div className="pointer-events-auto w-full text-center">
+          <Button variant="primary" onClick={next}>
+            {localisation("button_start_story") || "Start the Story"}
+          </Button>
+        </div>
+        {transcript.length > 0 ? (
+          <details
+            className={cn(
+              "pointer-events-auto mt-8 w-full max-w-[500px] rounded-2xl border-2 border-[#e5e5e5] bg-white px-4 py-3 text-left text-[#4b4b4b]",
+              story.learning_language_rtl && "[direction:rtl] text-right",
+            )}
+          >
+            <summary className="cursor-pointer text-[18px] font-bold">
+              Transcript
+            </summary>
+            <div className="mt-4 space-y-3 text-[18px] leading-[28px]">
+              {transcript.map((line) => (
+                <p key={line.id} className="m-0">
+                  {line.text}
+                </p>
+              ))}
+            </div>
+          </details>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add a collapsed Transcript details section to the direct-entry story start page
- Reuse the existing story transcript extraction so JS-rendered crawlers see the story text without changing the interactive reading flow
- Keep the transcript panel centered and capped at 500px wide

## Verification
- `biome format src/components/StoryTitlePage/StoryTitlePage.tsx --write`: passed
- `biome lint src/components/StoryTitlePage/StoryTitlePage.tsx`: passed
- `tsc --noEmit --pretty false`: blocked by existing Convex test-tooling type errors for `vitest`, `convex-test`, and `vite/client` in the isolated worktree
- Captured local screenshots of collapsed/opened states from `/story/56` before filing this PR