### PR TITLE
Track story feedback platform

### DIFF
--- a/app-mobile/src/story/StoryFeedback.tsx
+++ b/app-mobile/src/story/StoryFeedback.tsx
@@ -5,7 +5,7 @@ import BottomSheet, {
 } from "@expo/ui/community/bottom-sheet";
 import { useConvex, useMutation } from "convex/react";
 import React from "react";
-import { Pressable, StyleSheet, View } from "react-native";
+import { Platform, Pressable, StyleSheet, View } from "react-native";
 import { api } from "../api";
 import { Button } from "../components/Button";
 import { Text, TextInput } from "../components/Text";
@@ -36,6 +36,7 @@ type SubmitFeedback = (args: {
   operationKey: string;
   lineIndex?: number;
   lineText?: string;
+  source: "web" | "android" | "ios";
   category: FeedbackCategory;
   comment: string;
 }) => Promise<unknown>;
@@ -218,6 +219,12 @@ export function StoryFeedback({
         submitFeedback({
           storyId,
           operationKey,
+          source:
+            Platform.OS === "ios"
+              ? "ios"
+              : Platform.OS === "android"
+                ? "android"
+                : "web",
           lineIndex,
           lineText,
           category,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -246,6 +246,9 @@ export default defineSchema({
     line: v.optional(v.number()),
     lineText: v.optional(v.string()),
     lineElement: v.optional(v.any()),
+    source: v.optional(
+      v.union(v.literal("web"), v.literal("android"), v.literal("ios")),
+    ),
     category: v.union(
       v.literal("Text"),
       v.literal("Translation hints"),

--- a/convex/storyFeedback.test.ts
+++ b/convex/storyFeedback.test.ts
@@ -31,6 +31,7 @@ type FeedbackArgs = {
   lineIndex?: number;
   lineText?: string;
   lineElement?: unknown;
+  source?: "web" | "android" | "ios";
   category: "Text" | "Translation hints" | "Audio" | "Other";
   comment: string;
 };
@@ -110,6 +111,7 @@ function feedbackArgs(overrides: Partial<FeedbackArgs> = {}): FeedbackArgs {
   return {
     storyId: 10,
     operationKey: "feedback-operation-key",
+    source: "web",
     category: "Text" as const,
     comment: "There is a typo.",
     ...overrides,
@@ -237,6 +239,42 @@ describe("submitStoryFeedback", () => {
       expect(report.line).toBe(12);
       expect(report.lineText).toBe("Hola");
       expect(report.lineElement).toEqual(parsedLineElement);
+      expect(report.source).toBe("web");
+    });
+  });
+
+  test.each([
+    "ios",
+    "android",
+  ] as const)("stores the %s submitting client platform", async (source) => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t);
+
+    await t.mutation(
+      api.storyFeedback.submitStoryFeedback,
+      feedbackArgs({ source }),
+    );
+
+    await t.run(async (ctx) => {
+      const report = await ctx.db.query("story_feedback_reports").unique();
+      expect(report).not.toBeNull();
+      if (!report) return;
+      expect(report.source).toBe(source);
+    });
+  });
+
+  test("accepts legacy clients that do not send a platform", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t);
+    const { source: _source, ...legacyArgs } = feedbackArgs();
+
+    await t.mutation(api.storyFeedback.submitStoryFeedback, legacyArgs);
+
+    await t.run(async (ctx) => {
+      const report = await ctx.db.query("story_feedback_reports").unique();
+      expect(report).not.toBeNull();
+      if (!report) return;
+      expect(report.source).toBeUndefined();
     });
   });
 

--- a/convex/storyFeedback.ts
+++ b/convex/storyFeedback.ts
@@ -20,6 +20,12 @@ const feedbackStatusValidator = v.union(
   v.literal("resolved"),
 );
 
+const feedbackSourceValidator = v.union(
+  v.literal("web"),
+  v.literal("android"),
+  v.literal("ios"),
+);
+
 const feedbackReportValidator = v.object({
   _id: v.id("story_feedback_reports"),
   _creationTime: v.number(),
@@ -30,6 +36,7 @@ const feedbackReportValidator = v.object({
   line: v.optional(v.number()),
   lineText: v.optional(v.string()),
   lineElement: v.optional(v.any()),
+  source: v.optional(feedbackSourceValidator),
   category: feedbackCategoryValidator,
   comment: v.string(),
   userId: v.union(v.string(), v.null()),
@@ -258,6 +265,8 @@ export const submitStoryFeedback = mutation({
     // active source element by its public tracking index instead.
     lineIndex: v.optional(v.number()),
     lineText: v.optional(v.string()),
+    // Optional while previously released clients age out.
+    source: v.optional(feedbackSourceValidator),
     // TODO(remove after 2026-07-20): deprecated; ignored for trust safety.
     lineElement: v.optional(v.any()),
     category: feedbackCategoryValidator,
@@ -374,6 +383,7 @@ export const submitStoryFeedback = mutation({
       ...(line !== undefined ? { line } : {}),
       ...(lineText ? { lineText } : {}),
       ...(lineElement !== undefined ? { lineElement } : {}),
+      ...(args.source !== undefined ? { source: args.source } : {}),
       category: args.category,
       comment,
       userId: identity?.tokenIdentifier ?? null,

--- a/src/app/editor/feedback/feedback_review_view.tsx
+++ b/src/app/editor/feedback/feedback_review_view.tsx
@@ -27,6 +27,8 @@ export type FeedbackReport = {
   line?: number;
   lineText?: string;
   lineElement?: unknown;
+  operationKey?: string;
+  source?: "web" | "android" | "ios";
   category: "Text" | "Translation hints" | "Audio" | "Other";
   comment: string;
   userName: string | null;
@@ -50,6 +52,19 @@ const statusLabels: Record<FeedbackStatus, string> = {
   reviewed: "Reviewed",
   resolved: "Resolved",
 };
+
+const sourceLabels = {
+  web: "Web",
+  android: "Android",
+  ios: "iOS",
+} as const;
+
+function getFeedbackSourceLabel(report: FeedbackReport) {
+  if (report.source) return sourceLabels[report.source];
+  return report.operationKey?.startsWith("mobile-feedback:")
+    ? "Mobile (legacy)"
+    : "Web (legacy)";
+}
 
 export type FeedbackCourseFilter = {
   short: string;
@@ -273,6 +288,7 @@ function FeedbackReportRow({
           <span>{report.courseShort}</span>
           <span>Story {report.storyId}</span>
           {report.line !== undefined ? <span>Line {report.line}</span> : null}
+          <span>{getFeedbackSourceLabel(report)}</span>
           <span>{report.userName || report.userEmail || "Anonymous"}</span>
         </div>
 

--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -140,6 +140,7 @@ export default function StoryFeedback({
               await submitStoryFeedback({
                 storyId,
                 operationKey,
+                source: "web",
                 line,
                 lineText,
                 category,


### PR DESCRIPTION
## Summary
- record whether feedback was submitted from web, Android, or iOS
- keep the Convex mutation and stored schema backward-compatible with released clients
- show exact platform labels in feedback review, with best-effort legacy labels
- cover native platforms and legacy omission in Convex tests

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (99 passed)
- `pnpm test:convex` (38 passed)
- `pnpm --dir app-mobile lint`
- `pnpm --dir app-mobile typecheck`
- `pnpm test:mobile` (19 passed)
- `pnpm convex dev --once` (configured local development deployment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feedback submissions now record whether they came from the web, Android, or iOS.
  * Feedback reviewers can see the submission platform alongside report details.
  * Existing feedback from older clients remains supported.

* **Bug Fixes**
  * Improved feedback source identification for legacy submissions when platform data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->