### PR TITLE
Improve course page SEO: metadata, real 404s, sitemap lastmod, JSON-LD

### DIFF
--- a/convex/landing.ts
+++ b/convex/landing.ts
@@ -337,6 +337,9 @@ const publicStoryListItemValidator = v.object({
   gilded: v.string(),
   active_lip: v.string(),
   gilded_lip: v.string(),
+  // Millisecond timestamps used for sitemap <lastmod>.
+  change_date: v.optional(v.number()),
+  date_published: v.optional(v.number()),
 });
 
 const localizationEntryValidator = v.object({
@@ -451,6 +454,8 @@ export const getPublicCoursePageData = query({
           gilded: image.gilded,
           active_lip: image.active_lip,
           gilded_lip: image.gilded_lip,
+          change_date: story.change_date,
+          date_published: story.date_published,
         };
       })
       .filter(
@@ -467,6 +472,8 @@ export const getPublicCoursePageData = query({
           gilded: string;
           active_lip: string;
           gilded_lip: string;
+          change_date: number | undefined;
+          date_published: number | undefined;
         } => story !== null,
       )
       .sort((a, b) => {

--- a/src/app/(stories)/(main)/[course_id]/page.tsx
+++ b/src/app/(stories)/(main)/[course_id]/page.tsx
@@ -126,7 +126,11 @@ export default async function Page({
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        // Story names are contributor-controlled; escape "<" so none of them
+        // can contain "</script>" and terminate this tag.
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replaceAll("<", "\\u003c"),
+        }}
       />
       <div lang={fromLanguageCode} className="contents">
         <CoursePageClient

--- a/src/app/(stories)/(main)/[course_id]/page.tsx
+++ b/src/app/(stories)/(main)/[course_id]/page.tsx
@@ -5,8 +5,20 @@ import CoursePageClient from "./course_page_client";
 import { get_localisation_by_convex_language_id } from "@/lib/get_localisation";
 import { get_course_data, get_course } from "../get_course_data";
 import { ResolvingMetadata } from "next";
-import { preloadQuery } from "convex/nextjs";
+import { preloadQuery, preloadedQueryResult } from "convex/nextjs";
 import { api } from "@convex/_generated/api";
+
+// Every public course targets a language pair that official Duolingo Stories
+// does not cover (official pairs are never public here), so the metadata can
+// safely lead with that differentiator. Story counts under 10 read as thin, so
+// small courses omit the number.
+function courseDescription(language: string, count: number) {
+  const inventory =
+    count >= 10
+      ? `${count} free interactive ${language} stories`
+      : `free interactive ${language} stories`;
+  return `Duolingo doesn't have stories for ${language} — Duostories does: ${inventory} with audio, translated by the community. Read, listen, and practice ${language} online.`;
+}
 
 export async function generateMetadata(
   { params }: { params: Promise<{ course_id: string }> },
@@ -31,12 +43,12 @@ export async function generateMetadata(
     title:
       localization("meta_course_title", {
         $language: course.learning_language_name,
-      }) || `${course.learning_language_name} Duolingo Stories`,
+      }) ||
+      `${course.learning_language_name} Duolingo Stories – Learn ${course.learning_language_name} with Audio | Duostories`,
     description:
       localization("meta_course_description", {
         $language: course.learning_language_name,
-      }) ||
-      `Improve your ${course.learning_language_name} learning by community-translated Duolingo stories.`,
+      }) || courseDescription(course.learning_language_name, course.count),
     alternates: {
       canonical: `https://duostories.org/${params0.course_id}`,
     },
@@ -81,8 +93,47 @@ export default async function Page({
       short: course_id,
     },
   );
+  // Unknown slugs must produce a real 404. Without this check the route
+  // resolved with HTTP 200 (a soft 404) and only generateMetadata noindexed it.
+  const courseData = preloadedQueryResult(preloadedCourse);
+  if (!courseData) {
+    return notFound();
+  }
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${courseData.learning_language_name} Duolingo Stories`,
+    description: courseDescription(
+      courseData.learning_language_name,
+      courseData.count,
+    ),
+    inLanguage: course_id.split("-")[0],
+    numberOfItems: courseData.stories.length,
+    itemListElement: courseData.stories.map((story, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `https://duostories.org/story/${story.id}`,
+      name: story.name,
+    })),
+  };
+
+  // The from-language code marks the page chrome's language for crawlers;
+  // display:contents keeps the wrapper out of layout.
+  const fromLanguageCode = course_id.split("-")[1];
 
   return (
-    <CoursePageClient course_id={course_id} preloadedCourse={preloadedCourse} />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <div lang={fromLanguageCode} className="contents">
+        <CoursePageClient
+          course_id={course_id}
+          preloadedCourse={preloadedCourse}
+        />
+      </div>
+    </>
   );
 }

--- a/src/app/(stories)/(main)/page.tsx
+++ b/src/app/(stories)/(main)/page.tsx
@@ -7,6 +7,16 @@ import { preloadQuery } from "convex/nextjs";
 import { api } from "@convex/_generated/api";
 import LandingStatsClient from "./landing_stats_client";
 
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Duostories",
+  alternateName: "Unofficial Duolingo Stories",
+  url: "https://duostories.org/",
+  description:
+    "Community-translated interactive stories with audio for learning languages, in the style of Duolingo Stories.",
+};
+
 export default async function Page({}) {
   const preloadedLandingData = await preloadQuery(
     api.landing.getPublicLandingPageData,
@@ -15,6 +25,10 @@ export default async function Page({}) {
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <Header>
         <h1>Unofficial Duolingo Stories</h1>
         <p className="[&_a]:underline [&_a]:underline-offset-2">

--- a/src/app/(stories)/story/[story_id]/StoryTranscript.tsx
+++ b/src/app/(stories)/story/[story_id]/StoryTranscript.tsx
@@ -53,7 +53,11 @@ export default function StoryTranscript({ story }: { story: StoryData }) {
     <section aria-labelledby="story-transcript-heading" className="pb-10">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        // Story text is contributor-controlled; escape "<" so no line can
+        // contain "</script>" and terminate this tag.
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replaceAll("<", "\\u003c"),
+        }}
       />
       <StoryHeaderProgress
         course={story.course_short}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -64,26 +64,55 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })),
   );
 
+  // <lastmod> from story edit/publish timestamps: stories carry their own
+  // date, a course the newest date of its stories, the homepage the newest
+  // date overall. Entries without a known date omit lastmod rather than lie.
+  const storyLastModified = (story: {
+    change_date?: number;
+    date_published?: number;
+  }) => {
+    const timestamp = story.change_date ?? story.date_published;
+    return timestamp ? new Date(timestamp) : undefined;
+  };
+
   const courseEntries: MetadataRoute.Sitemap = coursePages.map(
-    ({ course }) => ({
-      url: toUrl(`/${course.short}`),
-      changeFrequency: "daily",
-      priority: 0.9,
-    }),
+    ({ course, pageData }) => {
+      const dates = (pageData?.stories ?? [])
+        .map((story) => storyLastModified(story)?.getTime())
+        .filter((time): time is number => time !== undefined);
+      return {
+        url: toUrl(`/${course.short}`),
+        lastModified: dates.length ? new Date(Math.max(...dates)) : undefined,
+        changeFrequency: "daily",
+        priority: 0.9,
+      };
+    },
   );
 
   const storyEntries: MetadataRoute.Sitemap = coursePages.flatMap(
     ({ pageData }) =>
       (pageData?.stories ?? []).map((story) => ({
         url: toUrl(`/story/${story.id}`),
+        lastModified: storyLastModified(story),
         changeFrequency: "weekly" as const,
         priority: 0.8,
       })),
   );
 
+  const siteLastModifiedTimes = courseEntries
+    .map((entry) =>
+      entry.lastModified instanceof Date
+        ? entry.lastModified.getTime()
+        : undefined,
+    )
+    .filter((time): time is number => time !== undefined);
+
   return [
     {
       url: toUrl("/"),
+      lastModified: siteLastModifiedTimes.length
+        ? new Date(Math.max(...siteLastModifiedTimes))
+        : undefined,
       changeFrequency: "daily",
       priority: 1,
     },


### PR DESCRIPTION
## What

Point 2 of the SEO roadmap — the course-page batch:

- **Metadata templates** (`[course_id]/page.tsx`): fallback title is now `{Language} Duolingo Stories – Learn {Language} with Audio | Duostories`; fallback description answers the dominant query intent ("does Duolingo have {language}"): *"Duolingo doesn't have stories for {Language} — Duostories does: {N} free interactive {Language} stories with audio…"* (story count included when ≥ 10). Safe claim: no `official` (Duolingo-covered) course is public.
- **Real 404s**: unknown course slugs (e.g. `/xx-yy`) returned HTTP 200 with canonical→homepage (soft 404). The page now validates the course via the preloaded query and calls `notFound()`, same as the story route.
- **Sitemap `<lastmod>`**: stories expose `change_date`/`date_published` through `getPublicCoursePageData`; story entries use their own date, course entries the newest story date, the homepage the newest overall. Entries without a date omit lastmod.
- **JSON-LD**: `ItemList` of stories on course pages, `WebSite` on the homepage.
- **`lang` attribute** on course page content (from-language, via a `display:contents` wrapper).

## Verified

- `pnpm typecheck` clean, all 94 tests pass, production build succeeds.
- Ran the built app: `/xx-yy` → 404 ✓, ItemList + WebSite JSON-LD present ✓, `lang` wrapper present ✓.

## Two things to know

1. **The new title/description templates are currently shadowed**: the Convex `localizations` table has English `meta_course_title`/`meta_course_description` entries that take precedence over the code fallback. To activate the new copy, delete (or update to match) those two English rows — translations for other languages keep working. Happy to do this via the admin/localization editor on request.
2. **lastmod appears only after the Convex functions deploy** (the local check against prod Convex showed none yet, as expected — the fields don't exist there until this PR's `convex/landing.ts` goes out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/expanded Schema.org JSON-LD structured metadata for the homepage and course pages.
  * Course pages now generate improved localized fallback titles/descriptions and set language context in the page markup.
  * Sitemap now includes `lastModified` timestamps for courses, stories, and the homepage (using available story publication/change dates).

* **Bug Fixes**
  * Course pages now return a true 404 when preloaded course data is missing, preventing “soft 404” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->