### PR TITLE
Improve story page SEO title

### DIFF
--- a/src/app/(stories)/story/[story_id]/page.tsx
+++ b/src/app/(stories)/story/[story_id]/page.tsx
@@ -10,7 +10,7 @@ import {
 import StoryWrapper from "./story_wrapper";
 import { get_story } from "./getStory";
 import StoryTranscript from "./StoryTranscript";
-import { getStoryDescription } from "./story_seo";
+import { getStoryDescription, getStoryTitle } from "./story_seo";
 import LocalisationProvider from "@/components/LocalisationProvider";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "@convex/_generated/api";
@@ -41,9 +41,12 @@ export async function generateMetadata({
 
   if (!story || !storyMeta) notFound();
 
+  const title = getStoryTitle(storyMeta);
+  const description = getStoryDescription(story);
+
   return {
-    title: `${storyMeta.from_language_name} - Duostories ${storyMeta.learning_language_long} from ${storyMeta.from_language_long}`,
-    description: getStoryDescription(story),
+    title,
+    description,
     alternates: {
       canonical: `https://duostories.org/story/${story_id}`,
     },
@@ -54,10 +57,12 @@ export async function generateMetadata({
       ],
       url: `https://duostories.org/story/${story_id}`,
       type: "website",
-      description: getStoryDescription(story),
+      title,
+      description,
     },
     twitter: {
-      description: getStoryDescription(story),
+      title,
+      description,
     },
   };
 }

--- a/src/app/(stories)/story/[story_id]/story_seo.ts
+++ b/src/app/(stories)/story/[story_id]/story_seo.ts
@@ -10,6 +10,11 @@ export type StoryTranscriptLine = {
   text: string;
 };
 
+type StoryTitleData = Pick<
+  StoryData,
+  "from_language_name" | "learning_language_long"
+>;
+
 function normalizeWhitespace(text: string) {
   return text.replace(/\s+/g, " ").trim();
 }
@@ -78,4 +83,8 @@ export function getStoryDescription(story: StoryData) {
       ? `${normalizedExcerpt.slice(0, 217).trimEnd()}...`
       : normalizedExcerpt;
   return `${baseDescription} ${trimmedExcerpt}`;
+}
+
+export function getStoryTitle(story: StoryTitleData) {
+  return `${story.from_language_name} - ${story.learning_language_long} Story with Audio | Duostories`;
 }


### PR DESCRIPTION
## Summary
- Change story page titles to search-native phrasing like `A Date - Dutch Story with Audio | Duostories`
- Reuse the same title for OpenGraph and Twitter metadata

## Verification
- `biome format` / `biome lint` on touched files: passed
- Local `/story/56` metadata rendered the new title
- `tsc --noEmit --pretty false`: blocked by existing `.next` auth route stub and Convex test-tooling type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved story page metadata for search engines and social sharing.
  * Story titles now consistently include language details and the “Story with Audio | Duostories” branding.
  * Updated descriptions are applied consistently across browser, Open Graph, and Twitter previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->