### PR TITLE
Use localized language names and $count in course metadata

### DIFF
--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -194,17 +194,20 @@ export default function CoursePageClient({
   return (
     <>
       <Header>
+        {/* course.name is the learning language's name in the course's own
+            base language ("Inglese" on an Italian-based course); the English
+            learning_language_name is only a fallback for courses without it. */}
         <h1>
           {localization("course_page_title", {
-            $language: course.learning_language_name,
-          }) ?? `${course.learning_language_name} Duolingo Stories`}
+            $language: course.name || course.learning_language_name,
+          }) ?? `${course.name || course.learning_language_name} Duolingo Stories`}
         </h1>
         <p>
           {localization("course_page_sub_title", {
-            $language: course.learning_language_name,
+            $language: course.name || course.learning_language_name,
             $count: `${course.count}`,
           }) ??
-            `Learn ${course.learning_language_name} with ${course.count} stories.`}
+            `Learn ${course.name || course.learning_language_name} with ${course.count} stories.`}
         </p>
         <p className="[&_a]:underline [&_a]:underline-offset-2">
           {localization("course_page_discuss", {}, [

--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -200,7 +200,8 @@ export default function CoursePageClient({
         <h1>
           {localization("course_page_title", {
             $language: course.name || course.learning_language_name,
-          }) ?? `${course.name || course.learning_language_name} Duolingo Stories`}
+          }) ??
+            `${course.name || course.learning_language_name} Duolingo Stories`}
         </h1>
         <p>
           {localization("course_page_sub_title", {

--- a/src/app/(stories)/(main)/[course_id]/page.tsx
+++ b/src/app/(stories)/(main)/[course_id]/page.tsx
@@ -10,14 +10,24 @@ import { api } from "@convex/_generated/api";
 
 // Every public course targets a language pair that official Duolingo Stories
 // does not cover (official pairs are never public here), so the metadata can
-// safely lead with that differentiator. Story counts under 10 read as thin, so
-// small courses omit the number.
+// safely lead with that differentiator. English fallback for locales without
+// meta_course_* localization entries; mirrors those strings' $language/$count.
 function courseDescription(language: string, count: number) {
   const inventory =
-    count >= 10
+    count > 0
       ? `${count} free interactive ${language} stories`
       : `free interactive ${language} stories`;
   return `Duolingo doesn't have stories for ${language} — Duostories does: ${inventory} with audio, translated by the community. Read, listen, and practice ${language} online.`;
+}
+
+// courses.name is the learning language's name written in the course's own
+// base language ("Russo" on an Italian-based course); a few courses have it
+// empty, so fall back to the English name.
+function displayLanguageName(course: {
+  name: string;
+  learning_language_name: string;
+}) {
+  return course.name || course.learning_language_name;
 }
 
 export async function generateMetadata(
@@ -38,17 +48,19 @@ export async function generateMetadata(
   );
 
   const meta = await parent;
+  const languageName = displayLanguageName(course);
+  const replacements = {
+    $language: languageName,
+    $count: `${course.count}`,
+  };
 
   return {
     title:
-      localization("meta_course_title", {
-        $language: course.learning_language_name,
-      }) ||
-      `${course.learning_language_name} Duolingo Stories – Learn ${course.learning_language_name} with Audio | Duostories`,
+      localization("meta_course_title", replacements) ||
+      `${languageName} Duolingo Stories – Learn ${languageName} with Audio | Duostories`,
     description:
-      localization("meta_course_description", {
-        $language: course.learning_language_name,
-      }) || courseDescription(course.learning_language_name, course.count),
+      localization("meta_course_description", replacements) ||
+      courseDescription(languageName, course.count),
     alternates: {
       canonical: `https://duostories.org/${params0.course_id}`,
     },
@@ -56,7 +68,7 @@ export async function generateMetadata(
       images: [
         `/api/og-course?lang=${params0.course_id.split("-")[0]}&count=${
           course.count
-        }&name=${course.learning_language_name}`,
+        }&name=${languageName}`,
       ],
       url: `https://duostories.org/${params0.course_id}`,
       type: "website",
@@ -103,9 +115,9 @@ export default async function Page({
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "ItemList",
-    name: `${courseData.learning_language_name} Duolingo Stories`,
+    name: `${displayLanguageName(courseData)} Duolingo Stories`,
     description: courseDescription(
-      courseData.learning_language_name,
+      displayLanguageName(courseData),
       courseData.count,
     ),
     inLanguage: course_id.split("-")[0],


### PR DESCRIPTION
Follow-up to #604, fixing the bug Richard spotted: course pages substituted `$language` with the **English** language name even on non-English-based courses, producing mixed-language text like *"Impara English con 4 storie"* on the Italian-based course — while `courses.name` already holds the correct localized name ("Inglese").

## Changes

- `$language` now substitutes `course.name` (the learning language's name in the course's base language), falling back to `learning_language_name` where `name` is empty (e.g. ie-es). Applied to: H1, subtitle, meta title/description, OG image name, and the ItemList JSON-LD.
- `$count` is now passed to the `meta_course_title`/`meta_course_description` localization calls, following the existing `course_page_sub_title` convention — so localized meta strings can include the story count. The English code fallback mirrors this (always shows the count, like the on-page subtitle).

## Verified

`pnpm typecheck` clean, all 94 tests pass.

## Note

This pairs with the pending localization-row proposal: once this deploys, the English `meta_course_*` rows should be **updated** (not emptied) to the new $language/$count templates — revised proposal to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)