### PR TITLE
Fix story reader dark mode and feedback key fallback

### DIFF
--- a/src/app/(stories)/story/[story_id]/StoryTranscript.tsx
+++ b/src/app/(stories)/story/[story_id]/StoryTranscript.tsx
@@ -50,7 +50,10 @@ export default function StoryTranscript({ story }: { story: StoryData }) {
   };
 
   return (
-    <section aria-labelledby="story-transcript-heading" className="pb-10">
+    <section
+      aria-labelledby="story-transcript-heading"
+      className="min-h-screen bg-[var(--body-background)] pb-10 text-[var(--text-color)]"
+    >
       <script
         type="application/ld+json"
         // Story text is contributor-controlled; escape "<" so no line can

--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -21,6 +21,7 @@ import {
   type FeedbackSubmitError,
   getFeedbackSubmitError,
 } from "./feedbackErrors";
+import { createOperationKey } from "@/lib/operation-key";
 
 type StoryFeedbackProps = {
   storyId: number;
@@ -63,9 +64,7 @@ export default function StoryFeedback({
   >("idle");
   const [submitError, setSubmitError] =
     React.useState<FeedbackSubmitError | null>(null);
-  const [operationKey, setOperationKey] = React.useState(() =>
-    crypto.randomUUID(),
-  );
+  const [operationKey, setOperationKey] = React.useState(createOperationKey);
   const isSubmitting = submitState === "submitting";
   const isSubmitted = submitState === "submitted";
   const terminalRejection = submitError?.canRetry === false;
@@ -78,7 +77,7 @@ export default function StoryFeedback({
       setSubmitError(null);
     } else {
       setComment("");
-      setOperationKey(crypto.randomUUID());
+      setOperationKey(createOperationKey());
     }
   }
 

--- a/src/components/StoryQuestionMultipleChoice/StoryQuestionMultipleChoice.tsx
+++ b/src/components/StoryQuestionMultipleChoice/StoryQuestionMultipleChoice.tsx
@@ -8,7 +8,6 @@ import StoryQuestionPrompt from "../StoryQuestionPrompt";
 import CheckButton from "../CheckButton";
 import { useChoiceButtons } from "@/hooks/use-choice-buttons.hook";
 import { StoryElementMultipleChoice } from "@/components/editor/story/syntax_parser_types";
-import { cn } from "@/lib/utils";
 
 /*
 The MULTIPLE_CHOICE question.
@@ -59,7 +58,7 @@ function StoryQuestionMultipleChoice({
       {/* Display the question if a question is there */}
       {element.question && <StoryQuestionPrompt question={element.question} />}
       {/* Display the answers */}
-      <ul className="list-none p-0 text-[#4b4b4b]">
+      <ul className="list-none p-0 text-[var(--text-color)]">
         {element.answers.map((answer, index) => (
           /* on answer field */
           <li

--- a/src/components/StoryTitlePage/StoryTitlePage.tsx
+++ b/src/components/StoryTitlePage/StoryTitlePage.tsx
@@ -30,7 +30,7 @@ function StoryTitlePage({
             alt={"title image"}
           />
         </div>
-        <div className="mt-[18px] mb-9 w-full text-center text-[25px] font-bold text-[#4b4b4b]">
+        <div className="mt-[18px] mb-9 w-full text-center text-[25px] font-bold text-[var(--text-color)]">
           {header.learningLanguageTitleContent.text}
         </div>
         <div className="pointer-events-auto w-full text-center">
@@ -41,7 +41,7 @@ function StoryTitlePage({
         {transcript.length > 0 ? (
           <details
             className={cn(
-              "pointer-events-auto mt-8 w-full max-w-[500px] rounded-2xl border-2 border-[#e5e5e5] bg-white px-4 py-3 text-left text-[#4b4b4b]",
+              "pointer-events-auto mt-8 w-full max-w-[500px] rounded-2xl border-2 border-[var(--color_base_border)] bg-[var(--color_base_background)] px-4 py-3 text-left text-[var(--text-color)]",
               story.learning_language_rtl && "[direction:rtl] text-right",
             )}
           >

--- a/src/lib/operation-key.test.ts
+++ b/src/lib/operation-key.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { createOperationKey } from "./operation-key";
+
+const originalCrypto = globalThis.crypto;
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: originalCrypto,
+  });
+});
+
+test("createOperationKey uses crypto.randomUUID when available", () => {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: {
+      randomUUID: () => "known-operation-key",
+    },
+  });
+
+  assert.equal(createOperationKey(), "known-operation-key");
+});
+
+test("createOperationKey falls back when crypto.randomUUID is unavailable", () => {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: {
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.set([
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+          0xbb, 0xcc, 0xdd, 0xee, 0xff,
+        ]);
+        return bytes;
+      },
+    },
+  });
+
+  assert.equal(createOperationKey(), "00112233-4455-4677-8899-aabbccddeeff");
+});

--- a/src/lib/operation-key.ts
+++ b/src/lib/operation-key.ts
@@ -1,0 +1,32 @@
+function bytesToUuid(bytes: Uint8Array) {
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10, 16).join(""),
+  ].join("-");
+}
+
+export function createOperationKey() {
+  const crypto = globalThis.crypto;
+
+  if (typeof crypto?.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  if (typeof crypto?.getRandomValues === "function") {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    return bytesToUuid(bytes);
+  }
+
+  return [
+    Date.now().toString(36),
+    Math.random().toString(36).slice(2),
+    Math.random().toString(36).slice(2),
+  ].join("-");
+}


### PR DESCRIPTION
## Summary

- Replace hard-coded light-mode text and panel colors in the story reader with existing theme tokens.
- Make the title page transcript drawer and no-JS transcript page respect dark mode.
- Add a browser-compatible operation key generator for story feedback so missing `crypto.randomUUID()` does not crash the reader.

## Root Cause

Some story reader surfaces used hard-coded gray/white colors instead of theme variables, so they stayed low-contrast or light in dark mode. Story feedback also called `crypto.randomUUID()` directly during render, which can be unavailable in non-secure browser contexts or older browsers.

## Validation

- `pnpm exec tsx --test src/lib/operation-key.test.ts`
- `pnpm run format`
- `pnpm typecheck`
- `pnpm test`
- `pnpm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme-aware styling across story transcripts, titles, feedback, and multiple-choice answers for improved visual consistency.

* **Bug Fixes**
  * Improved operation key generation across environments, including reliable fallbacks when standard browser UUID support is unavailable.

* **Tests**
  * Added coverage for standard and fallback operation key generation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->