### PR TITLE
Fix stale audio text dimming

### DIFF
--- a/app-mobile/src/story/HintText.test.ts
+++ b/app-mobile/src/story/HintText.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { buildHintTextTokens } from "./HintTextTokens";
+
+const content = {
+  text: "alpha beta gamma",
+  hintMap: [],
+};
+
+describe("buildHintTextTokens", () => {
+  test("does not dim text when no line audio is currently playing", () => {
+    const tokens = buildHintTextTokens({
+      content,
+      audioRange: undefined,
+      showHints: true,
+    });
+
+    expect(tokens.map((token) => token.dimmed)).toEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  test("dims text only while an audio range is active", () => {
+    const tokens = buildHintTextTokens({
+      content,
+      audioRange: 7,
+      showHints: true,
+    });
+
+    expect(tokens.map((token) => [token.text, token.dimmed])).toEqual([
+      ["alpha", false],
+      [" ", false],
+      ["beta", false],
+      [" ", true],
+      ["gamma", true],
+    ]);
+  });
+});

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -18,6 +18,7 @@ import {
   PLAY_AUDIO_ICON_SIZE,
 } from "./elements/PlayAudioButton";
 import { HintLookupContext, HintPopupContext } from "./HintPopup";
+import { buildHintTextTokens, type Token } from "./HintTextTokens";
 import type { ContentWithHints, HideRange } from "./types";
 
 // Web-parity text renderer (StoryLineHints): hinted words get a dashed
@@ -35,36 +36,6 @@ const UNDERLINE_BASELINE_GAP = 4;
 const UNDERLINE_BOTTOM_INSET = 2;
 
 type HintTextRenderMode = "auto" | "native" | "tokenized";
-
-function splitTextTokens(text: string): string[] {
-  if (!text) return [];
-  return text
-    .split(/([\s\\¡!"#$%&*,./:;<=>¿?@^_`{|}]+)/)
-    .filter((p) => p !== "");
-}
-
-function getOverlap(
-  start1: number,
-  end1: number,
-  start2: number,
-  end2: number,
-): boolean {
-  if (start2 === end2) return false;
-  if (start2 === undefined || end2 === undefined) return false;
-  if (start1 <= start2 && start2 < end1) return true;
-  return start2 <= start1 && start1 < end2;
-}
-
-type Token = {
-  text: string;
-  start: number;
-  hidden: boolean;
-  hiddenGroupKey?: string;
-  revealed: boolean;
-  dimmed: boolean;
-  hint?: { translation: string; pronunciation?: string };
-  hintGroupKey?: string;
-};
 
 type NativeSegment = Token & {
   key: string;
@@ -812,128 +783,6 @@ function HintPhraseBox({
   );
 }
 
-function buildTokens({
-  content,
-  audioRange,
-  hideRangesForChallenge,
-  showHints,
-  unhide,
-}: {
-  content: ContentWithHints;
-  audioRange?: number;
-  hideRangesForChallenge?: HideRange[];
-  showHints: boolean;
-  unhide?: number;
-}): Token[] {
-  const visible: ContentWithHints = showHints
-    ? content
-    : {
-        ...content,
-        hintMap: [],
-        hints: undefined,
-        hints_pronunciation: undefined,
-      };
-
-  let entry: HideRange | undefined = hideRangesForChallenge?.[0];
-  if (entry) {
-    if (unhide === -1) entry = undefined;
-    else if (unhide && unhide > entry.start)
-      entry = { start: unhide, end: Math.max(entry.end, unhide) };
-  }
-
-  const tokens: Token[] = [];
-  const hiddenGroupKey = entry
-    ? `hidden:${entry.start}:${entry.end}`
-    : undefined;
-
-  const pushRun = (
-    start: number,
-    end: number,
-    hint?: Token["hint"],
-    hintGroupKey?: string,
-  ): void => {
-    const pieces = splitTextTokens(visible.text.substring(start, end));
-    let position = start;
-    for (const piece of pieces) {
-      // Separate whitespace from punctuation (e.g. ". " -> "." + " ") so
-      // whitespace alone defines the wrap points.
-      for (const sub of piece.split(/(\s+)/)) {
-        if (!sub) continue;
-        const pieceStart = position;
-        const pieceEnd = position + sub.length;
-        position = pieceEnd;
-        const boundaries = new Set([pieceStart, pieceEnd]);
-
-        if (entry) {
-          if (entry.start > pieceStart && entry.start < pieceEnd)
-            boundaries.add(entry.start);
-          if (entry.end > pieceStart && entry.end < pieceEnd)
-            boundaries.add(entry.end);
-        }
-        for (const range of hideRangesForChallenge ?? []) {
-          if (range.start > pieceStart && range.start < pieceEnd)
-            boundaries.add(range.start);
-          if (range.end > pieceStart && range.end < pieceEnd)
-            boundaries.add(range.end);
-        }
-
-        const sortedBoundaries = Array.from(boundaries).sort((a, b) => a - b);
-        for (let index = 0; index < sortedBoundaries.length - 1; index += 1) {
-          const fragmentStart = sortedBoundaries[index];
-          const fragmentEnd = sortedBoundaries[index + 1];
-          if (fragmentStart === undefined || fragmentEnd === undefined)
-            continue;
-
-          const hidden =
-            entry !== undefined &&
-            getOverlap(fragmentStart, fragmentEnd, entry.start, entry.end);
-          const wasHidden = Boolean(
-            hideRangesForChallenge?.some((range) =>
-              getOverlap(fragmentStart, fragmentEnd, range.start, range.end),
-            ),
-          );
-          tokens.push({
-            text: sub.slice(
-              fragmentStart - pieceStart,
-              fragmentEnd - pieceStart,
-            ),
-            start: fragmentStart,
-            hidden,
-            hiddenGroupKey: hidden ? hiddenGroupKey : undefined,
-            revealed: wasHidden && !hidden,
-            dimmed:
-              audioRange !== undefined &&
-              (audioRange === 0 ||
-                (audioRange > 0 && audioRange < fragmentStart)),
-            hint,
-            hintGroupKey,
-          });
-        }
-      }
-    }
-  };
-
-  let textPos = 0;
-  for (const hint of visible.hintMap ?? []) {
-    if (hint.rangeFrom > textPos) pushRun(textPos, hint.rangeFrom);
-    const translation = visible.hints?.[hint.hintIndex];
-    const pronunciation = visible.hints_pronunciation?.[hint.hintIndex];
-    const hintGroupKey = translation
-      ? `hint:${hint.rangeFrom}:${hint.rangeTo}:${hint.hintIndex}`
-      : undefined;
-    pushRun(
-      hint.rangeFrom,
-      hint.rangeTo + 1,
-      translation ? { translation, pronunciation } : undefined,
-      hintGroupKey,
-    );
-    textPos = hint.rangeTo + 1;
-  }
-  if (textPos < visible.text.length) pushRun(textPos, visible.text.length);
-
-  return tokens;
-}
-
 function NativeHintOverlay({
   hiddenCovers,
   debugRects,
@@ -1493,7 +1342,7 @@ export function HintText({
   if (!content) return null;
 
   const flatStyle = StyleSheet.flatten(style) ?? {};
-  const tokens = buildTokens({
+  const tokens = buildHintTextTokens({
     content,
     audioRange,
     hideRangesForChallenge,

--- a/app-mobile/src/story/HintTextTokens.ts
+++ b/app-mobile/src/story/HintTextTokens.ts
@@ -1,0 +1,153 @@
+import type { ContentWithHints, HideRange } from "./types";
+
+export type Token = {
+  text: string;
+  start: number;
+  hidden: boolean;
+  hiddenGroupKey?: string;
+  revealed: boolean;
+  dimmed: boolean;
+  hint?: { translation: string; pronunciation?: string };
+  hintGroupKey?: string;
+};
+
+function splitTextTokens(text: string): string[] {
+  if (!text) return [];
+  return text
+    .split(/([\s\\¡!"#$%&*,./:;<=>¿?@^_`{|}]+)/)
+    .filter((p) => p !== "");
+}
+
+function getOverlap(
+  start1: number,
+  end1: number,
+  start2: number,
+  end2: number,
+): boolean {
+  if (start2 === end2) return false;
+  if (start2 === undefined || end2 === undefined) return false;
+  if (start1 <= start2 && start2 < end1) return true;
+  return start2 <= start1 && start1 < end2;
+}
+
+export function buildHintTextTokens({
+  content,
+  audioRange,
+  hideRangesForChallenge,
+  showHints,
+  unhide,
+}: {
+  content: ContentWithHints;
+  audioRange?: number;
+  hideRangesForChallenge?: HideRange[];
+  showHints: boolean;
+  unhide?: number;
+}): Token[] {
+  const visible: ContentWithHints = showHints
+    ? content
+    : {
+        ...content,
+        hintMap: [],
+        hints: undefined,
+        hints_pronunciation: undefined,
+      };
+
+  let entry: HideRange | undefined = hideRangesForChallenge?.[0];
+  if (entry) {
+    if (unhide === -1) entry = undefined;
+    else if (unhide && unhide > entry.start)
+      entry = { start: unhide, end: Math.max(entry.end, unhide) };
+  }
+
+  const tokens: Token[] = [];
+  const hiddenGroupKey = entry
+    ? `hidden:${entry.start}:${entry.end}`
+    : undefined;
+
+  const pushRun = (
+    start: number,
+    end: number,
+    hint?: Token["hint"],
+    hintGroupKey?: string,
+  ): void => {
+    const pieces = splitTextTokens(visible.text.substring(start, end));
+    let position = start;
+    for (const piece of pieces) {
+      // Separate whitespace from punctuation (e.g. ". " -> "." + " ") so
+      // whitespace alone defines the wrap points.
+      for (const sub of piece.split(/(\s+)/)) {
+        if (!sub) continue;
+        const pieceStart = position;
+        const pieceEnd = position + sub.length;
+        position = pieceEnd;
+        const boundaries = new Set([pieceStart, pieceEnd]);
+
+        if (entry) {
+          if (entry.start > pieceStart && entry.start < pieceEnd)
+            boundaries.add(entry.start);
+          if (entry.end > pieceStart && entry.end < pieceEnd)
+            boundaries.add(entry.end);
+        }
+        for (const range of hideRangesForChallenge ?? []) {
+          if (range.start > pieceStart && range.start < pieceEnd)
+            boundaries.add(range.start);
+          if (range.end > pieceStart && range.end < pieceEnd)
+            boundaries.add(range.end);
+        }
+
+        const sortedBoundaries = Array.from(boundaries).sort((a, b) => a - b);
+        for (let index = 0; index < sortedBoundaries.length - 1; index += 1) {
+          const fragmentStart = sortedBoundaries[index];
+          const fragmentEnd = sortedBoundaries[index + 1];
+          if (fragmentStart === undefined || fragmentEnd === undefined)
+            continue;
+
+          const hidden =
+            entry !== undefined &&
+            getOverlap(fragmentStart, fragmentEnd, entry.start, entry.end);
+          const wasHidden = Boolean(
+            hideRangesForChallenge?.some((range) =>
+              getOverlap(fragmentStart, fragmentEnd, range.start, range.end),
+            ),
+          );
+          tokens.push({
+            text: sub.slice(
+              fragmentStart - pieceStart,
+              fragmentEnd - pieceStart,
+            ),
+            start: fragmentStart,
+            hidden,
+            hiddenGroupKey: hidden ? hiddenGroupKey : undefined,
+            revealed: wasHidden && !hidden,
+            dimmed:
+              audioRange !== undefined &&
+              (audioRange === 0 ||
+                (audioRange > 0 && audioRange < fragmentStart)),
+            hint,
+            hintGroupKey,
+          });
+        }
+      }
+    }
+  };
+
+  let textPos = 0;
+  for (const hint of visible.hintMap ?? []) {
+    if (hint.rangeFrom > textPos) pushRun(textPos, hint.rangeFrom);
+    const translation = visible.hints?.[hint.hintIndex];
+    const pronunciation = visible.hints_pronunciation?.[hint.hintIndex];
+    const hintGroupKey = translation
+      ? `hint:${hint.rangeFrom}:${hint.rangeTo}:${hint.hintIndex}`
+      : undefined;
+    pushRun(
+      hint.rangeFrom,
+      hint.rangeTo + 1,
+      translation ? { translation, pronunciation } : undefined,
+      hintGroupKey,
+    );
+    textPos = hint.rangeTo + 1;
+  }
+  if (textPos < visible.text.length) pushRun(textPos, visible.text.length);
+
+  return tokens;
+}

--- a/app-mobile/src/story/Part.tsx
+++ b/app-mobile/src/story/Part.tsx
@@ -209,6 +209,7 @@ function ContinuationPart({
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
           audioRangeOverride={settings.audioRangeOverride}
+          audioHighlightEnabled={false}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -274,6 +275,7 @@ function SelectPhrasesPart({
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
           audioRangeOverride={settings.audioRangeOverride}
+          audioHighlightEnabled={false}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>
@@ -334,6 +336,7 @@ function ArrangePart({ parts, setButtonStatus, active, settings }: PartProps) {
           autoPlay={settings.audioAutoPlay}
           replayKey={settings.audioReplayKey}
           audioRangeOverride={settings.audioRangeOverride}
+          audioHighlightEnabled={false}
           onManualAudioPlay={settings.onManualAudioPlay}
         />
       </FadeIn>

--- a/app-mobile/src/story/audioHighlightOwner.ts
+++ b/app-mobile/src/story/audioHighlightOwner.ts
@@ -1,0 +1,33 @@
+export type AudioHighlightOwner = symbol | null;
+type AudioHighlightOwnerListener = (owner: AudioHighlightOwner) => void;
+
+let currentOwner: AudioHighlightOwner = null;
+const listeners = new Set<AudioHighlightOwnerListener>();
+
+export function claimAudioHighlight(owner: symbol): void {
+  setAudioHighlightOwner(owner);
+}
+
+export function releaseAudioHighlight(owner: symbol): void {
+  if (currentOwner === owner) setAudioHighlightOwner(null);
+}
+
+export function ownsAudioHighlight(owner: symbol): boolean {
+  return currentOwner === owner;
+}
+
+export function subscribeToAudioHighlightOwner(
+  listener: AudioHighlightOwnerListener,
+): () => void {
+  listeners.add(listener);
+  listener(currentOwner);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function setAudioHighlightOwner(owner: AudioHighlightOwner): void {
+  if (currentOwner === owner) return;
+  currentOwner = owner;
+  for (const listener of [...listeners]) listener(owner);
+}

--- a/app-mobile/src/story/elements/TextLine.tsx
+++ b/app-mobile/src/story/elements/TextLine.tsx
@@ -130,6 +130,7 @@ export function TextLine({
   autoPlay = true,
   replayKey = 0,
   audioRangeOverride,
+  audioHighlightEnabled = true,
   onManualAudioPlay,
   debugNativeLayout = false,
 }: {
@@ -140,6 +141,7 @@ export function TextLine({
   autoPlay?: boolean;
   replayKey?: number;
   audioRangeOverride?: number;
+  audioHighlightEnabled?: boolean;
   onManualAudioPlay?: () => void;
   debugNativeLayout?: boolean;
 }) {
@@ -147,7 +149,9 @@ export function TextLine({
   const styles = React.useMemo(() => createStyles(colors), [colors]);
   const audio = element.line?.content?.audio;
   const lineAudio = useLineAudio(audio, active, autoPlay, replayKey);
-  const audioRange = audioRangeOverride ?? lineAudio.audioRange;
+  const audioRange = audioHighlightEnabled
+    ? (audioRangeOverride ?? lineAudio.audioRange)
+    : undefined;
   const handlePlay = React.useCallback(() => {
     onManualAudioPlay?.();
     lineAudio.play();

--- a/app-mobile/src/story/useLineAudio.ts
+++ b/app-mobile/src/story/useLineAudio.ts
@@ -1,12 +1,23 @@
 import React from "react";
+import { AppState } from "react-native";
+import {
+  claimAudioHighlight,
+  ownsAudioHighlight,
+  releaseAudioHighlight,
+  subscribeToAudioHighlightOwner,
+} from "./audioHighlightOwner";
 import { playAudio } from "./audio";
 import type { AudioInfo } from "./types";
 
-const IDLE_AUDIO_RANGE = 99999;
 const PENDING_AUDIO_RANGE = 0;
+const IDLE_AUDIO_RANGE = 99999;
 
-function getInitialAudioRange(audio: AudioInfo | undefined) {
-  return audio?.url ? PENDING_AUDIO_RANGE : IDLE_AUDIO_RANGE;
+function canHighlightAudio(audio: AudioInfo | undefined) {
+  return Boolean(audio?.url && audio.keypoints?.length);
+}
+
+function normalizeAudioRange(range: number) {
+  return range >= IDLE_AUDIO_RANGE ? undefined : range;
 }
 
 /**
@@ -20,8 +31,9 @@ export function useLineAudio(
   autoPlay: boolean,
   replayKey = 0,
 ) {
-  const [audioRange, setAudioRange] = React.useState(() =>
-    getInitialAudioRange(audio),
+  const highlightOwnerRef = React.useRef(Symbol("line-audio-highlight"));
+  const [audioRange, setAudioRange] = React.useState<number | undefined>(
+    undefined,
   );
   const cancelRef = React.useRef<((resetRange?: boolean) => void) | null>(null);
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -39,7 +51,8 @@ export function useLineAudio(
       clearScheduledPlay();
       cancelRef.current?.(reveal);
       cancelRef.current = null;
-      if (reveal) setAudioRange(IDLE_AUDIO_RANGE);
+      releaseAudioHighlight(highlightOwnerRef.current);
+      if (reveal) setAudioRange(undefined);
     },
     [clearScheduledPlay],
   );
@@ -50,19 +63,53 @@ export function useLineAudio(
 
   React.useEffect(() => {
     cancelLineAudio(true);
-    setAudioRange(getInitialAudioRange(audio));
+    if (!audio) return;
+    setAudioRange(undefined);
   }, [audio, cancelLineAudio]);
 
   React.useEffect(() => {
     if (!active) cancelLineAudio(true);
   }, [active, cancelLineAudio]);
 
+  React.useEffect(() => {
+    return subscribeToAudioHighlightOwner((owner) => {
+      if (owner !== highlightOwnerRef.current) setAudioRange(undefined);
+    });
+  }, []);
+
+  const beginHighlight = React.useCallback(() => {
+    if (!canHighlightAudio(audio)) {
+      releaseAudioHighlight(highlightOwnerRef.current);
+      setAudioRange(undefined);
+      return;
+    }
+    claimAudioHighlight(highlightOwnerRef.current);
+    setAudioRange(PENDING_AUDIO_RANGE);
+  }, [audio]);
+
+  const handleRange = React.useCallback((range: number) => {
+    if (!ownsAudioHighlight(highlightOwnerRef.current)) return;
+    const nextRange = normalizeAudioRange(range);
+    setAudioRange(nextRange);
+    if (nextRange === undefined)
+      releaseAudioHighlight(highlightOwnerRef.current);
+  }, []);
+
   const play = React.useCallback(() => {
     if (!active) skipNextAutoPlayRef.current = true;
     cancelLineAudio(false);
-    setAudioRange(getInitialAudioRange(audio));
-    cancelRef.current = playAudio(audio, { onRange: setAudioRange });
-  }, [active, audio, cancelLineAudio]);
+    beginHighlight();
+    cancelRef.current = playAudio(audio, {
+      onRange: handleRange,
+    });
+  }, [active, audio, beginHighlight, cancelLineAudio, handleRange]);
+
+  React.useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState !== "active") cancelLineAudio(true);
+    });
+    return () => subscription.remove();
+  }, [cancelLineAudio]);
 
   React.useEffect(() => {
     if (!active || !autoPlay) return;
@@ -71,16 +118,27 @@ export function useLineAudio(
       return;
     }
     cancelLineAudio(false);
-    setAudioRange(getInitialAudioRange(audio));
     timeoutRef.current = setTimeout(
       () => {
         timeoutRef.current = null;
-        cancelRef.current = playAudio(audio, { onRange: setAudioRange });
+        beginHighlight();
+        cancelRef.current = playAudio(audio, {
+          onRange: handleRange,
+        });
       },
       replayKey > 0 ? 0 : 350,
     );
     return clearScheduledPlay;
-  }, [active, autoPlay, audio, replayKey, cancelLineAudio, clearScheduledPlay]);
+  }, [
+    active,
+    autoPlay,
+    audio,
+    replayKey,
+    beginHighlight,
+    cancelLineAudio,
+    clearScheduledPlay,
+    handleRange,
+  ]);
 
   return { audioRange, play, hasAudio: Boolean(audio?.url) };
 }


### PR DESCRIPTION
## Summary

- prevent arrange/select/continuation challenge text from being dimmed by audio highlighting while the learner is answering
- replace per-line-only dimming with a shared audio highlight owner, so only one mounted line can own keypoint dimming at a time
- clear audio highlight ownership when audio is cancelled, the line becomes inactive, or the app backgrounds
- move hint token building into a pure module and add regression tests for dimmed-token behavior

## Root Cause

Audio keypoint highlighting was stored independently inside each mounted line. Challenge lines that remain visible during answering could still receive audio ranges, and interrupted playback could leave stale ranges behind. Because there was no shared owner for highlight state, the code did not structurally enforce the rule that only the currently playing line may be dimmed.

## Readability Pass

The shared-owner bookkeeping now lives in `audioHighlightOwner.ts`, leaving `useLineAudio` focused on playback lifecycle. The large token-building function was moved out of `HintText.tsx` into `HintTextTokens.ts`, which makes the renderer smaller and gives tests a pure seam.

## Validation

- `pnpm --dir app-mobile format`
- `pnpm --dir app-mobile lint`
- `pnpm --dir app-mobile typecheck`
- `pnpm test:mobile`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved audio highlighting so playback highlights are coordinated and cleared correctly when playback stops, app activity changes, or another highlight begins.
  - Added support for disabling audio highlighting in selected challenge activities while keeping audio playback available.
  - Improved hint text rendering for hidden, revealed, dimmed, translation, and pronunciation states.

- **Bug Fixes**
  - Prevented stale or conflicting audio highlights from remaining visible.

- **Tests**
  - Added coverage for hint text dimming behavior during and outside audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->