### PR TITLE
Fix audio insertion anchor placement

### DIFF
--- a/src/components/editor/story/parser.test.ts
+++ b/src/components/editor/story/parser.test.ts
@@ -345,6 +345,24 @@ $8275/8e8657d3.mp3;5,50;2,550;1,438;7,162;0,525`);
   });
 });
 
+test("SELECT_PHRASE audio insert anchor stays after the hidden phrase translation", () => {
+  const [, , audioInsertLines] = processStoryFile(
+    `[SELECT_PHRASE]
+> Διαλέξτε τη φράση που λείπει. - Select the missing phrase.
+Speaker856: [Δεν~ξέρω], νομίζω πως~ναι.
+~ I~don't~know  I~think so
++ Δεν ξέρω
+- Δε θέλω
+- Δεν κάνω`,
+    0,
+    testAvatars,
+    { learning_language: "el", from_language: "en" },
+    "",
+  );
+
+  assert.deepEqual(audioInsertLines, [[undefined, 5]]);
+});
+
 test("LINE uses the default avatar link when a speaker override only changes the voice", () => {
   const avatarLink = "https://stories-cdn.duolingo.com/avatar/speaker-6.svg";
   const [story, meta] = processStoryFile(

--- a/src/lib/editor/audio/audio_edit_tools.test.ts
+++ b/src/lib/editor/audio/audio_edit_tools.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { Text } from "@codemirror/state";
 import {
+  get_audio_insert_line,
   timing_text_without_filename,
   timings_to_text,
 } from "@/lib/editor/audio/audio_edit_tools";
@@ -27,4 +29,19 @@ test("timing_text_without_filename prevents duplicate audio filenames on save", 
   )}`;
 
   assert.equal(savedText, "$1961/_f34f3b72.mp3;2,132768;7,127");
+});
+
+test("get_audio_insert_line targets the next syntax line", () => {
+  const doc = Text.of([
+    "[SELECT_PHRASE]",
+    "> Select the missing phrase",
+    "Speaker856: [Δεν~ξέρω], νομίζω πως~ναι.",
+    "~ I~don't~know  I~think so",
+    "+ Δεν ξέρω",
+  ]);
+
+  const line = get_audio_insert_line(doc, 5);
+
+  assert.equal(line.number, 5);
+  assert.equal(line.text, "+ Δεν ξέρω");
 });

--- a/src/lib/editor/audio/audio_edit_tools.ts
+++ b/src/lib/editor/audio/audio_edit_tools.ts
@@ -1,5 +1,5 @@
 import { fetch_post } from "@/lib/fetch_post";
-import type { ChangeDesc } from "@codemirror/state";
+import type { ChangeDesc, Text } from "@codemirror/state";
 import {
   add_word_marks_replacements,
   find_replace_with_mapping,
@@ -383,16 +383,17 @@ export function create_audio_insert_anchor(
     };
   }
 
-  const lineNumber = Math.min(
-    Math.max(1, line_insert - 1),
-    view.state.doc.lines,
-  );
-  const line_state = view.state.doc.line(lineNumber);
+  const line_state = get_audio_insert_line(view.state.doc, line_insert);
   return {
     kind: "insert",
     from: line_state.from,
     to: line_state.from,
   };
+}
+
+export function get_audio_insert_line(doc: Text, line_insert: number) {
+  const lineNumber = Math.min(Math.max(1, line_insert), doc.lines);
+  return doc.line(lineNumber);
 }
 
 export function map_audio_insert_anchor(
@@ -462,11 +463,7 @@ export function insert_audio_lines(
         };
       }
 
-      const lineInsertNumber = Math.min(
-        Math.max(1, line_insert - 1),
-        view.state.doc.lines,
-      );
-      const line_state = view.state.doc.line(lineInsertNumber);
+      const line_state = get_audio_insert_line(view.state.doc, line_insert);
       return {
         from: line_state.from,
         to: line_state.from,


### PR DESCRIPTION
## Summary
- fix new audio line insertion to use the parser's recorded target line directly
- cover the SELECT_PHRASE hidden-phrase case where audio was inserted before the translation hint
- add a small insertion-target unit test for the shared audio edit helper

## Validation
- pnpm exec tsx --test src/lib/editor/audio/audio_edit_tools.test.ts
- pnpm exec tsx --test src/components/editor/story/parser.test.ts
- pnpm test
- pnpm run format
- pnpm run lint

## Notes
- pnpm typecheck currently fails on existing Convex test type dependencies: missing vite/client, convex-test, and vitest types. This appears unrelated to this change.