### PR TITLE
Improve editor feedback review

### DIFF
--- a/convex/editorRead.ts
+++ b/convex/editorRead.ts
@@ -34,6 +34,7 @@ const editorCourseValidator = v.union(
     contributors_past: v.array(courseContributorValidator),
     todo_count: v.number(),
     audio_problem_count: v.number(),
+    unresolved_feedback_count: v.number(),
   }),
   v.null(),
 );
@@ -64,6 +65,7 @@ function toLanguage(language: LanguageDoc) {
 function toCourse(
   course: CourseDoc,
   languageById: Map<Id<"languages">, LanguageDoc>,
+  unresolvedFeedbackCount = 0,
 ) {
   const learningLanguage = languageById.get(course.learningLanguageId);
   const fromLanguage = languageById.get(course.fromLanguageId);
@@ -88,7 +90,27 @@ function toCourse(
     contributors_past: course.contributors_past ?? [],
     todo_count: course.todo_count ?? 0,
     audio_problem_count: course.audio_problem_count ?? 0,
+    unresolved_feedback_count: unresolvedFeedbackCount,
   };
+}
+
+async function getUnresolvedFeedbackCountsByCourseShort(ctx: QueryCtx) {
+  const [openReports, reviewedReports] = await Promise.all([
+    ctx.db
+      .query("story_feedback_reports")
+      .withIndex("by_status_and_created_at", (q) => q.eq("status", "open"))
+      .collect(),
+    ctx.db
+      .query("story_feedback_reports")
+      .withIndex("by_status_and_created_at", (q) => q.eq("status", "reviewed"))
+      .collect(),
+  ]);
+
+  const counts = new Map<string, number>();
+  for (const report of [...openReports, ...reviewedReports]) {
+    counts.set(report.courseShort, (counts.get(report.courseShort) ?? 0) + 1);
+  }
+  return counts;
 }
 
 async function getCourseByIdentifier(ctx: QueryCtx, identifier: string) {
@@ -240,8 +262,17 @@ export const getEditorSidebarData = query({
       languageById.set(language._id, language);
     }
 
+    const unresolvedFeedbackCounts =
+      await getUnresolvedFeedbackCountsByCourseShort(ctx);
+
     const courses = courseRows
-      .map((course) => toCourse(course, languageById))
+      .map((course) =>
+        toCourse(
+          course,
+          languageById,
+          course.short ? (unresolvedFeedbackCounts.get(course.short) ?? 0) : 0,
+        ),
+      )
       .sort((a, b) => b.count - a.count);
 
     return { courses };
@@ -286,6 +317,11 @@ export const getEditorCourseByIdentifier = query({
       contributors_past: contributorLists.contributors_past,
       todo_count: course.todo_count ?? 0,
       audio_problem_count: course.audio_problem_count ?? 0,
+      unresolved_feedback_count: course.short
+        ? ((await getUnresolvedFeedbackCountsByCourseShort(ctx)).get(
+            course.short,
+          ) ?? 0)
+        : 0,
     };
   },
 });

--- a/convex/editorRead.ts
+++ b/convex/editorRead.ts
@@ -94,21 +94,11 @@ function toCourse(
   };
 }
 
-async function getUnresolvedFeedbackCountsByCourseShort(ctx: QueryCtx) {
-  const [openReports, reviewedReports] = await Promise.all([
-    ctx.db
-      .query("story_feedback_reports")
-      .withIndex("by_status_and_created_at", (q) => q.eq("status", "open"))
-      .collect(),
-    ctx.db
-      .query("story_feedback_reports")
-      .withIndex("by_status_and_created_at", (q) => q.eq("status", "reviewed"))
-      .collect(),
-  ]);
-
-  const counts = new Map<string, number>();
-  for (const report of [...openReports, ...reviewedReports]) {
-    counts.set(report.courseShort, (counts.get(report.courseShort) ?? 0) + 1);
+async function getUnresolvedFeedbackCountsByCourseId(ctx: QueryCtx) {
+  const statsRows = await ctx.db.query("course_feedback_stats").collect();
+  const counts = new Map<Id<"courses">, number>();
+  for (const row of statsRows) {
+    counts.set(row.courseId, row.openCount + row.reviewedCount);
   }
   return counts;
 }
@@ -263,14 +253,14 @@ export const getEditorSidebarData = query({
     }
 
     const unresolvedFeedbackCounts =
-      await getUnresolvedFeedbackCountsByCourseShort(ctx);
+      await getUnresolvedFeedbackCountsByCourseId(ctx);
 
     const courses = courseRows
       .map((course) =>
         toCourse(
           course,
           languageById,
-          course.short ? (unresolvedFeedbackCounts.get(course.short) ?? 0) : 0,
+          unresolvedFeedbackCounts.get(course._id) ?? 0,
         ),
       )
       .sort((a, b) => b.count - a.count);
@@ -317,11 +307,14 @@ export const getEditorCourseByIdentifier = query({
       contributors_past: contributorLists.contributors_past,
       todo_count: course.todo_count ?? 0,
       audio_problem_count: course.audio_problem_count ?? 0,
-      unresolved_feedback_count: course.short
-        ? ((await getUnresolvedFeedbackCountsByCourseShort(ctx)).get(
-            course.short,
-          ) ?? 0)
-        : 0,
+      unresolved_feedback_count:
+        (await ctx.db
+          .query("course_feedback_stats")
+          .withIndex("by_course", (q) => q.eq("courseId", course._id))
+          .unique()
+          .then((stats) =>
+            stats ? stats.openCount + stats.reviewedCount : 0,
+          )) ?? 0,
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -244,6 +244,7 @@ export default defineSchema({
     courseShort: v.string(),
     line: v.optional(v.number()),
     lineText: v.optional(v.string()),
+    lineElement: v.optional(v.any()),
     category: v.union(
       v.literal("Text"),
       v.literal("Translation hints"),
@@ -264,6 +265,11 @@ export default defineSchema({
     .index("by_story_id", ["storyId"])
     .index("by_story_and_status", ["storyId", "status"])
     .index("by_course_short", ["courseShort"])
+    .index("by_course_short_status_created_at", [
+      "courseShort",
+      "status",
+      "createdAt",
+    ])
     .index("by_category", ["category"])
     .index("by_user_id", ["userId"])
     .index("by_status_and_created_at", ["status", "createdAt"]),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -239,6 +239,7 @@ export default defineSchema({
     .index("by_legacy_id", ["legacyId"]),
 
   story_feedback_reports: defineTable({
+    operationKey: v.optional(v.string()),
     storyId: v.number(),
     storyTitle: v.string(),
     courseShort: v.string(),
@@ -272,7 +273,8 @@ export default defineSchema({
     ])
     .index("by_category", ["category"])
     .index("by_user_id", ["userId"])
-    .index("by_status_and_created_at", ["status", "createdAt"]),
+    .index("by_status_and_created_at", ["status", "createdAt"])
+    .index("by_operation_key", ["operationKey"]),
 
   course_feedback_stats: defineTable({
     courseId: v.id("courses"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -274,6 +274,16 @@ export default defineSchema({
     .index("by_user_id", ["userId"])
     .index("by_status_and_created_at", ["status", "createdAt"]),
 
+  course_feedback_stats: defineTable({
+    courseId: v.id("courses"),
+    courseShort: v.string(),
+    openCount: v.number(),
+    reviewedCount: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_course", ["courseId"])
+    .index("by_course_short", ["courseShort"]),
+
   discord_stories_role_sync: defineTable({
     legacyUserId: v.number(),
     discordAccountId: v.union(v.string(), v.null()),

--- a/convex/storyFeedback.test.ts
+++ b/convex/storyFeedback.test.ts
@@ -8,13 +8,38 @@ const modules = import.meta.glob("./**/*.ts");
 
 type FeedbackArgs = {
   storyId: number;
-  storyTitle: string;
-  courseShort: string;
+  storyTitle?: string;
+  courseShort?: string;
   line?: number;
   lineText?: string;
   lineElement?: unknown;
   category: "Text" | "Translation hints" | "Audio" | "Other";
   comment: string;
+};
+
+const parsedLineElement = {
+  type: "LINE",
+  line: {
+    type: "PROSE",
+    content: {
+      text: "Hola",
+      hintMap: [{ hintIndex: 0, rangeFrom: 0, rangeTo: 3 }],
+      hints: ["Hello"],
+      audio: {
+        ssml: {
+          text: "Hola",
+          speaker: "es",
+          id: 1,
+          inser_index: 0,
+        },
+        url: "story-line.mp3",
+        keypoints: [{ rangeEnd: 4, audioStart: 120 }],
+      },
+    },
+  },
+  trackingProperties: { line_index: 1 },
+  lang: "es",
+  editor: { block_start_no: 12 },
 };
 
 async function seedCourseWithStory(t: ReturnType<typeof convexTest>) {
@@ -53,6 +78,12 @@ async function seedCourseWithStory(t: ReturnType<typeof convexTest>) {
       deleted: false,
       todo_count: 0,
     });
+    await ctx.db.insert("story_content", {
+      storyId,
+      text: "[Story]\nHola",
+      json: { elements: [parsedLineElement] },
+      lastUpdated: 1,
+    });
     return { courseId, storyId };
   });
 }
@@ -60,8 +91,6 @@ async function seedCourseWithStory(t: ReturnType<typeof convexTest>) {
 function feedbackArgs(overrides: Partial<FeedbackArgs> = {}): FeedbackArgs {
   return {
     storyId: 10,
-    storyTitle: "Story",
-    courseShort: "es-en",
     category: "Text" as const,
     comment: "There is a typo.",
     ...overrides,
@@ -144,34 +173,147 @@ describe("submitStoryFeedback", () => {
     );
   });
 
-  test("stores line preview data for review rendering", async () => {
+  test("derives course, title, and line preview data for review rendering", async () => {
     const t = convexTest(schema, modules);
     await seedCourseWithStory(t);
 
-    const lineElement = {
-      type: "LINE",
-      line: {
-        type: "PROSE",
-        content: {
-          text: "Hola",
-          hintMap: [{ hintIndex: 0, rangeFrom: 0, rangeTo: 3 }],
-          hints: ["Hello"],
-        },
-      },
-      trackingProperties: { line_index: 1 },
-      lang: "es",
-      editor: { block_start_no: 12 },
-    };
-
     await t.mutation(
       api.storyFeedback.submitStoryFeedback,
-      feedbackArgs({ line: 12, lineElement }),
+      feedbackArgs({
+        storyTitle: "Spoofed title",
+        courseShort: "fr-en",
+        line: 12,
+        lineText: "Spoofed line",
+        lineElement: { type: "LINE", bogus: true },
+      }),
     );
 
     await t.run(async (ctx) => {
       const [report] = await ctx.db.query("story_feedback_reports").collect();
+      expect(report.storyTitle).toBe("Story");
+      expect(report.courseShort).toBe("es-en");
       expect(report.line).toBe(12);
-      expect(report.lineElement).toEqual(lineElement);
+      expect(report.lineText).toBe("Hola");
+      expect(report.lineElement).toEqual(parsedLineElement);
+    });
+  });
+
+  test("stores sanitized text fallback when no line number is available", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t);
+
+    await t.mutation(
+      api.storyFeedback.submitStoryFeedback,
+      feedbackArgs({ lineText: "  Seen text\r\nsecond line  " }),
+    );
+
+    await t.run(async (ctx) => {
+      const [report] = await ctx.db.query("story_feedback_reports").collect();
+      expect(report.line).toBeUndefined();
+      expect(report.lineText).toBe("Seen text\nsecond line");
+      expect(report.lineElement).toBeUndefined();
+    });
+  });
+});
+
+describe("course feedback stats", () => {
+  test("submit and status updates maintain unresolved course counts", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t);
+
+    await t.mutation(api.storyFeedback.submitStoryFeedback, feedbackArgs());
+
+    await t.run(async (ctx) => {
+      const [stats] = await ctx.db.query("course_feedback_stats").collect();
+      expect(stats.openCount).toBe(1);
+      expect(stats.reviewedCount).toBe(0);
+    });
+
+    const asContributor = t.withIdentity({ role: "contributor", userId: "5" });
+    const reportId = await t.run(async (ctx) => {
+      const [report] = await ctx.db.query("story_feedback_reports").collect();
+      return report._id;
+    });
+
+    await asContributor.mutation(api.storyFeedback.updateStoryFeedbackStatus, {
+      reportId,
+      status: "reviewed",
+    });
+
+    await t.run(async (ctx) => {
+      const [stats] = await ctx.db.query("course_feedback_stats").collect();
+      expect(stats.openCount).toBe(0);
+      expect(stats.reviewedCount).toBe(1);
+    });
+
+    await asContributor.mutation(api.storyFeedback.updateStoryFeedbackStatus, {
+      reportId,
+      status: "resolved",
+    });
+
+    await t.run(async (ctx) => {
+      const [stats] = await ctx.db.query("course_feedback_stats").collect();
+      expect(stats.openCount).toBe(0);
+      expect(stats.reviewedCount).toBe(0);
+    });
+  });
+
+  test("admin recompute rebuilds stats from existing reports", async () => {
+    const t = convexTest(schema, modules);
+    const { courseId } = await seedCourseWithStory(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("story_feedback_reports", {
+        storyId: 10,
+        storyTitle: "Story",
+        courseShort: "spoofed",
+        category: "Text",
+        comment: "Open",
+        userId: null,
+        userName: null,
+        userEmail: null,
+        status: "open",
+        createdAt: 1,
+      });
+      await ctx.db.insert("story_feedback_reports", {
+        storyId: 10,
+        storyTitle: "Story",
+        courseShort: "spoofed",
+        category: "Text",
+        comment: "Reviewed",
+        userId: null,
+        userName: null,
+        userEmail: null,
+        status: "reviewed",
+        createdAt: 2,
+      });
+    });
+
+    await expect(
+      t
+        .withIdentity({ role: "contributor", userId: "5" })
+        .mutation(api.storyFeedback.recomputeCourseFeedbackStats, {}),
+    ).rejects.toThrow("Unauthorized");
+
+    const result = await t
+      .withIdentity({ role: "admin", userId: "1" })
+      .mutation(api.storyFeedback.recomputeCourseFeedbackStats, {});
+    expect(result.reportsCounted).toBe(2);
+
+    await t.run(async (ctx) => {
+      const stats = await ctx.db
+        .query("course_feedback_stats")
+        .withIndex("by_course", (q) => q.eq("courseId", courseId))
+        .unique();
+      expect(stats?.courseShort).toBe("es-en");
+      expect(stats?.openCount).toBe(1);
+      expect(stats?.reviewedCount).toBe(1);
+
+      const reports = await ctx.db.query("story_feedback_reports").collect();
+      expect(reports.map((report) => report.courseShort)).toEqual([
+        "es-en",
+        "es-en",
+      ]);
     });
   });
 });

--- a/convex/storyFeedback.test.ts
+++ b/convex/storyFeedback.test.ts
@@ -8,6 +8,7 @@ const modules = import.meta.glob("./**/*.ts");
 
 type FeedbackArgs = {
   storyId: number;
+  operationKey: string;
   storyTitle?: string;
   courseShort?: string;
   line?: number;
@@ -91,6 +92,7 @@ async function seedCourseWithStory(t: ReturnType<typeof convexTest>) {
 function feedbackArgs(overrides: Partial<FeedbackArgs> = {}): FeedbackArgs {
   return {
     storyId: 10,
+    operationKey: "feedback-operation-key",
     category: "Text" as const,
     comment: "There is a typo.",
     ...overrides,
@@ -115,6 +117,11 @@ describe("submitStoryFeedback", () => {
       "lineElement",
       { lineElement: { text: `${"x".repeat(20001)}` } },
       "Line preview is too large",
+    ],
+    [
+      "operationKey",
+      { operationKey: `${"x".repeat(201)}` },
+      "Operation key is too long",
     ],
   ])("%s length cap rejects oversized values", async (_field, overrides, error) => {
     const t = convexTest(schema, modules);
@@ -190,11 +197,38 @@ describe("submitStoryFeedback", () => {
 
     await t.run(async (ctx) => {
       const [report] = await ctx.db.query("story_feedback_reports").collect();
+      expect(report.operationKey).toBe("feedback-operation-key");
       expect(report.storyTitle).toBe("Story");
       expect(report.courseShort).toBe("es-en");
       expect(report.line).toBe(12);
       expect(report.lineText).toBe("Hola");
       expect(report.lineElement).toEqual(parsedLineElement);
+    });
+  });
+
+  test("uses operation keys to make repeated submissions idempotent", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t);
+
+    const first = await t.mutation(
+      api.storyFeedback.submitStoryFeedback,
+      feedbackArgs({ operationKey: "feedback:retry:1" }),
+    );
+    const second = await t.mutation(
+      api.storyFeedback.submitStoryFeedback,
+      feedbackArgs({
+        operationKey: "feedback:retry:1",
+        comment: "Retried after success",
+      }),
+    );
+
+    expect(second.reportId).toBe(first.reportId);
+    await t.run(async (ctx) => {
+      const reports = await ctx.db.query("story_feedback_reports").collect();
+      const [stats] = await ctx.db.query("course_feedback_stats").collect();
+      expect(reports).toHaveLength(1);
+      expect(stats.openCount).toBe(1);
+      expect(stats.reviewedCount).toBe(0);
     });
   });
 

--- a/convex/storyFeedback.test.ts
+++ b/convex/storyFeedback.test.ts
@@ -287,6 +287,18 @@ describe("course feedback stats", () => {
         status: "reviewed",
         createdAt: 2,
       });
+      await ctx.db.insert("story_feedback_reports", {
+        storyId: 10,
+        storyTitle: "Story",
+        courseShort: "spoofed",
+        category: "Text",
+        comment: "Resolved",
+        userId: null,
+        userName: null,
+        userEmail: null,
+        status: "resolved",
+        createdAt: 3,
+      });
     });
 
     await expect(
@@ -311,6 +323,7 @@ describe("course feedback stats", () => {
 
       const reports = await ctx.db.query("story_feedback_reports").collect();
       expect(reports.map((report) => report.courseShort)).toEqual([
+        "es-en",
         "es-en",
         "es-en",
       ]);

--- a/convex/storyFeedback.test.ts
+++ b/convex/storyFeedback.test.ts
@@ -10,7 +10,9 @@ type FeedbackArgs = {
   storyId: number;
   storyTitle: string;
   courseShort: string;
+  line?: number;
   lineText?: string;
+  lineElement?: unknown;
   category: "Text" | "Translation hints" | "Audio" | "Other";
   comment: string;
 };
@@ -80,6 +82,11 @@ describe("submitStoryFeedback", () => {
       "Course short is too long",
     ],
     ["lineText", { lineText: `${"x".repeat(501)}` }, "Line text is too long"],
+    [
+      "lineElement",
+      { lineElement: { text: `${"x".repeat(20001)}` } },
+      "Line preview is too large",
+    ],
   ])("%s length cap rejects oversized values", async (_field, overrides, error) => {
     const t = convexTest(schema, modules);
     await seedCourseWithStory(t);
@@ -135,6 +142,37 @@ describe("submitStoryFeedback", () => {
     ).rejects.toThrow(
       "This story already has many open reports. Please try again later.",
     );
+  });
+
+  test("stores line preview data for review rendering", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t);
+
+    const lineElement = {
+      type: "LINE",
+      line: {
+        type: "PROSE",
+        content: {
+          text: "Hola",
+          hintMap: [{ hintIndex: 0, rangeFrom: 0, rangeTo: 3 }],
+          hints: ["Hello"],
+        },
+      },
+      trackingProperties: { line_index: 1 },
+      lang: "es",
+      editor: { block_start_no: 12 },
+    };
+
+    await t.mutation(
+      api.storyFeedback.submitStoryFeedback,
+      feedbackArgs({ line: 12, lineElement }),
+    );
+
+    await t.run(async (ctx) => {
+      const [report] = await ctx.db.query("story_feedback_reports").collect();
+      expect(report.line).toBe(12);
+      expect(report.lineElement).toEqual(lineElement);
+    });
   });
 });
 
@@ -210,5 +248,46 @@ describe("listStoryFeedbackReports", () => {
       "Report 100",
     ]);
     expect(secondPage.isDone).toBe(true);
+  });
+
+  test("filters reports by course short", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t);
+
+    await t.run(async (ctx) => {
+      for (const [courseShort, createdAt] of [
+        ["es-en", 100],
+        ["fr-en", 200],
+        ["es-en", 300],
+      ] as const) {
+        await ctx.db.insert("story_feedback_reports", {
+          storyId: 10,
+          storyTitle: "Story",
+          courseShort,
+          category: "Text",
+          comment: `${courseShort} report ${createdAt}`,
+          userId: null,
+          userName: null,
+          userEmail: null,
+          status: "open",
+          createdAt,
+        });
+      }
+    });
+
+    const asContributor = t.withIdentity({ role: "contributor", userId: "5" });
+    const page = await asContributor.query(
+      api.storyFeedback.listStoryFeedbackReports,
+      {
+        status: "open",
+        courseShort: "es-en",
+        paginationOpts: { numItems: 10, cursor: null },
+      },
+    );
+
+    expect(page.page.map((report) => report.comment)).toEqual([
+      "es-en report 300",
+      "es-en report 100",
+    ]);
   });
 });

--- a/convex/storyFeedback.ts
+++ b/convex/storyFeedback.ts
@@ -3,8 +3,9 @@ import {
   paginationResultValidator,
 } from "convex/server";
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
-import { requireContributorOrAdmin } from "./lib/authorization";
+import type { Doc, Id } from "./_generated/dataModel";
+import { mutation, query, type MutationCtx } from "./_generated/server";
+import { requireAdmin, requireContributorOrAdmin } from "./lib/authorization";
 
 const feedbackCategoryValidator = v.union(
   v.literal("Text"),
@@ -37,13 +38,180 @@ const feedbackReportValidator = v.object({
   createdAt: v.number(),
 });
 
+type FeedbackStatus = "open" | "reviewed" | "resolved";
+type StoryDoc = Doc<"stories">;
+type CourseDoc = Doc<"courses">;
+type StoryContentDoc = Doc<"story_content">;
+
+function normalizeOptionalLineText(value: string | undefined) {
+  const text = value?.replace(/\r\n?/g, "\n").trim();
+  if (!text) return undefined;
+  if (text.length > 500) {
+    throw new Error("Line text is too long");
+  }
+  if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/.test(text)) {
+    throw new Error("Line text contains unsupported characters");
+  }
+  return text;
+}
+
+function normalizeDerivedLineText(value: string | undefined) {
+  const text = value?.replace(/\r\n?/g, "\n").trim();
+  if (!text) return undefined;
+  if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/.test(text)) {
+    return undefined;
+  }
+  return text.length > 500 ? text.slice(0, 500) : text;
+}
+
+function getCourseShort(course: CourseDoc) {
+  return course.short?.trim() || `${course.legacyId}`;
+}
+
+function parseStoryJson(storyContent: StoryContentDoc | null) {
+  if (!storyContent) return null;
+  if (typeof storyContent.json === "string") {
+    try {
+      return JSON.parse(storyContent.json) as unknown;
+    } catch {
+      return null;
+    }
+  }
+  return storyContent.json as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getLineTextFromElement(element: Record<string, unknown>) {
+  const line = element.line;
+  if (!isRecord(line)) return undefined;
+  const content = line.content;
+  if (!isRecord(content) || typeof content.text !== "string") return undefined;
+
+  const speaker =
+    line.type === "CHARACTER"
+      ? typeof line.characterName === "string"
+        ? line.characterName
+        : typeof line.characterId === "string" ||
+            typeof line.characterId === "number"
+          ? `${line.characterId}`
+          : ""
+      : "";
+
+  return speaker ? `${speaker}: ${content.text}` : content.text;
+}
+
+function editorLineMatches(
+  element: Record<string, unknown>,
+  lineNumber: number,
+) {
+  const editor = element.editor;
+  if (!isRecord(editor)) return false;
+  return (
+    editor.block_start_no === lineNumber ||
+    editor.start_no === lineNumber ||
+    editor.active_no === lineNumber
+  );
+}
+
+function getLineSnapshotFromStoryJson(storyJson: unknown, lineNumber?: number) {
+  if (lineNumber === undefined) return undefined;
+  if (!isRecord(storyJson) || !Array.isArray(storyJson.elements)) {
+    return undefined;
+  }
+
+  const element = storyJson.elements.find(
+    (candidate) =>
+      isRecord(candidate) &&
+      candidate.type === "LINE" &&
+      editorLineMatches(candidate, lineNumber),
+  );
+  if (!isRecord(element)) return undefined;
+
+  const serialized = JSON.stringify(element);
+  if (serialized.length > 50000) return undefined;
+  return JSON.parse(serialized) as unknown;
+}
+
+function getStatusDelta(status: FeedbackStatus, delta: number) {
+  return {
+    openCount: status === "open" ? delta : 0,
+    reviewedCount: status === "reviewed" ? delta : 0,
+  };
+}
+
+async function applyCourseFeedbackStatsDelta(
+  ctx: MutationCtx,
+  courseId: Id<"courses">,
+  courseShort: string,
+  openDelta: number,
+  reviewedDelta: number,
+) {
+  if (openDelta === 0 && reviewedDelta === 0) return;
+
+  const now = Date.now();
+  const existing = await ctx.db
+    .query("course_feedback_stats")
+    .withIndex("by_course", (q) => q.eq("courseId", courseId))
+    .unique();
+
+  if (!existing) {
+    await ctx.db.insert("course_feedback_stats", {
+      courseId,
+      courseShort,
+      openCount: Math.max(0, openDelta),
+      reviewedCount: Math.max(0, reviewedDelta),
+      updatedAt: now,
+    });
+    return;
+  }
+
+  await ctx.db.patch(existing._id, {
+    courseShort,
+    openCount: Math.max(0, existing.openCount + openDelta),
+    reviewedCount: Math.max(0, existing.reviewedCount + reviewedDelta),
+    updatedAt: now,
+  });
+}
+
+async function getStoryCourseAndContent(
+  ctx: MutationCtx,
+  legacyStoryId: number,
+) {
+  const story = await ctx.db
+    .query("stories")
+    .withIndex("by_legacy_id", (q) => q.eq("legacyId", legacyStoryId))
+    .unique();
+  if (!story) {
+    throw new Error("Unknown story");
+  }
+
+  const [course, storyContent] = await Promise.all([
+    ctx.db.get(story.courseId),
+    ctx.db
+      .query("story_content")
+      .withIndex("by_story", (q) => q.eq("storyId", story._id))
+      .unique(),
+  ]);
+  if (!course) {
+    throw new Error("Unknown course");
+  }
+
+  return { story, course, storyContent };
+}
+
 export const submitStoryFeedback = mutation({
   args: {
     storyId: v.number(),
-    storyTitle: v.string(),
-    courseShort: v.string(),
+    // TODO(remove after 2026-07-20): deprecated; derived server-side.
+    storyTitle: v.optional(v.string()),
+    // TODO(remove after 2026-07-20): deprecated; derived server-side.
+    courseShort: v.optional(v.string()),
     line: v.optional(v.number()),
     lineText: v.optional(v.string()),
+    // TODO(remove after 2026-07-20): deprecated; ignored for trust safety.
     lineElement: v.optional(v.any()),
     category: feedbackCategoryValidator,
     comment: v.string(),
@@ -60,20 +228,14 @@ export const submitStoryFeedback = mutation({
       throw new Error("Comment is too long");
     }
 
-    const storyTitle = args.storyTitle.trim();
-    if (storyTitle.length > 200) {
+    if (args.storyTitle !== undefined && args.storyTitle.length > 200) {
       throw new Error("Story title is too long");
     }
-
-    const courseShort = args.courseShort.trim();
-    if (courseShort.length > 20) {
+    if (args.courseShort !== undefined && args.courseShort.length > 20) {
       throw new Error("Course short is too long");
     }
 
-    const lineText = args.lineText?.trim();
-    if (lineText !== undefined && lineText.length > 500) {
-      throw new Error("Line text is too long");
-    }
+    const submittedLineText = normalizeOptionalLineText(args.lineText);
     if (args.lineElement !== undefined) {
       const serializedLineElement = JSON.stringify(args.lineElement);
       if (serializedLineElement.length > 20000) {
@@ -81,13 +243,10 @@ export const submitStoryFeedback = mutation({
       }
     }
 
-    const story = await ctx.db
-      .query("stories")
-      .withIndex("by_legacy_id", (q) => q.eq("legacyId", args.storyId))
-      .unique();
-    if (!story) {
-      throw new Error("Unknown story");
-    }
+    const { story, course, storyContent } = await getStoryCourseAndContent(
+      ctx,
+      args.storyId,
+    );
 
     const openReports = await ctx.db
       .query("story_feedback_reports")
@@ -107,15 +266,25 @@ export const submitStoryFeedback = mutation({
       email?: string | null;
     } | null;
 
+    const storyJson = parseStoryJson(storyContent);
+    const lineElement = getLineSnapshotFromStoryJson(storyJson, args.line);
+    const derivedLineText = isRecord(lineElement)
+      ? getLineTextFromElement(lineElement)
+      : undefined;
+    const lineText =
+      derivedLineText !== undefined
+        ? normalizeDerivedLineText(derivedLineText)
+        : submittedLineText;
+    const storyTitle = story.name;
+    const courseShort = getCourseShort(course);
+
     const reportId = await ctx.db.insert("story_feedback_reports", {
       storyId: args.storyId,
       storyTitle,
       courseShort,
       ...(args.line !== undefined ? { line: args.line } : {}),
       ...(lineText ? { lineText } : {}),
-      ...(args.lineElement !== undefined
-        ? { lineElement: args.lineElement }
-        : {}),
+      ...(lineElement !== undefined ? { lineElement } : {}),
       category: args.category,
       comment,
       userId: identity?.tokenIdentifier ?? null,
@@ -124,6 +293,8 @@ export const submitStoryFeedback = mutation({
       status: "open",
       createdAt: Date.now(),
     });
+
+    await applyCourseFeedbackStatsDelta(ctx, story.courseId, courseShort, 1, 0);
 
     return { reportId };
   },
@@ -167,8 +338,21 @@ export const updateStoryFeedbackStatus = mutation({
   handler: async (ctx, args) => {
     await requireContributorOrAdmin(ctx);
 
+    const existing = await ctx.db.get(args.reportId);
+    if (!existing) {
+      throw new Error("Feedback report not found");
+    }
+
+    const { story, course } = await getStoryCourseAndContent(
+      ctx,
+      existing.storyId,
+    );
+    const courseShort = getCourseShort(course);
+
     await ctx.db.patch(args.reportId, {
       status: args.status,
+      storyTitle: story.name,
+      courseShort,
     });
 
     const report = await ctx.db.get(args.reportId);
@@ -176,6 +360,127 @@ export const updateStoryFeedbackStatus = mutation({
       throw new Error("Feedback report not found");
     }
 
+    const previousDelta = getStatusDelta(existing.status, -1);
+    const nextDelta = getStatusDelta(args.status, 1);
+    await applyCourseFeedbackStatsDelta(
+      ctx,
+      story.courseId,
+      courseShort,
+      previousDelta.openCount + nextDelta.openCount,
+      previousDelta.reviewedCount + nextDelta.reviewedCount,
+    );
+
     return report;
+  },
+});
+
+export const recomputeCourseFeedbackStats = mutation({
+  args: {},
+  returns: v.object({
+    coursesUpdated: v.number(),
+    reportsCounted: v.number(),
+  }),
+  handler: async (ctx) => {
+    await requireAdmin(ctx);
+
+    const [courses, existingStats, openReports, reviewedReports] =
+      await Promise.all([
+        ctx.db.query("courses").collect(),
+        ctx.db.query("course_feedback_stats").collect(),
+        ctx.db
+          .query("story_feedback_reports")
+          .withIndex("by_status_and_created_at", (q) => q.eq("status", "open"))
+          .collect(),
+        ctx.db
+          .query("story_feedback_reports")
+          .withIndex("by_status_and_created_at", (q) =>
+            q.eq("status", "reviewed"),
+          )
+          .collect(),
+      ]);
+
+    const courseById = new Map(courses.map((course) => [course._id, course]));
+    const storyByLegacyId = new Map<number, StoryDoc>();
+    const reports = [
+      ...openReports.map((report) => ({ report, status: "open" as const })),
+      ...reviewedReports.map((report) => ({
+        report,
+        status: "reviewed" as const,
+      })),
+    ];
+    const counts = new Map<
+      Id<"courses">,
+      { courseShort: string; openCount: number; reviewedCount: number }
+    >();
+
+    for (const { report, status } of reports) {
+      let story = storyByLegacyId.get(report.storyId);
+      if (!story) {
+        story =
+          (await ctx.db
+            .query("stories")
+            .withIndex("by_legacy_id", (q) => q.eq("legacyId", report.storyId))
+            .unique()) ?? undefined;
+        if (story) storyByLegacyId.set(report.storyId, story);
+      }
+      if (!story) continue;
+
+      const course = courseById.get(story.courseId);
+      if (!course) continue;
+
+      const courseShort = getCourseShort(course);
+      if (
+        report.courseShort !== courseShort ||
+        report.storyTitle !== story.name
+      ) {
+        await ctx.db.patch(report._id, {
+          courseShort,
+          storyTitle: story.name,
+        });
+      }
+
+      const existing = counts.get(course._id) ?? {
+        courseShort,
+        openCount: 0,
+        reviewedCount: 0,
+      };
+      if (status === "open") existing.openCount += 1;
+      else existing.reviewedCount += 1;
+      counts.set(course._id, existing);
+    }
+
+    const now = Date.now();
+    let coursesUpdated = 0;
+    for (const course of courses) {
+      const next = counts.get(course._id) ?? {
+        courseShort: getCourseShort(course),
+        openCount: 0,
+        reviewedCount: 0,
+      };
+      const current = existingStats.find(
+        (stat) => stat.courseId === course._id,
+      );
+      if (!current) {
+        await ctx.db.insert("course_feedback_stats", {
+          courseId: course._id,
+          courseShort: next.courseShort,
+          openCount: next.openCount,
+          reviewedCount: next.reviewedCount,
+          updatedAt: now,
+        });
+        coursesUpdated += 1;
+        continue;
+      }
+
+      await ctx.db.patch(current._id, {
+        courseShort: next.courseShort,
+        openCount: next.openCount,
+        reviewedCount: next.reviewedCount,
+        updatedAt: now,
+      });
+      coursesUpdated += 1;
+    }
+
+    return { coursesUpdated, reportsCounted: reports.length };
   },
 });

--- a/convex/storyFeedback.ts
+++ b/convex/storyFeedback.ts
@@ -27,6 +27,7 @@ const feedbackReportValidator = v.object({
   courseShort: v.string(),
   line: v.optional(v.number()),
   lineText: v.optional(v.string()),
+  lineElement: v.optional(v.any()),
   category: feedbackCategoryValidator,
   comment: v.string(),
   userId: v.union(v.string(), v.null()),
@@ -43,6 +44,7 @@ export const submitStoryFeedback = mutation({
     courseShort: v.string(),
     line: v.optional(v.number()),
     lineText: v.optional(v.string()),
+    lineElement: v.optional(v.any()),
     category: feedbackCategoryValidator,
     comment: v.string(),
   },
@@ -71,6 +73,12 @@ export const submitStoryFeedback = mutation({
     const lineText = args.lineText?.trim();
     if (lineText !== undefined && lineText.length > 500) {
       throw new Error("Line text is too long");
+    }
+    if (args.lineElement !== undefined) {
+      const serializedLineElement = JSON.stringify(args.lineElement);
+      if (serializedLineElement.length > 20000) {
+        throw new Error("Line preview is too large");
+      }
     }
 
     const story = await ctx.db
@@ -105,6 +113,9 @@ export const submitStoryFeedback = mutation({
       courseShort,
       ...(args.line !== undefined ? { line: args.line } : {}),
       ...(lineText ? { lineText } : {}),
+      ...(args.lineElement !== undefined
+        ? { lineElement: args.lineElement }
+        : {}),
       category: args.category,
       comment,
       userId: identity?.tokenIdentifier ?? null,
@@ -121,11 +132,23 @@ export const submitStoryFeedback = mutation({
 export const listStoryFeedbackReports = query({
   args: {
     status: feedbackStatusValidator,
+    courseShort: v.optional(v.string()),
     paginationOpts: paginationOptsValidator,
   },
   returns: paginationResultValidator(feedbackReportValidator),
   handler: async (ctx, args) => {
     await requireContributorOrAdmin(ctx);
+
+    const courseShort = args.courseShort;
+    if (courseShort !== undefined) {
+      return await ctx.db
+        .query("story_feedback_reports")
+        .withIndex("by_course_short_status_created_at", (q) =>
+          q.eq("courseShort", courseShort).eq("status", args.status),
+        )
+        .order("desc")
+        .paginate(args.paginationOpts);
+    }
 
     return await ctx.db
       .query("story_feedback_reports")

--- a/convex/storyFeedback.ts
+++ b/convex/storyFeedback.ts
@@ -23,6 +23,7 @@ const feedbackStatusValidator = v.union(
 const feedbackReportValidator = v.object({
   _id: v.id("story_feedback_reports"),
   _creationTime: v.number(),
+  operationKey: v.optional(v.string()),
   storyId: v.number(),
   storyTitle: v.string(),
   courseShort: v.string(),
@@ -204,6 +205,7 @@ async function getStoryCourseAndContent(
 export const submitStoryFeedback = mutation({
   args: {
     storyId: v.number(),
+    operationKey: v.string(),
     // TODO(remove after 2026-07-20): deprecated; derived server-side.
     storyTitle: v.optional(v.string()),
     // TODO(remove after 2026-07-20): deprecated; derived server-side.
@@ -219,6 +221,14 @@ export const submitStoryFeedback = mutation({
     reportId: v.id("story_feedback_reports"),
   }),
   handler: async (ctx, args) => {
+    const operationKey = args.operationKey.trim();
+    if (!operationKey) {
+      throw new Error("Operation key is required");
+    }
+    if (operationKey.length > 200) {
+      throw new Error("Operation key is too long");
+    }
+
     const comment = args.comment.trim();
     if (!comment) {
       throw new Error("Comment is required");
@@ -240,6 +250,14 @@ export const submitStoryFeedback = mutation({
       if (serializedLineElement.length > 20000) {
         throw new Error("Line preview is too large");
       }
+    }
+
+    const existingReport = await ctx.db
+      .query("story_feedback_reports")
+      .withIndex("by_operation_key", (q) => q.eq("operationKey", operationKey))
+      .unique();
+    if (existingReport) {
+      return { reportId: existingReport._id };
     }
 
     const { story, course, storyContent } = await getStoryCourseAndContent(
@@ -278,6 +296,7 @@ export const submitStoryFeedback = mutation({
     const courseShort = getCourseShort(course);
 
     const reportId = await ctx.db.insert("story_feedback_reports", {
+      operationKey,
       storyId: args.storyId,
       storyTitle,
       courseShort,
@@ -400,15 +419,15 @@ export const recomputeCourseFeedbackStats = mutation({
       let openCount = 0;
       let reviewedCount = 0;
 
-      for (const status of ["open", "reviewed", "resolved"] as const) {
-        const stories = ctx.db
-          .query("stories")
-          .withIndex("by_course", (q) => q.eq("courseId", course._id));
+      const stories = ctx.db
+        .query("stories")
+        .withIndex("by_course", (q) => q.eq("courseId", course._id));
 
-        for await (const story of stories) {
-          const legacyStoryId = story.legacyId;
-          if (legacyStoryId === undefined) continue;
+      for await (const story of stories) {
+        const legacyStoryId = story.legacyId;
+        if (legacyStoryId === undefined) continue;
 
+        for (const status of ["open", "reviewed", "resolved"] as const) {
           const reports = ctx.db
             .query("story_feedback_reports")
             .withIndex("by_story_and_status", (q) =>

--- a/convex/storyFeedback.ts
+++ b/convex/storyFeedback.ts
@@ -39,7 +39,6 @@ const feedbackReportValidator = v.object({
 });
 
 type FeedbackStatus = "open" | "reviewed" | "resolved";
-type StoryDoc = Doc<"stories">;
 type CourseDoc = Doc<"courses">;
 type StoryContentDoc = Doc<"story_content">;
 
@@ -375,97 +374,80 @@ export const updateStoryFeedbackStatus = mutation({
 });
 
 export const recomputeCourseFeedbackStats = mutation({
-  args: {},
+  args: {
+    courseCursor: v.optional(v.union(v.string(), v.null())),
+    limit: v.optional(v.number()),
+  },
   returns: v.object({
     coursesUpdated: v.number(),
     reportsCounted: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
   }),
-  handler: async (ctx) => {
+  handler: async (ctx, args) => {
     await requireAdmin(ctx);
 
-    const [courses, existingStats, openReports, reviewedReports] =
-      await Promise.all([
-        ctx.db.query("courses").collect(),
-        ctx.db.query("course_feedback_stats").collect(),
-        ctx.db
-          .query("story_feedback_reports")
-          .withIndex("by_status_and_created_at", (q) => q.eq("status", "open"))
-          .collect(),
-        ctx.db
-          .query("story_feedback_reports")
-          .withIndex("by_status_and_created_at", (q) =>
-            q.eq("status", "reviewed"),
-          )
-          .collect(),
-      ]);
+    const limit = Math.min(Math.max(args.limit ?? 25, 1), 100);
+    const coursePage = await ctx.db
+      .query("courses")
+      .paginate({ cursor: args.courseCursor ?? null, numItems: limit });
 
-    const courseById = new Map(courses.map((course) => [course._id, course]));
-    const storyByLegacyId = new Map<number, StoryDoc>();
-    const reports = [
-      ...openReports.map((report) => ({ report, status: "open" as const })),
-      ...reviewedReports.map((report) => ({
-        report,
-        status: "reviewed" as const,
-      })),
-    ];
-    const counts = new Map<
-      Id<"courses">,
-      { courseShort: string; openCount: number; reviewedCount: number }
-    >();
-
-    for (const { report, status } of reports) {
-      let story = storyByLegacyId.get(report.storyId);
-      if (!story) {
-        story =
-          (await ctx.db
-            .query("stories")
-            .withIndex("by_legacy_id", (q) => q.eq("legacyId", report.storyId))
-            .unique()) ?? undefined;
-        if (story) storyByLegacyId.set(report.storyId, story);
-      }
-      if (!story) continue;
-
-      const course = courseById.get(story.courseId);
-      if (!course) continue;
-
-      const courseShort = getCourseShort(course);
-      if (
-        report.courseShort !== courseShort ||
-        report.storyTitle !== story.name
-      ) {
-        await ctx.db.patch(report._id, {
-          courseShort,
-          storyTitle: story.name,
-        });
-      }
-
-      const existing = counts.get(course._id) ?? {
-        courseShort,
-        openCount: 0,
-        reviewedCount: 0,
-      };
-      if (status === "open") existing.openCount += 1;
-      else existing.reviewedCount += 1;
-      counts.set(course._id, existing);
-    }
-
-    const now = Date.now();
     let coursesUpdated = 0;
-    for (const course of courses) {
-      const next = counts.get(course._id) ?? {
-        courseShort: getCourseShort(course),
-        openCount: 0,
-        reviewedCount: 0,
-      };
-      const current = existingStats.find(
-        (stat) => stat.courseId === course._id,
-      );
+    let reportsCounted = 0;
+
+    for (const course of coursePage.page) {
+      const courseShort = getCourseShort(course);
+      let openCount = 0;
+      let reviewedCount = 0;
+
+      for (const status of ["open", "reviewed", "resolved"] as const) {
+        const stories = ctx.db
+          .query("stories")
+          .withIndex("by_course", (q) => q.eq("courseId", course._id));
+
+        for await (const story of stories) {
+          const legacyStoryId = story.legacyId;
+          if (legacyStoryId === undefined) continue;
+
+          const reports = ctx.db
+            .query("story_feedback_reports")
+            .withIndex("by_story_and_status", (q) =>
+              q.eq("storyId", legacyStoryId).eq("status", status),
+            );
+
+          for await (const report of reports) {
+            if (
+              report.courseShort !== courseShort ||
+              report.storyTitle !== story.name
+            ) {
+              await ctx.db.patch(report._id, {
+                courseShort,
+                storyTitle: story.name,
+              });
+            }
+
+            if (status === "open") {
+              openCount += 1;
+              reportsCounted += 1;
+            } else if (status === "reviewed") {
+              reviewedCount += 1;
+              reportsCounted += 1;
+            }
+          }
+        }
+      }
+
+      const current = await ctx.db
+        .query("course_feedback_stats")
+        .withIndex("by_course", (q) => q.eq("courseId", course._id))
+        .unique();
+      const now = Date.now();
       if (!current) {
         await ctx.db.insert("course_feedback_stats", {
           courseId: course._id,
-          courseShort: next.courseShort,
-          openCount: next.openCount,
-          reviewedCount: next.reviewedCount,
+          courseShort,
+          openCount,
+          reviewedCount,
           updatedAt: now,
         });
         coursesUpdated += 1;
@@ -473,14 +455,19 @@ export const recomputeCourseFeedbackStats = mutation({
       }
 
       await ctx.db.patch(current._id, {
-        courseShort: next.courseShort,
-        openCount: next.openCount,
-        reviewedCount: next.reviewedCount,
+        courseShort,
+        openCount,
+        reviewedCount,
         updatedAt: now,
       });
       coursesUpdated += 1;
     }
 
-    return { coursesUpdated, reportsCounted: reports.length };
+    return {
+      coursesUpdated,
+      reportsCounted,
+      nextCursor: coursePage.isDone ? null : coursePage.continueCursor,
+      isDone: coursePage.isDone,
+    };
   },
 });

--- a/src/app/editor/(course)/course/[course_id]/feedback/page.tsx
+++ b/src/app/editor/(course)/course/[course_id]/feedback/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { api } from "@convex/_generated/api";
+import { fetchAuthQuery } from "@/lib/auth-server";
+import StoryFeedbackPageClient from "../../../feedback/page_client";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ course_id: string }>;
+}): Promise<Metadata> {
+  const courseId = (await params).course_id;
+  const course = await fetchAuthQuery(
+    api.editorRead.getEditorCourseByIdentifier,
+    {
+      identifier: courseId,
+    },
+  );
+
+  if (!course) notFound();
+
+  return {
+    title: `${course.learning_language_name} Feedback | Duostories Editor`,
+  };
+}
+
+export default async function CourseFeedbackPage({
+  params,
+}: {
+  params: Promise<{ course_id: string }>;
+}) {
+  return <StoryFeedbackPageClient courseId={(await params).course_id} />;
+}

--- a/src/app/editor/(course)/course_list.tsx
+++ b/src/app/editor/(course)/course_list.tsx
@@ -114,6 +114,13 @@ export default function CourseList({
                     label={`${course.audio_problem_count} audio problems`}
                     className="bg-sky-100 text-sky-950"
                   />
+                  <CountBadge
+                    count={course.unresolved_feedback_count}
+                    icon="💬"
+                    title={`This course has ${course.unresolved_feedback_count} unresolved feedback reports.`}
+                    label={`${course.unresolved_feedback_count} feedback reports`}
+                    className="bg-emerald-100 text-emerald-950"
+                  />
                   {course.official ? (
                     <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center">
                       <img

--- a/src/app/editor/(course)/feedback/feedback_review_view.tsx
+++ b/src/app/editor/(course)/feedback/feedback_review_view.tsx
@@ -2,6 +2,7 @@
 
 export {
   default,
+  type FeedbackCourseFilter,
   type FeedbackReport,
   type FeedbackStatus,
 } from "@/app/editor/feedback/feedback_review_view";

--- a/src/app/editor/(course)/feedback/page_client.tsx
+++ b/src/app/editor/(course)/feedback/page_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, usePaginatedQuery } from "convex/react";
+import { useMutation, usePaginatedQuery, useQuery } from "convex/react";
 import Link from "next/link";
 import React from "react";
 import { api } from "@convex/_generated/api";
@@ -10,20 +10,39 @@ import {
   EditorHeaderActions,
   EditorHeaderBreadcrumbs,
 } from "@/app/editor/_components/header_context";
+import type { CourseProps } from "../types";
 import FeedbackReviewView, {
+  type FeedbackCourseFilter,
   type FeedbackReport,
   type FeedbackStatus,
 } from "./feedback_review_view";
 
-export default function StoryFeedbackPageClient() {
+export default function StoryFeedbackPageClient({
+  courseId,
+}: {
+  courseId?: string;
+}) {
   const [status, setStatus] = React.useState<FeedbackStatus>("open");
+  const sidebarData = useQuery(api.editorRead.getEditorSidebarData, {});
+  const course = useQuery(
+    api.editorRead.getEditorCourseByIdentifier,
+    courseId ? { identifier: courseId } : "skip",
+  ) as CourseProps | null | undefined;
+  const selectedCourseShort =
+    courseId === undefined ? undefined : (course?.short ?? courseId);
+  const shouldSkipReports = courseId !== undefined && course === undefined;
   const {
     results,
     status: paginationStatus,
     loadMore,
   } = usePaginatedQuery(
     api.storyFeedback.listStoryFeedbackReports,
-    { status },
+    shouldSkipReports
+      ? "skip"
+      : {
+          status,
+          ...(selectedCourseShort ? { courseShort: selectedCourseShort } : {}),
+        },
     { initialNumItems: 50 },
   );
   const updateStatus = useMutation(api.storyFeedback.updateStoryFeedbackStatus);
@@ -42,16 +61,24 @@ export default function StoryFeedbackPageClient() {
     }
   }
 
+  const breadcrumbPath = [
+    { type: "Editor", href: "/editor" },
+    { type: "sep" },
+    selectedCourseShort
+      ? {
+          type: "Feedback",
+          href: "/editor/feedback",
+        }
+      : { type: "Feedback" },
+    ...(selectedCourseShort
+      ? [{ type: "sep" }, { type: selectedCourseShort }]
+      : []),
+  ];
+
   return (
     <>
       <EditorHeaderBreadcrumbs>
-        <Breadcrumbs
-          path={[
-            { type: "Editor", href: "/editor" },
-            { type: "sep" },
-            { type: "Feedback" },
-          ]}
-        />
+        <Breadcrumbs path={breadcrumbPath} />
       </EditorHeaderBreadcrumbs>
       <EditorHeaderActions>
         <Link
@@ -65,11 +92,15 @@ export default function StoryFeedbackPageClient() {
       <FeedbackReviewView
         status={status}
         reports={
-          paginationStatus === "LoadingFirstPage"
+          paginationStatus === "LoadingFirstPage" || shouldSkipReports
             ? undefined
             : (results as FeedbackReport[])
         }
         paginationStatus={paginationStatus}
+        courses={getCourseFilters(
+          (sidebarData?.courses ?? []) as CourseProps[],
+        )}
+        selectedCourseShort={selectedCourseShort}
         updatingId={updatingId}
         onStatusChange={setStatus}
         onLoadMore={() => loadMore(50)}
@@ -77,4 +108,14 @@ export default function StoryFeedbackPageClient() {
       />
     </>
   );
+}
+
+function getCourseFilters(courses: CourseProps[]): FeedbackCourseFilter[] {
+  return courses
+    .filter((course) => course.short)
+    .map((course) => ({
+      short: course.short ?? "",
+      name: `${course.learning_language_name} [${course.from_language_short}]`,
+      unresolvedFeedbackCount: course.unresolved_feedback_count,
+    }));
 }

--- a/src/app/editor/(course)/feedback/page_client.tsx
+++ b/src/app/editor/(course)/feedback/page_client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMutation, usePaginatedQuery, useQuery } from "convex/react";
-import Link from "next/link";
 import React from "react";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
@@ -10,6 +9,7 @@ import {
   EditorHeaderActions,
   EditorHeaderBreadcrumbs,
 } from "@/app/editor/_components/header_context";
+import EditorButton from "../../editor_button";
 import type { CourseProps } from "../types";
 import FeedbackReviewView, {
   type FeedbackCourseFilter,
@@ -48,6 +48,10 @@ export default function StoryFeedbackPageClient({
   const updateStatus = useMutation(api.storyFeedback.updateStoryFeedbackStatus);
   const [updatingId, setUpdatingId] =
     React.useState<Id<"story_feedback_reports"> | null>(null);
+  const courseHref =
+    courseId !== undefined && course
+      ? `/editor/course/${course.short ?? course.id}`
+      : undefined;
 
   async function setReportStatus(
     reportId: Id<"story_feedback_reports">,
@@ -61,19 +65,31 @@ export default function StoryFeedbackPageClient({
     }
   }
 
-  const breadcrumbPath = [
-    { type: "Editor", href: "/editor" },
-    { type: "sep" },
-    selectedCourseShort
-      ? {
-          type: "Feedback",
-          href: "/editor/feedback",
-        }
-      : { type: "Feedback" },
-    ...(selectedCourseShort
-      ? [{ type: "sep" }, { type: selectedCourseShort }]
-      : []),
-  ];
+  const breadcrumbPath =
+    course && courseHref
+      ? [
+          { type: "Editor", href: "/editor" },
+          { type: "sep" },
+          {
+            type: "course",
+            href: courseHref,
+            lang1: {
+              languageId: course.learningLanguageId,
+              name: course.learning_language_name,
+            },
+            lang2: {
+              languageId: course.fromLanguageId,
+              name: course.from_language_name,
+            },
+          },
+          { type: "sep" },
+          { type: "Feedback" },
+        ]
+      : [
+          { type: "Editor", href: "/editor" },
+          { type: "sep" },
+          { type: "Feedback" },
+        ];
 
   return (
     <>
@@ -81,12 +97,13 @@ export default function StoryFeedbackPageClient({
         <Breadcrumbs path={breadcrumbPath} />
       </EditorHeaderBreadcrumbs>
       <EditorHeaderActions>
-        <Link
-          href="/editor"
-          className="inline-flex min-h-10 items-center rounded-[12px] border-2 border-[var(--overview-hr)] bg-[var(--body-background)] px-4 text-[0.92rem] font-bold text-[var(--text-color)] hover:bg-[var(--body-background-faint)]"
-        >
-          Editor
-        </Link>
+        <EditorButton
+          id="button_back"
+          href={courseHref ?? "/editor"}
+          data-cy="button_back"
+          img="back.svg"
+          text={courseHref ? "Back" : "Editor"}
+        />
       </EditorHeaderActions>
 
       <FeedbackReviewView

--- a/src/app/editor/(course)/layout_flag.tsx
+++ b/src/app/editor/(course)/layout_flag.tsx
@@ -119,6 +119,15 @@ export default function LayoutFlag() {
                 text={"Back"}
               />
             )}
+            {!import_id ? (
+              <EditorButton
+                id="button_feedback"
+                href={`/editor/course/${course.short}/feedback`}
+                data-cy="button_feedback"
+                img="stories.png"
+                text="Feedback"
+              />
+            ) : null}
             <div className="ml-[50px] max-[1120px]:ml-0" />
           </>
         ) : (

--- a/src/app/editor/(course)/layout_flag.tsx
+++ b/src/app/editor/(course)/layout_flag.tsx
@@ -39,6 +39,7 @@ export default function LayoutFlag() {
 
   if (
     nestedRoute === "story" ||
+    nestedRoute === "feedback" ||
     nestedRoute === "voices" ||
     nestedRoute === "localization"
   ) {

--- a/src/app/editor/(course)/types.ts
+++ b/src/app/editor/(course)/types.ts
@@ -17,6 +17,7 @@ export type CourseProps = {
   contributors_past: string[];
   todo_count: number;
   audio_problem_count: number;
+  unresolved_feedback_count: number;
 };
 
 export type ContributorSummaryProps = {

--- a/src/app/editor/feedback/feedback_review_view.tsx
+++ b/src/app/editor/feedback/feedback_review_view.tsx
@@ -68,7 +68,7 @@ const feedbackPreviewSettings: StorySettings = {
   setHideNonHighlighted: () => {},
   show_hints: true,
   setShowHints: () => {},
-  show_audio: false,
+  show_audio: true,
   setShowAudio: () => {},
   id: 0,
   show_title_page: false,
@@ -277,14 +277,13 @@ function FeedbackReportRow({
         </div>
 
         {isStoryElementLine(report.lineElement) ? (
-          <div className="mb-3 min-w-0 overflow-hidden rounded-[8px] border-l-4 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-4 py-1 [&_.audio-button]:hidden">
+          <div className="mb-3 min-w-0 overflow-hidden rounded-[8px] border-l-4 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-4 py-1">
             <StoryTextLine
               active={false}
               element={report.lineElement}
               settings={feedbackPreviewSettings}
               editorShowTranslationsOverride={true}
               editorShowAudioDetailsOverride={false}
-              hideAudioButton
               compact
             />
           </div>
@@ -353,16 +352,28 @@ function isStoryElementLine(value: unknown): value is StoryElementLine {
   }
   if (!isRecord(value.line.content)) return false;
   if (typeof value.line.content.text !== "string") return false;
-  if (!Array.isArray(value.line.content.hintMap)) return false;
+  if (!isValidHintMap(value.line.content.hintMap)) return false;
   if (
     value.line.content.hints !== undefined &&
-    !Array.isArray(value.line.content.hints)
+    !isStringArray(value.line.content.hints)
   ) {
     return false;
   }
   if (
     value.line.content.hints_pronunciation !== undefined &&
-    !Array.isArray(value.line.content.hints_pronunciation)
+    !isStringArray(value.line.content.hints_pronunciation)
+  ) {
+    return false;
+  }
+  if (
+    value.hideRangesForChallenge !== undefined &&
+    !isValidHideRanges(value.hideRangesForChallenge)
+  ) {
+    return false;
+  }
+  if (
+    value.line.content.audio !== undefined &&
+    !isValidLineAudio(value.line.content.audio)
   ) {
     return false;
   }
@@ -380,6 +391,57 @@ function isStoryElementLine(value: unknown): value is StoryElementLine {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function isValidHintMap(value: unknown) {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        isRecord(item) &&
+        typeof item.hintIndex === "number" &&
+        typeof item.rangeFrom === "number" &&
+        typeof item.rangeTo === "number",
+    )
+  );
+}
+
+function isValidHideRanges(value: unknown) {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) =>
+        isRecord(item) &&
+        typeof item.start === "number" &&
+        typeof item.end === "number",
+    )
+  );
+}
+
+function isValidLineAudio(value: unknown) {
+  if (!isRecord(value)) return false;
+  if (value.url !== undefined && typeof value.url !== "string") return false;
+  if (
+    value.keypoints !== undefined &&
+    !(
+      Array.isArray(value.keypoints) &&
+      value.keypoints.every(
+        (item) =>
+          isRecord(item) &&
+          typeof item.rangeEnd === "number" &&
+          typeof item.audioStart === "number",
+      )
+    )
+  ) {
+    return false;
+  }
+  return value.ssml === undefined || isRecord(value.ssml);
 }
 
 function StatusButton({

--- a/src/app/editor/feedback/feedback_review_view.tsx
+++ b/src/app/editor/feedback/feedback_review_view.tsx
@@ -10,6 +10,9 @@ import {
 import Link from "next/link";
 import React from "react";
 import type { Id } from "@convex/_generated/dataModel";
+import StoryTextLine from "@/components/StoryTextLine";
+import type { StorySettings } from "@/components/StoryProgress";
+import type { StoryElementLine } from "@/components/editor/story/syntax_parser_types";
 import Button from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
@@ -23,6 +26,7 @@ export type FeedbackReport = {
   courseShort: string;
   line?: number;
   lineText?: string;
+  lineElement?: unknown;
   category: "Text" | "Translation hints" | "Audio" | "Other";
   comment: string;
   userName: string | null;
@@ -47,10 +51,35 @@ const statusLabels: Record<FeedbackStatus, string> = {
   resolved: "Resolved",
 };
 
+export type FeedbackCourseFilter = {
+  short: string;
+  name: string;
+  unresolvedFeedbackCount: number;
+};
+
+const feedbackPreviewSettings: StorySettings = {
+  hide_questions: false,
+  show_all: true,
+  show_names: false,
+  rtl: false,
+  highlight_name: [],
+  hideNonHighlighted: false,
+  setHighlightName: () => {},
+  setHideNonHighlighted: () => {},
+  show_hints: true,
+  setShowHints: () => {},
+  show_audio: false,
+  setShowAudio: () => {},
+  id: 0,
+  show_title_page: false,
+};
+
 export default function FeedbackReviewView({
   status,
   reports,
   paginationStatus,
+  courses,
+  selectedCourseShort,
   updatingId,
   onStatusChange,
   onLoadMore,
@@ -63,6 +92,8 @@ export default function FeedbackReviewView({
     | "CanLoadMore"
     | "LoadingMore"
     | "Exhausted";
+  courses?: FeedbackCourseFilter[];
+  selectedCourseShort?: string;
   updatingId: Id<"story_feedback_reports"> | null;
   onStatusChange: (status: FeedbackStatus) => void;
   onLoadMore?: () => void;
@@ -80,7 +111,9 @@ export default function FeedbackReviewView({
             Story reports
           </div>
           <h1 className="m-0 text-[1.8rem] leading-tight font-bold">
-            Feedback
+            {selectedCourseShort
+              ? `${selectedCourseShort} feedback`
+              : "Feedback"}
           </h1>
         </div>
 
@@ -109,6 +142,25 @@ export default function FeedbackReviewView({
           })}
         </div>
       </div>
+
+      {courses && courses.length > 0 ? (
+        <nav className="mb-5 flex gap-2 overflow-x-auto pb-1">
+          <CourseFilterLink
+            href="/editor/feedback"
+            selected={selectedCourseShort === undefined}
+            label="All"
+          />
+          {courses.map((course) => (
+            <CourseFilterLink
+              key={course.short}
+              href={`/editor/course/${course.short}/feedback`}
+              selected={selectedCourseShort === course.short}
+              label={course.name}
+              count={course.unresolvedFeedbackCount}
+            />
+          ))}
+        </nav>
+      ) : null}
 
       {reports === undefined ? (
         <Spinner />
@@ -146,6 +198,38 @@ export default function FeedbackReviewView({
         </>
       )}
     </main>
+  );
+}
+
+function CourseFilterLink({
+  href,
+  selected,
+  label,
+  count,
+}: {
+  href: string;
+  selected: boolean;
+  label: string;
+  count?: number;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={selected ? "page" : undefined}
+      className={cn(
+        "inline-flex h-10 shrink-0 items-center gap-2 rounded-full border px-4 text-[0.9rem] font-bold no-underline transition-colors",
+        selected
+          ? "border-[var(--button-background)] bg-[var(--button-background)] text-[var(--button-color)]"
+          : "border-[var(--header-border)] bg-[var(--body-background-faint)] text-[var(--text-color)] hover:bg-[var(--body-background)]",
+      )}
+    >
+      <span>{label}</span>
+      {count && count > 0 ? (
+        <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--body-background)_85%,transparent)] px-1.5 text-[0.72rem]">
+          {count}
+        </span>
+      ) : null}
+    </Link>
   );
 }
 
@@ -188,11 +272,23 @@ function FeedbackReportRow({
         <div className="mb-3 flex flex-wrap gap-x-3 gap-y-1 text-[0.9rem] text-[var(--text-color-dim)]">
           <span>{report.courseShort}</span>
           <span>Story {report.storyId}</span>
-          {report.line ? <span>Line {report.line}</span> : null}
+          {report.line !== undefined ? <span>Line {report.line}</span> : null}
           <span>{report.userName || report.userEmail || "Anonymous"}</span>
         </div>
 
-        {report.lineText ? (
+        {isStoryElementLine(report.lineElement) ? (
+          <div className="mb-3 min-w-0 overflow-hidden rounded-[8px] border-l-4 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-4 py-1 [&_.audio-button]:hidden">
+            <StoryTextLine
+              active={false}
+              element={report.lineElement}
+              settings={feedbackPreviewSettings}
+              editorShowTranslationsOverride={true}
+              editorShowAudioDetailsOverride={false}
+              hideAudioButton
+              compact
+            />
+          </div>
+        ) : report.lineText ? (
           <blockquote className="m-0 mb-3 rounded-[8px] border-l-4 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-4 py-3 text-[0.95rem] leading-6">
             {report.lineText}
           </blockquote>
@@ -241,6 +337,49 @@ function FeedbackReportRow({
       </div>
     </article>
   );
+}
+
+function isStoryElementLine(value: unknown): value is StoryElementLine {
+  if (!isRecord(value) || value.type !== "LINE") return false;
+  if (!isRecord(value.line) || !isRecord(value.editor)) return false;
+  if (!isRecord(value.trackingProperties)) return false;
+  if (typeof value.lang !== "string") return false;
+  if (
+    value.line.type !== "CHARACTER" &&
+    value.line.type !== "PROSE" &&
+    value.line.type !== "TITLE"
+  ) {
+    return false;
+  }
+  if (!isRecord(value.line.content)) return false;
+  if (typeof value.line.content.text !== "string") return false;
+  if (!Array.isArray(value.line.content.hintMap)) return false;
+  if (
+    value.line.content.hints !== undefined &&
+    !Array.isArray(value.line.content.hints)
+  ) {
+    return false;
+  }
+  if (
+    value.line.content.hints_pronunciation !== undefined &&
+    !Array.isArray(value.line.content.hints_pronunciation)
+  ) {
+    return false;
+  }
+  if (value.line.type !== "CHARACTER") return true;
+
+  return (
+    (typeof value.line.characterId === "number" ||
+      typeof value.line.characterId === "string") &&
+    (value.line.avatarUrl === undefined ||
+      typeof value.line.avatarUrl === "string") &&
+    (value.line.characterName === undefined ||
+      typeof value.line.characterName === "string")
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function StatusButton({

--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -58,6 +58,9 @@ export default function StoryFeedback({
     "idle" | "submitting" | "submitted"
   >("idle");
   const [submitError, setSubmitError] = React.useState<string | null>(null);
+  const [operationKey, setOperationKey] = React.useState(() =>
+    crypto.randomUUID(),
+  );
   const isSubmitting = submitState === "submitting";
   const isSubmitted = submitState === "submitted";
 
@@ -68,6 +71,7 @@ export default function StoryFeedback({
       setSubmitError(null);
     } else {
       setComment("");
+      setOperationKey(crypto.randomUUID());
     }
   }
 
@@ -128,6 +132,7 @@ export default function StoryFeedback({
             try {
               await submitStoryFeedback({
                 storyId,
+                operationKey,
                 line,
                 lineText,
                 category,

--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -39,6 +39,43 @@ const feedbackCategories = [
 
 type FeedbackCategory = (typeof feedbackCategories)[number]["value"];
 
+function getFeedbackLinePreview(
+  lineElement?: StoryElementLine,
+): StoryElementLine | undefined {
+  if (!lineElement) return undefined;
+
+  const content = { ...lineElement.line.content };
+  delete content.audio;
+  const base = {
+    type: "LINE" as const,
+    hideRangesForChallenge: lineElement.hideRangesForChallenge,
+    trackingProperties: lineElement.trackingProperties,
+    lang: lineElement.lang,
+    editor: lineElement.editor,
+  };
+
+  if (lineElement.line.type === "CHARACTER") {
+    return {
+      ...base,
+      line: {
+        type: "CHARACTER",
+        avatarUrl: lineElement.line.avatarUrl,
+        characterId: lineElement.line.characterId,
+        characterName: lineElement.line.characterName,
+        content,
+      },
+    };
+  }
+
+  return {
+    ...base,
+    line: {
+      type: lineElement.line.type,
+      content,
+    },
+  };
+}
+
 export default function StoryFeedback({
   storyId,
   storyTitle,
@@ -136,6 +173,7 @@ export default function StoryFeedback({
                 courseShort,
                 line,
                 lineText,
+                lineElement: getFeedbackLinePreview(lineElement),
                 category,
                 comment,
               });

--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -20,8 +20,6 @@ import { cn } from "@/lib/utils";
 
 type StoryFeedbackProps = {
   storyId: number;
-  storyTitle: string;
-  courseShort: string;
   line?: number;
   lineText?: string;
   lineElement?: StoryElementLine;
@@ -39,47 +37,8 @@ const feedbackCategories = [
 
 type FeedbackCategory = (typeof feedbackCategories)[number]["value"];
 
-function getFeedbackLinePreview(
-  lineElement?: StoryElementLine,
-): StoryElementLine | undefined {
-  if (!lineElement) return undefined;
-
-  const content = { ...lineElement.line.content };
-  delete content.audio;
-  const base = {
-    type: "LINE" as const,
-    hideRangesForChallenge: lineElement.hideRangesForChallenge,
-    trackingProperties: lineElement.trackingProperties,
-    lang: lineElement.lang,
-    editor: lineElement.editor,
-  };
-
-  if (lineElement.line.type === "CHARACTER") {
-    return {
-      ...base,
-      line: {
-        type: "CHARACTER",
-        avatarUrl: lineElement.line.avatarUrl,
-        characterId: lineElement.line.characterId,
-        characterName: lineElement.line.characterName,
-        content,
-      },
-    };
-  }
-
-  return {
-    ...base,
-    line: {
-      type: lineElement.line.type,
-      content,
-    },
-  };
-}
-
 export default function StoryFeedback({
   storyId,
-  storyTitle,
-  courseShort,
   line,
   lineText,
   lineElement,
@@ -152,7 +111,7 @@ export default function StoryFeedback({
             </div>
           ) : (
             <p className="mt-3 mb-0 whitespace-pre-wrap text-[1rem] leading-6">
-              {lineText || storyTitle}
+              {lineText || `Story ${storyId}`}
             </p>
           )}
         </div>
@@ -169,11 +128,8 @@ export default function StoryFeedback({
             try {
               await submitStoryFeedback({
                 storyId,
-                storyTitle,
-                courseShort,
                 line,
                 lineText,
-                lineElement: getFeedbackLinePreview(lineElement),
                 category,
                 comment,
               });

--- a/src/components/StoryProgress/StoryProgress.tsx
+++ b/src/components/StoryProgress/StoryProgress.tsx
@@ -738,8 +738,6 @@ function StoryProgress({
               feedback={
                 <StoryFeedback
                   storyId={story.id}
-                  storyTitle={story.from_language_name}
-                  courseShort={story.course_short}
                   line={currentEditorLine}
                   lineText={currentFeedbackLineText}
                   lineElement={currentFeedbackLineElement}


### PR DESCRIPTION
## Summary

- Adds a course-scoped feedback review route at `/editor/course/[course_id]/feedback` while keeping the global `/editor/feedback` view.
- Shows unresolved feedback counts in the editor course list.
- Stores a compact rendered line preview for new feedback reports and renders it in review with the shared `StoryTextLine` component, including inline translation hints.
- Keeps existing text-only feedback reports working as a fallback and preserves editor deep links with `?line=`.

## Validation

- `pnpm exec vitest run --config vitest.config.ts convex/storyFeedback.test.ts`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm test`
- `pnpm convex dev --once`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added course-specific feedback pages with adaptive breadcrumbs/back navigation and course-based filtering.
  - Course list and feedback filters now show unresolved feedback counts.
  - Feedback reviews can display story line previews (including line numbers/formatting) when available.
- **Bug Fixes**
  - Reject oversized line previews and improve fallback behavior when line number context is missing.
  - Ensure course feedback counts stay accurate when feedback status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->