### PR TITLE
Fix audio dimming regressions

### DIFF
--- a/app-mobile/app/debug/story-shot.tsx
+++ b/app-mobile/app/debug/story-shot.tsx
@@ -3,6 +3,7 @@ import { ScrollView, StyleSheet, View } from "react-native";
 import { useLocalSearchParams } from "expo-router";
 import { Text } from "../../src/components/Text";
 import { QuestionPrompt } from "../../src/story/elements/QuestionPrompt";
+import { PointToPhraseQuestion } from "../../src/story/elements/PointToPhraseQuestion";
 import { SelectPhraseQuestion } from "../../src/story/elements/SelectPhraseQuestion";
 import { TextLine } from "../../src/story/elements/TextLine";
 import { HintPopupHost } from "../../src/story/HintPopup";
@@ -15,6 +16,7 @@ import type {
   ContentWithHints,
   HideRange,
   StoryElementLine,
+  StoryElementPointToPhrase,
   StoryElementSelectPhrase,
 } from "../../src/story/types";
 import { useTheme } from "../../src/theme";
@@ -145,6 +147,84 @@ const hiddenLatinLine: StoryElementLine = {
   },
 };
 
+function hiddenLineFixture({
+  text,
+  phrase,
+  lang,
+  lineIndex,
+  rtl = false,
+}: {
+  text: string;
+  phrase: string;
+  lang: string;
+  lineIndex: number;
+  rtl?: boolean;
+}): { element: StoryElementLine; rtl: boolean } {
+  return {
+    element: {
+      type: "LINE",
+      lang,
+      trackingProperties: {
+        line_index: lineIndex,
+        challenge_type: "select-phrases",
+      },
+      hideRangesForChallenge: [hiddenRange(text, phrase)],
+      line: {
+        type: "PROSE",
+        content: content({ text }),
+      },
+    },
+    rtl,
+  };
+}
+
+const hiddenRangeLines = [
+  hiddenLineFixture({
+    text: "We have a very important language exam tomorrow.",
+    phrase: "very important language exam",
+    lang: "en",
+    lineIndex: 10,
+  }),
+  hiddenLineFixture({
+    text: "Potřebuji klíče od svého auta.",
+    phrase: "klíče od svého auta",
+    lang: "cs",
+    lineIndex: 11,
+  }),
+  hiddenLineFixture({
+    text: "నా తాళం చెవులు ఎక్కడ ఉన్నాయి?",
+    phrase: "తాళం చెవులు",
+    lang: "te",
+    lineIndex: 12,
+  }),
+  hiddenLineFixture({
+    text: "אני צריך את המפתחות שלי.",
+    phrase: "המפתחות שלי",
+    lang: "he",
+    lineIndex: 13,
+    rtl: true,
+  }),
+  hiddenLineFixture({
+    text: "أحتاج إلى مفاتيح سيارتي.",
+    phrase: "مفاتيح سيارتي",
+    lang: "ar",
+    lineIndex: 14,
+    rtl: true,
+  }),
+  hiddenLineFixture({
+    text: "我需要我的车钥匙。",
+    phrase: "我的车钥匙",
+    lang: "zh",
+    lineIndex: 15,
+  }),
+  hiddenLineFixture({
+    text: "私は車の鍵が必要です。",
+    phrase: "車の鍵",
+    lang: "ja",
+    lineIndex: 16,
+  }),
+];
+
 const answers: StoryElementSelectPhrase = {
   type: "SELECT_PHRASE",
   lang: "cs",
@@ -153,13 +233,35 @@ const answers: StoryElementSelectPhrase = {
   correctAnswerIndex: 1,
 };
 
+const pointToPhraseQuestion: StoryElementPointToPhrase = {
+  type: "POINT_TO_PHRASE",
+  lang: "ast",
+  lang_question: "en",
+  trackingProperties: { line_index: 20, challenge_type: "point-to-phrase" },
+  question: content({ text: 'Choose the option that means "tired."' }),
+  correctAnswerIndex: 2,
+  transcriptParts: [
+    { selectable: true, text: "Perdón" },
+    { selectable: false, text: ", mio amor, " },
+    { selectable: true, text: "toi" },
+    { selectable: true, text: "cansada" },
+    { selectable: false, text: " -¡" },
+    { selectable: true, text: "Trabayo" },
+    { selectable: false, text: " enferma!" },
+  ],
+};
+
 function RealisticStoryFixture({
   includeLatinBlank,
+  showHiddenRangeMatrix,
+  showPointToPhrase,
   showRevealedBlank,
   showTeluguLine,
   debugTeluguLayout,
 }: {
   includeLatinBlank: boolean;
+  showHiddenRangeMatrix: boolean;
+  showPointToPhrase: boolean;
   showRevealedBlank: boolean;
   showTeluguLine: boolean;
   debugTeluguLayout: boolean;
@@ -219,7 +321,30 @@ function RealisticStoryFixture({
           autoPlay={false}
         />
       ) : null}
+      {showHiddenRangeMatrix ? (
+        <>
+          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+            Hidden range underline matrix
+          </Text>
+          {hiddenRangeLines.map(({ element, rtl }) => (
+            <TextLine
+              key={element.trackingProperties.line_index}
+              element={element}
+              active={false}
+              unhide={0}
+              rtl={rtl}
+              autoPlay={false}
+            />
+          ))}
+        </>
+      ) : null}
       <SelectPhraseQuestion element={answers} advance={() => {}} />
+      {showPointToPhrase ? (
+        <PointToPhraseQuestion
+          element={pointToPhraseQuestion}
+          advance={() => {}}
+        />
+      ) : null}
     </View>
   );
 }
@@ -228,6 +353,10 @@ export default function StoryShotScreen() {
   const { colors } = useTheme();
   const params = useLocalSearchParams<{ case?: string; debug?: string }>();
   const includeLatinBlank = params.case === "all" || params.case === "latin";
+  const showHiddenRangeMatrix =
+    params.case === "all" || params.case === "hide-ranges";
+  const showPointToPhrase =
+    params.case === "all" || params.case === "point-to-phrase";
   const showRevealedBlank = params.case === "all" || params.case === "revealed";
   const showTeluguLine = params.case === "all" || params.case === "telugu";
   const debugTeluguLayout = params.debug === "1";
@@ -244,6 +373,8 @@ export default function StoryShotScreen() {
         <ScrollView contentContainerStyle={styles.content}>
           <RealisticStoryFixture
             includeLatinBlank={includeLatinBlank}
+            showHiddenRangeMatrix={showHiddenRangeMatrix}
+            showPointToPhrase={showPointToPhrase}
             showRevealedBlank={showRevealedBlank}
             showTeluguLine={showTeluguLine}
             debugTeluguLayout={debugTeluguLayout}
@@ -296,6 +427,11 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: "800",
     marginBottom: 2,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: "800",
+    marginTop: 12,
   },
   footerFixture: {
     position: "absolute",

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -812,7 +812,7 @@ function NativeHintOverlay({
             y={cover.y}
             width={cover.width}
             height={cover.height}
-            fill={colors.surface}
+            fill={colors.background}
           />
         ))}
       {drawRangeDebug &&
@@ -1171,14 +1171,6 @@ function NativeHintText({
         containerStyle,
       ]}
     >
-      <NativeHintOverlay
-        hiddenCovers={[]}
-        debugRects={[]}
-        debugBaselines={[]}
-        underlineSegments={underlineSegments}
-        colors={colors}
-        drawCovers={false}
-      />
       <Text
         onLayout={(event) => {
           setTextLayout(event.nativeEvent.layout);
@@ -1259,9 +1251,8 @@ function NativeHintText({
         hiddenCovers={hiddenCovers}
         debugRects={debugRects}
         debugBaselines={debugBaselines}
-        underlineSegments={debugNativeLayout ? underlineSegments : []}
+        underlineSegments={underlineSegments}
         colors={colors}
-        drawUnderlines={false}
         drawRangeDebug={debugNativeLayout}
       />
       <View

--- a/app-mobile/src/story/elements/PointToPhraseQuestion.tsx
+++ b/app-mobile/src/story/elements/PointToPhraseQuestion.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
-import { colors, fontSizes } from "../../theme";
+import { fontSizes, type ThemeColors, useTheme } from "../../theme";
 import { Text } from "../../components/Text";
 import { WordChip } from "../WordChip";
 import { getLanguageTextStyle } from "../languageStyles";
@@ -16,6 +16,8 @@ export function PointToPhraseQuestion({
   element: StoryElementPointToPhrase;
   advance: () => void;
 }) {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
   // Dense button index -> transcript part index (only selectable parts).
   const buttonIndices: number[] = [];
   for (let index = 0; index < element.transcriptParts.length; index++) {
@@ -63,16 +65,18 @@ export function PointToPhraseQuestion({
   );
 }
 
-const styles = StyleSheet.create({
-  transcript: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    alignItems: "center",
-    marginTop: 6,
-  },
-  plainText: {
-    fontSize: fontSizes.body,
-    lineHeight: 38,
-    color: colors.text,
-  },
-});
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    transcript: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      alignItems: "center",
+      marginTop: 6,
+    },
+    plainText: {
+      fontSize: fontSizes.body,
+      lineHeight: 38,
+      color: colors.text,
+    },
+  });
+}

--- a/app-mobile/src/story/useLineAudio.ts
+++ b/app-mobile/src/story/useLineAudio.ts
@@ -118,10 +118,10 @@ export function useLineAudio(
       return;
     }
     cancelLineAudio(false);
+    beginHighlight();
     timeoutRef.current = setTimeout(
       () => {
         timeoutRef.current = null;
-        beginHighlight();
         cancelRef.current = playAudio(audio, {
           onRange: handleRange,
         });


### PR DESCRIPTION
## Summary

- restore hide-range underline visibility in the native hint text renderer
- make auto-play audio lines claim pending highlight immediately, so new lines start grayed before audio playback begins

## Root Cause

PR #612 made the audio highlight ownership stricter, but two visual details regressed:

- native hidden-text covers were drawn after the underline layer, which could cover the hide-range underline even though hidden text is already transparent
- auto-play lines only claimed the audio highlight inside the delayed playback callback, leaving a brief fully revealed state before the line became gray

## Validation

- `pnpm --dir app-mobile format`
- `pnpm --dir app-mobile lint`
- `pnpm --dir app-mobile typecheck`
- `pnpm test:mobile`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved native hint rendering by adjusting hidden cover styling and removing an extra initial overlay render to avoid visual artifacts.
  - Underline segments are now consistently configured, with range debug still controlled by the existing debug layout setting.
  - Highlighting now starts immediately when autoplay begins, reducing perceived delay before playback feedback.

- **New Features**
  - Expanded debug story fixture scenarios, including hidden-range underline matrix and point-to-phrase question options.

- **Refactor**
  - Updated point-to-phrase question styling to derive colors from the current app theme for consistent theming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->