### PR TITLE
Render story lines correctly in mobile feedback

### DIFF
--- a/app-mobile/app/debug/story-shot.tsx
+++ b/app-mobile/app/debug/story-shot.tsx
@@ -254,8 +254,9 @@ export default function StoryShotScreen() {
             <StoryFeedbackFloat>
               <StoryFeedback
                 storyId={1234}
-                lineIndex={1}
-                lineText="Lucy: I think my keys are in the car."
+                lineIndex={2}
+                lineText="Eddy: నా తాళం చెవులు ఎక్కడ ఉన్నాయి?"
+                lineElement={teluguLine}
                 initialOpen={openFeedback}
                 submitFeedback={() => Promise.resolve()}
               />

--- a/app-mobile/src/story/Reader.tsx
+++ b/app-mobile/src/story/Reader.tsx
@@ -354,6 +354,8 @@ export function Reader({
               storyId={story.id}
               lineIndex={feedbackContext.lineIndex}
               lineText={feedbackContext.lineText}
+              lineElement={feedbackContext.lineElement}
+              storyRtl={story.learning_language_rtl}
               disabled={buttonStatus === "..."}
               onOpen={pauseForOverlay}
             />

--- a/app-mobile/src/story/StoryFeedback.tsx
+++ b/app-mobile/src/story/StoryFeedback.tsx
@@ -15,6 +15,7 @@ import { api } from "../api";
 import { Button } from "../components/Button";
 import { Text, TextInput } from "../components/Text";
 import { type ThemeColors, useTheme } from "../theme";
+import { TextLine } from "./elements/TextLine";
 import {
   type FeedbackSubmitError,
   getFeedbackSubmitError,
@@ -25,7 +26,7 @@ import {
   submitFeedbackWithTimeout,
   waitForFeedbackConnection,
 } from "./feedbackSubmission";
-import type { StoryElement } from "./types";
+import type { StoryElement, StoryElementLine } from "./types";
 
 const feedbackCategories = [
   { label: "Text", value: "Text" },
@@ -136,6 +137,7 @@ export function getFeedbackContext(
   return {
     ...(lineIndex !== undefined ? { lineIndex } : {}),
     ...(lineText ? { lineText } : {}),
+    ...(visibleElement?.type === "LINE" ? { lineElement: visibleElement } : {}),
   };
 }
 
@@ -143,6 +145,8 @@ export function StoryFeedback({
   storyId,
   lineIndex,
   lineText,
+  lineElement,
+  storyRtl = false,
   disabled = false,
   initialOpen = false,
   onOpen,
@@ -151,6 +155,8 @@ export function StoryFeedback({
   storyId: number;
   lineIndex?: number;
   lineText?: string;
+  lineElement?: StoryElementLine;
+  storyRtl?: boolean;
   disabled?: boolean;
   initialOpen?: boolean;
   onOpen?: () => void;
@@ -316,11 +322,22 @@ export function StoryFeedback({
               </View>
 
               <Text style={styles.eyebrow}>Current line</Text>
-              <View style={styles.linePreview}>
-                <Text style={styles.lineText}>
-                  {lineText || `Story ${storyId}`}
-                </Text>
-              </View>
+              {lineElement ? (
+                <View style={styles.storyLinePreview}>
+                  <TextLine
+                    element={lineElement}
+                    active={false}
+                    rtl={storyRtl}
+                    autoPlay={false}
+                  />
+                </View>
+              ) : (
+                <View style={styles.linePreview}>
+                  <Text style={styles.lineText}>
+                    {lineText || `Story ${storyId}`}
+                  </Text>
+                </View>
+              )}
 
               <Text style={styles.label}>Category</Text>
               <View style={styles.categoryGrid}>
@@ -517,6 +534,7 @@ function createStyles(colors: ThemeColors) {
       paddingVertical: 12,
       marginTop: 7,
     },
+    storyLinePreview: { marginTop: 2 },
     lineText: { color: colors.text, fontSize: 16, lineHeight: 22 },
     label: {
       color: colors.text,


### PR DESCRIPTION
## Summary
- render mobile feedback’s current-line preview with the existing `TextLine` component
- preserve the character avatar, speech bubble, audio control, native-script wrapping, and RTL behavior
- keep the plain-text preview for questions and other non-line feedback contexts
- update the debug fixture with a Telugu line containing audio

## Why
The feedback sheet flattened character dialogue into `characterId: text` (for example, `560: …`), so it lost the avatar and speech-bubble presentation used in the story reader.

## User impact
Character dialogue now looks the same in the feedback sheet as it does in the story, and opening the sheet does not autoplay audio.

## Validation
- `pnpm run test:mobile` — 19 passed
- `pnpm --dir app-mobile format:check`
- `pnpm --dir app-mobile lint`
- `pnpm --dir app-mobile typecheck`
- iPhone-sized Telugu/audio debug render reviewed at 390×844


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer “Current line” preview in story feedback, displaying the selected story line with proper right-to-left language support.
  * Feedback now uses the currently visible story line when available.
* **Bug Fixes**
  * Updated the debug feedback view to reference the intended Telugu story line instead of unrelated debug text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->