### PR TITLE
Add no-audio course tag handling

### DIFF
--- a/app-mobile/app/(tabs)/index.tsx
+++ b/app-mobile/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import { useQuery } from "convex/react";
 import { api } from "../../src/api";
 import { captureMobileEventLater } from "../../src/analytics";
 import { useAuthSession } from "../../src/auth-client";
+import { hasNoAudioCourseTag } from "../../src/course-tags";
 import { useAppState } from "../../src/app-state";
 import { useNetworkStatus } from "../../src/network";
 import { maybeRequestAppReview } from "../../src/reviewPrompt";
@@ -69,6 +70,10 @@ export default function LearnTab() {
       course && course !== null ? (course.stories as StoryListItem[]) : [],
     [course],
   );
+  const noAudioCourse = hasNoAudioCourseTag(
+    course && course !== null ? course.tags : undefined,
+  );
+  const effectiveListening = noAudioCourse ? false : listening;
   const isStoryDone = React.useCallback(
     (storyId: number) =>
       session?.session
@@ -105,16 +110,18 @@ export default function LearnTab() {
               key={story.id}
               story={story}
               done={isStoryDone(story.id)}
-              listeningMode={listening}
+              listeningMode={effectiveListening}
               disabled={isOffline}
               onPress={() => {
                 captureMobileEventLater("story_opened", {
                   story_id: story.id,
                   course_short: courseShort,
-                  listening_mode: listening,
+                  listening_mode: effectiveListening,
                 });
                 router.push(
-                  `/story/${story.id}?listening=${listening ? "1" : "0"}`,
+                  `/story/${story.id}?listening=${
+                    effectiveListening ? "1" : "0"
+                  }`,
                 );
               }}
             />
@@ -122,7 +129,7 @@ export default function LearnTab() {
         </View>
       </View>
     ),
-    [courseShort, isOffline, isStoryDone, listening, router, styles],
+    [courseShort, effectiveListening, isOffline, isStoryDone, router, styles],
   );
 
   // Reload local progress whenever the tab regains focus (e.g. after a story).
@@ -138,14 +145,20 @@ export default function LearnTab() {
         ]);
         if (cancelled) return;
         setDoneMap(done);
-        setListening(listeningMode);
+        setListening(noAudioCourse ? false : listeningMode);
         setLocalProgressLoaded(true);
       })();
       return () => {
         cancelled = true;
       };
-    }, [courseShort]),
+    }, [courseShort, noAudioCourse]),
   );
+
+  React.useEffect(() => {
+    if (!courseShort || !noAudioCourse || !listening) return;
+    setListening(false);
+    void setListeningMode(courseShort, false);
+  }, [courseShort, listening, noAudioCourse]);
 
   React.useEffect(() => {
     if (!courseShort || !localProgressLoaded || isServerProgressPending) return;
@@ -231,22 +244,24 @@ export default function LearnTab() {
             ]}
           />
         </View>
-        <View style={styles.listeningRow}>
-          <Text style={styles.listeningLabel}>Listening mode</Text>
-          <Switch
-            value={listening}
-            onValueChange={(value) => {
-              setListening(value);
-              captureMobileEventLater("mobile_listening_mode_toggled", {
-                course_short: courseShort,
-                enabled: value,
-              });
-              void setListeningMode(courseShort, value);
-            }}
-            trackColor={{ true: colors.blue }}
-            thumbColor={colors.surface}
-          />
-        </View>
+        {!noAudioCourse ? (
+          <View style={styles.listeningRow}>
+            <Text style={styles.listeningLabel}>Listening mode</Text>
+            <Switch
+              value={listening}
+              onValueChange={(value) => {
+                setListening(value);
+                captureMobileEventLater("mobile_listening_mode_toggled", {
+                  course_short: courseShort,
+                  enabled: value,
+                });
+                void setListeningMode(courseShort, value);
+              }}
+              trackColor={{ true: colors.blue }}
+              thumbColor={colors.surface}
+            />
+          </View>
+        ) : null}
       </View>
 
       <FlatList

--- a/app-mobile/app/story/[id].tsx
+++ b/app-mobile/app/story/[id].tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery } from "convex/react";
 import { api } from "../../src/api";
 import { captureMobileEventLater } from "../../src/analytics";
 import { useAuthSession } from "../../src/auth-client";
+import { hasNoAudioCourseTag } from "../../src/course-tags";
 import { useAppState } from "../../src/app-state";
 import { useNetworkStatus } from "../../src/network";
 import { markReviewPromptCompletionPending } from "../../src/reviewPrompt";
@@ -43,6 +44,10 @@ export default function StoryScreen() {
     api.storyRead.getStoryByLegacyId,
     Number.isFinite(storyId) ? { storyId } : "skip",
   ) as StoryData | null | undefined;
+  const effectiveListening =
+    story && story !== null && hasNoAudioCourseTag(story.course_tags)
+      ? false
+      : listening;
 
   // Course story list (anonymous-friendly) to pick the next unread story.
   const course = useQuery(
@@ -98,13 +103,13 @@ export default function StoryScreen() {
         course_id: story.course_id,
         course_short: story.course_short,
         learning_language: story.learning_language_long,
-        listening_mode: listening,
-        hide_questions: listening || hideStoryQuestions,
+        listening_mode: effectiveListening,
+        hide_questions: effectiveListening || hideStoryQuestions,
         signed_in: Boolean(session?.session),
         ...extra,
       });
     },
-    [hideStoryQuestions, listening, session?.session, story],
+    [effectiveListening, hideStoryQuestions, session?.session, story],
   );
 
   React.useEffect(() => {
@@ -150,8 +155,10 @@ export default function StoryScreen() {
   }, [router]);
 
   const retry = React.useCallback(() => {
-    router.replace(`/story/${storyId}?listening=${listening ? "1" : "0"}`);
-  }, [listening, router, storyId]);
+    router.replace(
+      `/story/${storyId}?listening=${effectiveListening ? "1" : "0"}`,
+    );
+  }, [effectiveListening, router, storyId]);
 
   const onQuit = React.useCallback(
     ({ shouldConfirmQuit }: { shouldConfirmQuit: boolean }) => {
@@ -184,7 +191,7 @@ export default function StoryScreen() {
       });
       stopAudio();
       router.replace(
-        `/story/${nextStoryId}?listening=${listening ? "1" : "0"}`,
+        `/story/${nextStoryId}?listening=${effectiveListening ? "1" : "0"}`,
       );
       return;
     }
@@ -194,7 +201,7 @@ export default function StoryScreen() {
     course?.stories.length,
     doneIds?.size,
     leave,
-    listening,
+    effectiveListening,
     nextStoryId,
     router,
   ]);
@@ -245,8 +252,8 @@ export default function StoryScreen() {
         <Reader
           key={story.id}
           story={story}
-          hideQuestions={listening || hideStoryQuestions}
-          listening={listening}
+          hideQuestions={effectiveListening || hideStoryQuestions}
+          listening={effectiveListening}
           onQuit={onQuit}
           onEnd={onEnd}
           onBackToOverview={leave}

--- a/app-mobile/src/course-tags.ts
+++ b/app-mobile/src/course-tags.ts
@@ -1,0 +1,7 @@
+export const NO_AUDIO_COURSE_TAG = "no-audio";
+
+export function hasNoAudioCourseTag(tags: readonly string[] | undefined) {
+  return (tags ?? []).some(
+    (tag) => tag.trim().toLowerCase() === NO_AUDIO_COURSE_TAG,
+  );
+}

--- a/app-mobile/src/story/types.ts
+++ b/app-mobile/src/story/types.ts
@@ -142,6 +142,7 @@ export type StoryData = {
   learning_language_long: string;
   learning_language_rtl: boolean;
   course_short: string;
+  course_tags: string[];
   elements: StoryElement[];
   illustrations?: { gilded?: string; active?: string; locked?: string };
 };

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -32,6 +32,7 @@ import type * as languageWrite from "../languageWrite.js";
 import type * as lib_authorization from "../lib/authorization.js";
 import type * as lib_courseContributors from "../lib/courseContributors.js";
 import type * as lib_courseCounts from "../lib/courseCounts.js";
+import type * as lib_courseTags from "../lib/courseTags.js";
 import type * as lib_discordAvatarSync from "../lib/discordAvatarSync.js";
 import type * as lib_phpbb from "../lib/phpbb.js";
 import type * as lib_publicStoryContent from "../lib/publicStoryContent.js";
@@ -79,6 +80,7 @@ declare const fullApi: ApiFromModules<{
   "lib/authorization": typeof lib_authorization;
   "lib/courseContributors": typeof lib_courseContributors;
   "lib/courseCounts": typeof lib_courseCounts;
+  "lib/courseTags": typeof lib_courseTags;
   "lib/discordAvatarSync": typeof lib_discordAvatarSync;
   "lib/phpbb": typeof lib_phpbb;
   "lib/publicStoryContent": typeof lib_publicStoryContent;

--- a/convex/adminWrite.ts
+++ b/convex/adminWrite.ts
@@ -1,7 +1,11 @@
+import { internal } from "./_generated/api";
 import { mutation } from "./_generated/server";
-import type { MutationCtx } from "./_generated/server";
+import { internalMutation, type MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { requireAdmin } from "./lib/authorization";
+import { hasNoAudioCourseTag } from "./lib/courseTags";
+
+const CLEAR_NO_AUDIO_STORY_AUDIO_PROBLEM_BATCH_SIZE = 100;
 
 function toLegacyLanguageResponse(row: {
   legacyId: number;
@@ -262,6 +266,23 @@ export const updateAdminCourse = mutation({
     patchData.tags = nextTags;
 
     await ctx.db.patch(course._id, patchData);
+    if (hasNoAudioCourseTag(nextTags)) {
+      if ((course.audio_problem_count ?? 0) !== 0) {
+        await ctx.db.patch(course._id, {
+          audio_problem_count: 0,
+          lastOperationKey: operationKey,
+        });
+      }
+      await ctx.scheduler.runAfter(
+        0,
+        internal.adminWrite.clearNoAudioCourseStoryAudioProblems,
+        {
+          courseId: course._id,
+          operationKey,
+          cursor: null,
+        },
+      );
+    }
 
     return {
       id: args.id,
@@ -275,6 +296,46 @@ export const updateAdminCourse = mutation({
       short,
       tags: nextTags,
     };
+  },
+});
+
+export const clearNoAudioCourseStoryAudioProblems = internalMutation({
+  args: {
+    courseId: v.id("courses"),
+    operationKey: v.string(),
+    cursor: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("stories")
+      .withIndex("by_course", (q) => q.eq("courseId", args.courseId))
+      .paginate({
+        cursor: args.cursor,
+        numItems: CLEAR_NO_AUDIO_STORY_AUDIO_PROBLEM_BATCH_SIZE,
+      });
+
+    for (const story of page.page) {
+      if ((story.audio_problem_count ?? 0) === 0) continue;
+      await ctx.db.patch(story._id, {
+        audio_problem_count: 0,
+        lastOperationKey: args.operationKey,
+      });
+    }
+
+    if (!page.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.adminWrite.clearNoAudioCourseStoryAudioProblems,
+        {
+          courseId: args.courseId,
+          operationKey: args.operationKey,
+          cursor: page.continueCursor,
+        },
+      );
+    }
+
+    return null;
   },
 });
 

--- a/convex/courseWrite.ts
+++ b/convex/courseWrite.ts
@@ -2,6 +2,7 @@ import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { requireContributorOrAdmin } from "./lib/authorization";
 import { recomputeCoursePublishedCount } from "./lib/courseCounts";
+import { hasNoAudioCourseTag } from "./lib/courseTags";
 
 export const recomputePublishedCount = mutation({
   args: {
@@ -100,13 +101,17 @@ export const setAudioProblemCounts = mutation({
         continue;
       }
 
-      if ((course.audio_problem_count ?? 0) === entry.audioProblemCount) {
+      const nextAudioProblemCount = hasNoAudioCourseTag(course.tags)
+        ? 0
+        : entry.audioProblemCount;
+
+      if ((course.audio_problem_count ?? 0) === nextAudioProblemCount) {
         unchanged += 1;
         continue;
       }
 
       await ctx.db.patch(course._id, {
-        audio_problem_count: entry.audioProblemCount,
+        audio_problem_count: nextAudioProblemCount,
         lastOperationKey: operationKey,
       });
       updated += 1;
@@ -130,14 +135,19 @@ export const setAudioProblemCounts = mutation({
         missingStories.push(entry.legacyStoryId);
         continue;
       }
+      const storyCourse = await ctx.db.get(story.courseId);
+      const nextAudioProblemCount =
+        storyCourse && hasNoAudioCourseTag(storyCourse.tags)
+          ? 0
+          : entry.audioProblemCount;
 
-      if ((story.audio_problem_count ?? 0) === entry.audioProblemCount) {
+      if ((story.audio_problem_count ?? 0) === nextAudioProblemCount) {
         unchangedStories += 1;
         continue;
       }
 
       await ctx.db.patch(story._id, {
-        audio_problem_count: entry.audioProblemCount,
+        audio_problem_count: nextAudioProblemCount,
         lastOperationKey: operationKey,
       });
       updatedStories += 1;

--- a/convex/editorRead.ts
+++ b/convex/editorRead.ts
@@ -6,6 +6,7 @@ import {
   getSessionLegacyUserId,
   isContributorOrAdmin,
 } from "./lib/authorization";
+import { hasNoAudioCourseTag } from "./lib/courseTags";
 import { courseContributorValidator } from "./lib/courseContributors";
 
 type LanguageDoc = Doc<"languages">;
@@ -34,6 +35,7 @@ const editorCourseValidator = v.union(
     contributors_past: v.array(courseContributorValidator),
     todo_count: v.number(),
     audio_problem_count: v.number(),
+    tags: v.array(v.string()),
   }),
   v.null(),
 );
@@ -59,6 +61,12 @@ function toLanguage(language: LanguageDoc) {
     public: language.public,
     rtl: language.rtl,
   };
+}
+
+function deriveAudioProblemCount(course: CourseDoc) {
+  return hasNoAudioCourseTag(course.tags)
+    ? 0
+    : (course.audio_problem_count ?? 0);
 }
 
 function toCourse(
@@ -87,7 +95,8 @@ function toCourse(
     contributors: course.contributors ?? [],
     contributors_past: course.contributors_past ?? [],
     todo_count: course.todo_count ?? 0,
-    audio_problem_count: course.audio_problem_count ?? 0,
+    audio_problem_count: deriveAudioProblemCount(course),
+    tags: course.tags ?? [],
   };
 }
 
@@ -285,7 +294,8 @@ export const getEditorCourseByIdentifier = query({
       contributors: contributorLists.contributors,
       contributors_past: contributorLists.contributors_past,
       todo_count: course.todo_count ?? 0,
-      audio_problem_count: course.audio_problem_count ?? 0,
+      audio_problem_count: deriveAudioProblemCount(course),
+      tags: course.tags ?? [],
     };
   },
 });
@@ -364,6 +374,7 @@ export const getEditorStoriesByCourseLegacyId = query({
       }
     }
 
+    const noAudioCourse = hasNoAudioCourseTag(course.tags);
     const result = stories.map((story: StoryDoc) => {
       const authorId = toNumber(story.authorId);
       const authorChangeId = toNumber(story.authorChangeId);
@@ -397,7 +408,9 @@ export const getEditorStoriesByCourseLegacyId = query({
         status: derivedStatus,
         public: story.public,
         todo_count: story.todo_count ?? 0,
-        audio_problem_count: story.audio_problem_count ?? 0,
+        audio_problem_count: noAudioCourse
+          ? 0
+          : (story.audio_problem_count ?? 0),
         approvalCount: approvalCount ?? 0,
         approvedByCurrentUser: storyIdsApprovedByCurrentUser.has(story._id),
         author:
@@ -686,6 +699,7 @@ export const getEditorStoryPageData = query({
         short: course.short ?? "",
         learning_language: learningLanguage.legacyId,
         from_language: fromLanguage.legacyId,
+        course_tags: course.tags ?? [],
       },
     };
   },

--- a/convex/lib/courseCounts.ts
+++ b/convex/lib/courseCounts.ts
@@ -1,5 +1,6 @@
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
+import { hasNoAudioCourseTag } from "./courseTags";
 
 type CourseStory = Doc<"stories">;
 
@@ -43,6 +44,12 @@ export async function recomputeCourseAudioProblemCount(
   const course = await ctx.db.get(courseId);
   if (!course) {
     throw new Error(`Course ${courseId} not found`);
+  }
+  if (hasNoAudioCourseTag(course.tags)) {
+    if ((course.audio_problem_count ?? 0) !== 0) {
+      await ctx.db.patch(courseId, { audio_problem_count: 0 });
+    }
+    return 0;
   }
 
   const courseStories = stories ?? (await loadCourseStories(ctx, courseId));

--- a/convex/lib/courseTags.ts
+++ b/convex/lib/courseTags.ts
@@ -1,0 +1,7 @@
+export const NO_AUDIO_COURSE_TAG = "no-audio";
+
+export function hasNoAudioCourseTag(tags: readonly string[] | undefined) {
+  return (tags ?? []).some(
+    (tag) => tag.trim().toLowerCase() === NO_AUDIO_COURSE_TAG,
+  );
+}

--- a/convex/storyRead.ts
+++ b/convex/storyRead.ts
@@ -16,6 +16,7 @@ const storyReadResultValidator = v.union(
     learning_language_long: v.string(),
     learning_language_rtl: v.boolean(),
     course_short: v.string(),
+    course_tags: v.array(v.string()),
     elements: v.array(v.any()),
     illustrations: v.object({
       gilded: v.string(),
@@ -109,6 +110,7 @@ export const getStoryByLegacyId = query({
       learning_language_long: learningLanguage.name,
       learning_language_rtl: learningLanguage.rtl,
       course_short: `${learningLanguage.short}-${fromLanguage.short}`,
+      course_tags: course.tags ?? [],
       elements,
       illustrations: {
         gilded,

--- a/convex/storyWrite.ts
+++ b/convex/storyWrite.ts
@@ -10,6 +10,7 @@ import {
   recomputeCourseAudioProblemCount,
   recomputeCoursePublishedCount,
 } from "./lib/courseCounts";
+import { hasNoAudioCourseTag } from "./lib/courseTags";
 import { upsertPublicStoryContent } from "./lib/publicStoryContent";
 
 export const setStory = mutation({
@@ -110,8 +111,9 @@ export const setStory = mutation({
     ) {
       throw new Error("audioProblemCount must be a non-negative integer");
     }
-    const nextAudioProblemCount =
-      args.audioProblemCount === undefined
+    const nextAudioProblemCount = hasNoAudioCourseTag(course.tags)
+      ? 0
+      : args.audioProblemCount === undefined
         ? story.audio_problem_count
         : story.public && !story.deleted
           ? args.audioProblemCount

--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -8,6 +8,7 @@ import StoryButton from "./story_button";
 import get_localisation_func from "@/lib/get_localisation_func";
 import ContributorList from "@/components/ContributorList";
 import Switch from "@/components/ui/switch";
+import { hasNoAudioCourseTag } from "@/lib/course-tags";
 
 function SetTitle({ children }: { children: React.ReactNode }) {
   return (
@@ -121,13 +122,21 @@ export default function CoursePageClient({
     [course_id],
   );
   const [listeningMode, setListeningMode] = React.useState(false);
+  const course = usePreloadedQuery(preloadedCourse);
+  const noAudioCourse = hasNoAudioCourseTag(course?.tags);
 
   React.useEffect(() => {
     if (typeof window === "undefined") return;
+    if (noAudioCourse) {
+      setListeningMode(false);
+      window.localStorage.setItem(listeningStorageKey, "0");
+      return;
+    }
     setListeningMode(window.localStorage.getItem(listeningStorageKey) === "1");
-  }, [listeningStorageKey]);
+  }, [listeningStorageKey, noAudioCourse]);
 
   const toggleListeningMode = React.useCallback(() => {
+    if (noAudioCourse) return;
     setListeningMode((prev) => {
       const next = !prev;
       if (typeof window !== "undefined") {
@@ -135,9 +144,8 @@ export default function CoursePageClient({
       }
       return next;
     });
-  }, [listeningStorageKey]);
+  }, [listeningStorageKey, noAudioCourse]);
 
-  const course = usePreloadedQuery(preloadedCourse);
   const localizationMap = React.useMemo(() => {
     const data: Record<string, string> = {};
     for (const row of course?.localization ?? []) data[row.tag] = row.text;
@@ -207,33 +215,35 @@ export default function CoursePageClient({
       </Header>
       <div>
         {showNoNativeWarning ? <NoNativeWarning /> : null}
-        <div
-          className="mx-auto mb-6 flex w-full max-w-[720px] cursor-pointer items-center justify-between gap-3 rounded-xl border border-[var(--overview-hr)] px-4 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--overview-hr)]"
-          role="button"
-          tabIndex={0}
-          aria-pressed={listeningMode}
-          onClick={toggleListeningMode}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              toggleListeningMode();
-            }
-          }}
-        >
-          <div>
-            <div className="font-bold">Listening mode (skip questions)</div>
-            <div className="text-[calc(13/16*1rem)] text-[var(--text-color-dim)]">
-              Opens stories in autoplay and skips interactive questions.
-            </div>
-          </div>
+        {!noAudioCourse ? (
           <div
-            onClick={(e) => {
-              e.stopPropagation();
+            className="mx-auto mb-6 flex w-full max-w-[720px] cursor-pointer items-center justify-between gap-3 rounded-xl border border-[var(--overview-hr)] px-4 py-3 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--overview-hr)]"
+            role="button"
+            tabIndex={0}
+            aria-pressed={listeningMode}
+            onClick={toggleListeningMode}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                toggleListeningMode();
+              }
             }}
           >
-            <Switch checked={listeningMode} onClick={toggleListeningMode} />
+            <div>
+              <div className="font-bold">Listening mode (skip questions)</div>
+              <div className="text-[calc(13/16*1rem)] text-[var(--text-color-dim)]">
+                Opens stories in autoplay and skips interactive questions.
+              </div>
+            </div>
+            <div
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <Switch checked={listeningMode} onClick={toggleListeningMode} />
+            </div>
           </div>
-        </div>
+        ) : null}
         {course.about ? <About about={course.about} /> : null}
         <Contributors
           contributors={course.contributors}

--- a/src/app/(stories)/story/[story_id]/auto_play/story_wrapper.tsx
+++ b/src/app/(stories)/story/[story_id]/auto_play/story_wrapper.tsx
@@ -4,11 +4,15 @@ import React from "react";
 import StoryAutoPlay from "@/components/StoryAutoPlay";
 import { useQuery } from "convex/react";
 import { api } from "@convex/_generated/api";
+import { hasNoAudioCourseTag } from "@/lib/course-tags";
 
 export default function StoryWrapper({ storyId }: { storyId: number }) {
   const story = useQuery(api.storyRead.getStoryByLegacyId, { storyId });
   if (story === undefined) return null;
   if (story === null) return <p>Story not found.</p>;
+  if (hasNoAudioCourseTag(story.course_tags)) {
+    return <p>Listening mode is not available for this course.</p>;
+  }
 
   return <StoryAutoPlay story={story} />;
 }

--- a/src/app/editor/(course)/types.ts
+++ b/src/app/editor/(course)/types.ts
@@ -17,6 +17,7 @@ export type CourseProps = {
   contributors_past: string[];
   todo_count: number;
   audio_problem_count: number;
+  tags: string[];
 };
 
 export type ContributorSummaryProps = {

--- a/src/app/editor/story/[story]/types.ts
+++ b/src/app/editor/story/[story]/types.ts
@@ -11,6 +11,7 @@ export type StoryData = {
   short: string;
   learning_language: number;
   from_language: number;
+  course_tags: string[];
 };
 
 export type StoryEditorPageData = {

--- a/src/app/editor/story/[story]/v2/use_story_editor_model.ts
+++ b/src/app/editor/story/[story]/v2/use_story_editor_model.ts
@@ -10,6 +10,7 @@ import {
 import type { Avatar, StoryData } from "@/app/editor/story/[story]/types";
 import { retryOnceAfterAuthRefresh } from "./save_auth_retry";
 import { checkStoryLineAudio } from "./audio_problem_check";
+import { hasNoAudioCourseTag } from "@/lib/course-tags";
 
 type LanguageLike = {
   short: string;
@@ -270,7 +271,9 @@ export function useStoryEditorModel({
     const saveStartRevision = revision;
     const operationKey = `story:${storyData.id}:set_story:v2:${Date.now()}:${saveStartRevision}`;
     try {
-      const audioCheck = await checkStoryLineAudio(parsedStoryBase);
+      const audioCheck = hasNoAudioCourseTag(storyData.course_tags)
+        ? { audioProblemCount: 0 as const }
+        : await checkStoryLineAudio(parsedStoryBase);
       const saveArgs = {
         legacyStoryId: storyData.id,
         duo_id: storyData.duo_id ?? "",
@@ -322,6 +325,7 @@ export function useStoryEditorModel({
     revision,
     setStoryMutation,
     storyData.course_id,
+    storyData.course_tags,
     storyData.duo_id,
     storyData.id,
     storyData.official,

--- a/src/lib/course-tags.ts
+++ b/src/lib/course-tags.ts
@@ -1,0 +1,7 @@
+export const NO_AUDIO_COURSE_TAG = "no-audio";
+
+export function hasNoAudioCourseTag(tags: readonly string[] | undefined) {
+  return (tags ?? []).some(
+    (tag) => tag.trim().toLowerCase() === NO_AUDIO_COURSE_TAG,
+  );
+}


### PR DESCRIPTION
## Summary

Adds `no-audio` as a course tag that disables audio-problem accounting and listening mode for courses where proper TTS is not available.

## What changed

- Added shared `no-audio` tag helpers for Convex, web, and mobile.
- Forced audio problem counts to zero for `no-audio` courses in story saves, bulk syncs, aggregate recomputes, and editor read models.
- Clears existing stored story/course audio problem counts when an admin adds the tag.
- Hides the web and mobile listening-mode toggles for tagged courses.
- Forces listening mode off for direct mobile story URLs and web `/auto_play` routes.
- Threads course tags through story/editor read data so clients can enforce the behavior consistently.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm --dir app-mobile format`
- `pnpm --dir app-mobile lint`
- `pnpm --dir app-mobile typecheck`
- `pnpm convex dev --once`

Note: `pnpm convex dev --once` configured a local Convex deployment in ignored `.env.local`; no tracked env file changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Courses tagged as “no audio” now automatically disable Listening mode across web and mobile.
  - Listening mode UI is hidden when unavailable; autoplay and story playback are blocked with a clear message.
  - Story navigation and analytics now use the effective listening state, including updates to retry/next behavior.
  - Course and story data now include course tags.

- **Bug Fixes**
  - Audio problem counts are enforced to remain at zero for no-audio courses and related stories.
  - Editors skip audio validation when saving stories for no-audio courses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->