### PR TITLE
Fix dark mode mobile switch thumb

### DIFF
--- a/app-mobile/app/(tabs)/index.tsx
+++ b/app-mobile/app/(tabs)/index.tsx
@@ -257,8 +257,9 @@ export default function LearnTab() {
                 });
                 void setListeningMode(courseShort, value);
               }}
-              trackColor={{ true: colors.blue }}
-              thumbColor={colors.surface}
+              trackColor={{ false: colors.border, true: colors.blue }}
+              thumbColor={colors.switchThumb}
+              ios_backgroundColor={colors.border}
             />
           </View>
         ) : null}

--- a/app-mobile/app/(tabs)/profile.tsx
+++ b/app-mobile/app/(tabs)/profile.tsx
@@ -250,7 +250,8 @@ export default function ProfileTab() {
             value={hideStoryQuestions}
             onValueChange={setHideStoryQuestions}
             trackColor={{ false: colors.border, true: colors.blue }}
-            thumbColor={colors.surface}
+            thumbColor={colors.switchThumb}
+            ios_backgroundColor={colors.border}
           />
         </View>
 

--- a/app-mobile/src/theme.ts
+++ b/app-mobile/src/theme.ts
@@ -26,6 +26,7 @@ export const lightColors = {
   disabled: "#afafaf",
   disabledBackground: "#e5e5e5",
   hiddenUnderline: "#4b4b4b",
+  switchThumb: "#ffffff",
 };
 
 export const darkColors: ThemeColors = {
@@ -49,6 +50,7 @@ export const darkColors: ThemeColors = {
   disabled: "#65727a",
   disabledBackground: "#26343a",
   hiddenUnderline: "#f1f7fb",
+  switchThumb: "#ffffff",
 };
 
 export type ThemeColors = typeof lightColors;


### PR DESCRIPTION
## Summary

- add a dedicated white `switchThumb` theme token for mobile
- use it for the Learn tab listening-mode switch and the profile settings switch
- explicitly set the off-track color and iOS background color so native switch rendering is consistent across light/dark mode

## Root Cause

The native React Native `Switch` thumb was using `colors.surface`. In dark mode that token resolves to `#131f22`, making the off-state thumb nearly black against the dark Learn header.

## Validation

- `pnpm --dir app-mobile format`
- `pnpm --dir app-mobile lint`
- `pnpm --dir app-mobile typecheck`
- Captured native Android screenshots in light and dark mode:
  - Light: http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260715T210705Z-learn-light.png
  - Dark: http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260715T210705Z-learn-dark.png


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated toggle switches across listening mode and profile settings for clearer visual states.
  * Improved light and dark theme support with consistent switch track, thumb, and iOS background colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->