### PR TITLE
Lengthen homepage meta description

### DIFF
--- a/src/app/(stories)/(main)/layout.tsx
+++ b/src/app/(stories)/(main)/layout.tsx
@@ -11,7 +11,7 @@ export const metadata = {
   title:
     "Duostories: improve your Duolingo learning with community translated Duolingo stories.",
   description:
-    "Supplement your Duolingo course with community-translated Duolingo stories.",
+    "Free interactive stories with audio in 78 languages — including many Duolingo doesn't offer, like Albanian, Quechua, and Toki Pona. Translated by the community, free to read and listen online.",
   alternates: {
     canonical: "https://duostories.org",
   },
@@ -26,7 +26,7 @@ export const metadata = {
   openGraph: {
     title: "Duostories",
     description:
-      "Supplement your Duolingo course with community-translated Duolingo stories.",
+      "Free interactive stories with audio in 78 languages — including many Duolingo doesn't offer, like Albanian, Quechua, and Toki Pona. Translated by the community, free to read and listen online.",
     type: "website",
     url: `https://duostories.org`,
   },


### PR DESCRIPTION
Bing Webmaster Tools flagged the homepage description as too short (75 chars, generic: *"Supplement your Duolingo course with community-translated Duolingo stories."*). The homepage takes ~half of all search clicks, so it's the one short-description page worth fixing.

New (≈190 chars, front-loaded): *"Free interactive stories with audio in 78 languages — including many Duolingo doesn't offer, like Albanian, Quechua, and Toki Pona. Translated by the community, free to read and listen online."*

- Names concrete niche languages (Albanian/Quechua/Toki Pona are all real top search queries hitting the site) and leads with the value.
- Updated the matching OpenGraph description too.
- Only affects the homepage: faq/privacy have their own metadata, course pages override via generateMetadata; this `(main)/layout.tsx` default is effectively home-only.

typecheck + biome format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated page and social sharing descriptions to highlight free interactive stories with audio in 78 languages.
  * Added examples of supported languages and noted that translations are community-provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->