### PR TITLE
Handle POINT_TO_PHRASE questions with no tappable options

### DIFF
--- a/app-mobile/src/story/Part.tsx
+++ b/app-mobile/src/story/Part.tsx
@@ -359,20 +359,26 @@ function PointToPhrasePart({
   active,
   settings,
 }: PartProps) {
+  const line = parts[0] as StoryElementLine;
+  const question = parts[1] as StoryElementPointToPhrase | undefined;
+  // Broken story data can produce a question with nothing to tap; treat it
+  // like a plain line so the reader is not stuck without a correct answer.
+  const skipQuestion =
+    settings.hideQuestions ||
+    !question?.transcriptParts?.some((part) => part.selectable);
+
   React.useEffect(() => {
     if (!active) return;
-    if (settings.hideQuestions) {
+    if (skipQuestion) {
       setButtonStatus("continue");
       return;
     }
     if (partProgress === 0) setButtonStatus("idle");
-  }, [active, partProgress, setButtonStatus, settings.hideQuestions]);
+  }, [active, partProgress, setButtonStatus, skipQuestion]);
 
   const showQuestion = active && partProgress === 1;
-  const line = parts[0] as StoryElementLine;
-  const question = parts[1] as StoryElementPointToPhrase;
 
-  if (settings.hideQuestions) {
+  if (skipQuestion) {
     return (
       <FadeIn>
         <TextLine
@@ -403,7 +409,7 @@ function PointToPhrasePart({
           />
         </FadeIn>
       )}
-      {showQuestion && (
+      {showQuestion && question && (
         <FadeIn>
           <PointToPhraseQuestion
             element={question}

--- a/src/components/StoryChallengePointToPhrase/StoryChallengePointToPhrase.tsx
+++ b/src/components/StoryChallengePointToPhrase/StoryChallengePointToPhrase.tsx
@@ -5,6 +5,7 @@ import FadeGlideIn from "../FadeGlideIn";
 import {
   StoryElement,
   StoryElementLine,
+  StoryElementPointToPhrase,
 } from "@/components/editor/story/syntax_parser_types";
 import { StorySettings } from "@/components/StoryProgress";
 
@@ -23,19 +24,26 @@ function StoryChallengePointToPhrase({
   hidden: boolean;
   settings: StorySettings;
 }) {
+  const question = parts[1] as StoryElementPointToPhrase | undefined;
+  // Broken story data can produce a question with nothing to tap; treat it
+  // like a plain line so the reader is not stuck without a correct answer.
+  const skip_question =
+    settings.hide_questions ||
+    !question?.transcriptParts?.some((part) => part.selectable);
+
   React.useEffect(() => {
     if (!active) return;
-    if (settings.hide_questions) {
+    if (skip_question) {
       setButtonStatus("continue");
       return;
     }
     if (partProgress === 0) setButtonStatus("idle");
-  }, [active, partProgress, setButtonStatus, settings.hide_questions]);
+  }, [active, partProgress, setButtonStatus, skip_question]);
 
   const id = React.useId();
   const show_question = active && partProgress === 1;
 
-  if (settings.hide_questions) {
+  if (skip_question) {
     return (
       <FadeGlideIn
         key={`${id}-1`}

--- a/src/components/editor/story/parser.test.ts
+++ b/src/components/editor/story/parser.test.ts
@@ -312,6 +312,43 @@ Speaker414: 今日{ちゅー} 何{ぬー}?
   assert.equal(story.elements[1]?.line.content.text, "今日 何?");
 });
 
+test("POINT_TO_PHRASE without tappable options emits an error and keeps the line", () => {
+  const story = parseStory(
+    `[POINT_TO_PHRASE]
+> Choose the option that means "help."
+Speaker414: تَمَام أَحْتَاج~إِلَى مُسَاعِدَة
+~             perfect     I~need      help`,
+    "en",
+    "ar",
+  );
+
+  assert.equal(story.elements.length, 2);
+  assert.equal(story.elements[0]?.type, "ERROR");
+  assert.equal(story.elements[0]?.errorKind, "parse");
+  assert.match(story.elements[0]?.text ?? "", /no tappable options/);
+  assert.equal(story.elements[1]?.type, "LINE");
+});
+
+test("POINT_TO_PHRASE with marked options parses into a question", () => {
+  const story = parseStory(
+    `[POINT_TO_PHRASE]
+> Choose the option that means "help."
+Speaker414: (تَمَام) (أَحْتَاج~إِلَى) (+مُسَاعِدَة)
+~             perfect     I~need      help`,
+    "en",
+    "ar",
+  );
+
+  assert.equal(story.elements.length, 2);
+  assert.equal(story.elements[0]?.type, "LINE");
+  assert.equal(story.elements[1]?.type, "POINT_TO_PHRASE");
+  assert.equal(story.elements[1]?.correctAnswerIndex, 2);
+  assert.equal(
+    story.elements[1]?.transcriptParts.filter((part) => part.selectable).length,
+    3,
+  );
+});
+
 test("editor block anchors use the block header line and keep the text line active", () => {
   const story = parseStory(`[DATA]
 fromLanguageName=Good Morning

--- a/src/components/editor/story/syntax_parser_new.ts
+++ b/src/components/editor/story/syntax_parser_new.ts
@@ -1135,6 +1135,25 @@ function processBlockPointToPhrase(
     data.text ?? "",
   );
 
+  const hasSelectablePart =
+    Array.isArray(transcriptParts) &&
+    transcriptParts.some((part) => part.selectable);
+  if (!hasSelectablePart) {
+    pushStoryErrorData(story, {
+      message:
+        "The [POINT_TO_PHRASE] line has no tappable options. Wrap each option in parentheses and mark the correct one with a plus, e.g. (word) (+correct word).",
+      errorKind: "parse",
+      sourceLine: data.text,
+      lineNumber: data.text_lineno,
+      editor: {
+        block_start_no: start_no,
+        start_no: start_no2,
+        end_no: line_iter.get_lineno(),
+        active_no: data.text_lineno,
+      },
+    });
+  }
+
   story.elements.push({
     type: "LINE",
     hideRangesForChallenge: data_text.hideRanges,
@@ -1151,19 +1170,21 @@ function processBlockPointToPhrase(
       active_no: start_no1,
     },
   } as StoryElementLine);
-  story.elements.push({
-    type: "POINT_TO_PHRASE",
-    correctAnswerIndex: correctAnswerIndex,
-    transcriptParts: transcriptParts,
-    question: question_data_text.content,
-    trackingProperties: {
-      line_index: story.meta.line_index,
-      challenge_type: "point-to-phrase",
-    },
-    lang_question: lang || story_languages.from_language,
-    lang: story_languages.learning_language,
-    editor: { start_no: start_no2, end_no: line_iter.get_lineno() },
-  } as StoryElementPointToPhrase);
+  if (hasSelectablePart) {
+    story.elements.push({
+      type: "POINT_TO_PHRASE",
+      correctAnswerIndex: correctAnswerIndex,
+      transcriptParts: transcriptParts,
+      question: question_data_text.content,
+      trackingProperties: {
+        line_index: story.meta.line_index,
+        challenge_type: "point-to-phrase",
+      },
+      lang_question: lang || story_languages.from_language,
+      lang: story_languages.learning_language,
+      editor: { start_no: start_no2, end_no: line_iter.get_lineno() },
+    } as StoryElementPointToPhrase);
+  }
   story.meta.line_index += 1;
 }
 


### PR DESCRIPTION
## Summary

A `[POINT_TO_PHRASE]` line without `(...)` markers parses into a question where no transcript part is selectable, so readers can never answer it and get hard-stuck. This was reported on Discord for the "help" question in *A New Coat* (story 2350, ar-en course), where the translated line lost its parentheses markers.

- **Parser** (`syntax_parser_new.ts`): a `[POINT_TO_PHRASE]` block with no tappable options now emits a structured editor error, keeps the spoken line, and no longer emits the unanswerable question element.
- **Web reader** (`StoryChallengePointToPhrase.tsx`): if a published question has no selectable parts, it falls back to the plain-line/continue behavior (same path as "hide questions"), so existing broken stories stay playable.
- **Mobile reader** (`app-mobile/src/story/Part.tsx`): same fallback in `PointToPhrasePart`.

## Testing

- Two new parser tests covering the error case and the correctly-marked case.
- `pnpm test` (101 pass), `pnpm run test:convex` (38 pass), `pnpm run test:mobile` (19 pass).
- `pnpm run typecheck` / lint clean for the touched files in both roots; mobile `pnpm --dir app-mobile typecheck` clean for `Part.tsx`.

The story content itself (2350 markers, 5930 untranslated Spanish tail) still needs fixing in the editor; this PR only prevents and defuses the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stories with point-to-phrase steps that have no selectable options now skip the question instead of becoming unusable.
  * The continue button now appears immediately when a question must be skipped.
  * Prevented empty point-to-phrase questions from rendering.

* **Editor Improvements**
  * Invalid point-to-phrase blocks now show a parsing error.
  * Valid blocks correctly preserve selectable options and answer information.

* **Tests**
  * Added coverage for valid and invalid point-to-phrase story blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->