### PR TITLE
Cache public story pages

### DIFF
--- a/src/app/(stories)/story/[story_id]/page.tsx
+++ b/src/app/(stories)/story/[story_id]/page.tsx
@@ -1,12 +1,6 @@
 import React, { Suspense } from "react";
-import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
-import { fetchAuthQuery } from "@/lib/auth-server";
 import getUserId from "@/lib/getUserId";
-import {
-  HIDE_STORY_QUESTIONS_COOKIE,
-  isStoryQuestionsDisabled,
-} from "@/lib/story-preferences";
 import StoryWrapper from "./story_wrapper";
 import { get_story } from "./getStory";
 import StoryTranscript from "./StoryTranscript";
@@ -16,6 +10,9 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "@convex/_generated/api";
 import { fetchQuery } from "convex/nextjs";
 import { fetchAuthMutation } from "@/lib/auth-server";
+
+export const revalidate = 86400;
+export const dynamic = "force-static";
 
 const convexUrl =
   process.env.NEXT_PUBLIC_CONVEX_URL ?? process.env.CONVEX_URL ?? "";
@@ -67,32 +64,16 @@ export default async function Page({
 }: {
   params: Promise<{ story_id: string }>;
 }) {
-  const cookieStore = await cookies();
   const story_id = parseInt((await params).story_id);
 
   const story = await get_story(story_id);
   if (!story) notFound();
   const course_id = story.course_id;
 
-  const user_id = await getUserId();
-  const cookieHideStoryQuestions = isStoryQuestionsDisabled(
-    cookieStore.get(HIDE_STORY_QUESTIONS_COOKIE)?.value,
-  );
-  const savedStoryPreferences = user_id
-    ? ((await fetchAuthQuery(
-        api.userPreferences.getCurrentStoryPreferences,
-        {},
-      )) as {
-        hasSavedPreference: boolean;
-        hideStoryQuestions: boolean;
-      })
-    : null;
-  const hideStoryQuestions =
-    savedStoryPreferences?.hasSavedPreference === true
-      ? savedStoryPreferences.hideStoryQuestions
-      : cookieHideStoryQuestions;
   async function setStoryDoneAction() {
     "use server";
+    const user_id = await getUserId();
+
     if (!user_id) {
       await convex.mutation(api.storyDone.recordStoryDone, {
         legacyStoryId: story_id,
@@ -131,7 +112,6 @@ export default async function Page({
           <Suspense fallback={null}>
             <StoryWrapper
               story={story}
-              hideStoryQuestions={hideStoryQuestions}
               storyFinishedIndexUpdate={setStoryDoneAction}
               //localization={localization}
             />

--- a/src/app/(stories)/story/[story_id]/story_wrapper.tsx
+++ b/src/app/(stories)/story/[story_id]/story_wrapper.tsx
@@ -10,6 +10,10 @@ import { api } from "@convex/_generated/api";
 import posthog from "posthog-js";
 import { authClient } from "@/lib/auth-client";
 import {
+  HIDE_STORY_QUESTIONS_COOKIE,
+  isStoryQuestionsDisabled,
+} from "@/lib/story-preferences";
+import {
   getCurrentPostHogUser,
   identifyPostHogUser,
   type PostHogUser,
@@ -17,11 +21,9 @@ import {
 
 export default function StoryWrapper({
   story,
-  hideStoryQuestions,
   storyFinishedIndexUpdate,
 }: {
   story: StoryData;
-  hideStoryQuestions: boolean;
   storyFinishedIndexUpdate: () => Promise<
     | {
         message: string;
@@ -40,6 +42,8 @@ export default function StoryWrapper({
   const searchParams = useSearchParams();
   const [highlight_name, setHighlightName] = React.useState<string[]>([]);
   const [hideNonHighlighted, setHideNonHighlighted] = React.useState(false);
+  const [cookieHideStoryQuestions, setCookieHideStoryQuestions] =
+    React.useState(false);
   const trackedStoryStart = React.useRef(false);
   const completionInFlight = React.useRef(false);
   const { data: session } = authClient.useSession();
@@ -64,6 +68,10 @@ export default function StoryWrapper({
         }
       : "skip",
   );
+  const storyPreferences = useQuery(
+    api.userPreferences.getCurrentStoryPreferences,
+    {},
+  );
   const showNextStoryAction = Boolean(nextStep?.nextStoryId);
   const nextStoryPreview = useQuery(
     api.storyRead.getStoryPreviewByLegacyId,
@@ -71,6 +79,23 @@ export default function StoryWrapper({
       ? { storyId: nextStep.nextStoryId }
       : "skip",
   );
+  const hideStoryQuestions =
+    storyPreferences?.hasSavedPreference === true
+      ? storyPreferences.hideStoryQuestions
+      : cookieHideStoryQuestions;
+
+  React.useEffect(() => {
+    setCookieHideStoryQuestions(
+      isStoryQuestionsDisabled(
+        document.cookie
+          .split("; ")
+          .find((cookie) =>
+            cookie.startsWith(`${HIDE_STORY_QUESTIONS_COOKIE}=`),
+          )
+          ?.split("=")[1],
+      ),
+    );
+  }, []);
 
   const captureStoryEvent = React.useCallback(
     async (eventName: "story_started" | "story_completed") => {


### PR DESCRIPTION
## Summary
- Make `/story/[story_id]` statically cacheable with 24h revalidation
- Remove cookie/auth reads from the story page server render
- Resolve hide-question preferences in the client wrapper using Convex auth state plus the existing cookie fallback
- Resolve the current user inside the completion server action instead of capturing user state during page render

## Verification
- `biome format` / `biome lint` on touched files: passed
- `pnpm build`: passed
- Production `next start` header check for `/story/56`:
  - first request: `x-nextjs-cache: MISS`, `Cache-Control: s-maxage=86400, stale-while-revalidate=31449600`
  - second request: `x-nextjs-cache: HIT`, same shared cache header
- `tsc --noEmit --pretty false`: blocked by existing missing test tooling/types for `vitest`, `convex-test`, and `vite/client`