### PR TITLE
Add widget-flag API endpoint for the iOS home widget

### DIFF
--- a/convex/landing.ts
+++ b/convex/landing.ts
@@ -350,6 +350,11 @@ const localizationEntryValidator = v.object({
 const publicCoursePageValidator = v.union(
   v.object({
     ...courseListItemValidator.fields,
+    // Flag identifiers for the learning language, used by the mobile
+    // next-story widget (which renders the flag server-side as a PNG).
+    learning_language_short: v.string(),
+    learning_language_flag: v.optional(v.union(v.number(), v.string())),
+    learning_language_flag_file: v.optional(v.string()),
     contributors: v.array(courseContributorValidator),
     contributors_past: v.array(courseContributorValidator),
     stories: v.array(publicStoryListItemValidator),
@@ -502,6 +507,9 @@ export const getPublicCoursePageData = query({
       learning_language: legacyLearningLanguageId,
       learningLanguageId: course.learningLanguageId as Id<"languages">,
       learning_language_name: learningLanguageName,
+      learning_language_short: learningLanguage?.short ?? "",
+      learning_language_flag: learningLanguage?.flag,
+      learning_language_flag_file: learningLanguage?.flag_file ?? undefined,
       contributors: contributorLists.contributors,
       contributors_past: contributorLists.contributors_past,
       stories: mappedStories,

--- a/src/app/api/widget-flag/route.tsx
+++ b/src/app/api/widget-flag/route.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { ImageResponse } from "next/og";
+import type { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+// Order of flags in the Duolingo CloudFront sprite sheet. Mirrors the
+// client Flag components (src/components/ui/flag.tsx, app-mobile Flag.tsx)
+// and the og-course route so the widget flag matches the rest of the site.
+const FLAG_ORDER = [
+  "en",
+  "es",
+  "fr",
+  "de",
+  "ja",
+  "it",
+  "ko",
+  "zh",
+  "ru",
+  "pt",
+  "tr",
+  "nl",
+  "sv",
+  "ga",
+  "el",
+  "he",
+  "pl",
+  "no",
+  "vi",
+  "da",
+  "hv",
+  "ro",
+  "sw",
+  "eo",
+  "hu",
+  "cy",
+  "uk",
+  "tlh",
+  "cs",
+  "hi",
+  "id",
+  "hw",
+  "nv",
+  "ar",
+  "ca",
+  "th",
+  "gn",
+  "world",
+  "duo",
+  "tools",
+  "reader",
+  "la",
+  "gd",
+  "fi",
+  "yi",
+  "ht",
+  "tl",
+  "zu",
+];
+
+const SPRITE_URL =
+  "https://d35aaqx5ub95lt.cloudfront.net/vendor/87938207afff1598611ba626a8c4827c.svg";
+const CUSTOM_FLAG_BASE = "https://duostories.org/flags";
+const SQUARE_CUSTOM_FLAG_FILES = new Set(["flag_gsw.svg"]);
+
+function getFlagId(iso: string | null, flag: number | null): number {
+  let index = 0;
+  if (iso) {
+    const found = FLAG_ORDER.indexOf(iso);
+    if (found >= 0) index = found;
+  }
+  if (index === 0 && iso !== "en") {
+    index = flag && flag > 0 && flag < 48 ? flag : 37; // "world" fallback
+  }
+  return index;
+}
+
+// Rendered at 3x the sprite's base cell so the widget can downscale crisply.
+const SCALE = 3;
+const CELL_W = 82 * SCALE;
+const CELL_H = 66 * SCALE;
+const RADIUS = 16 * SCALE;
+const SPRITE_TOTAL_H = 66 * 48 * SCALE;
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const flagFile = searchParams.get("flag_file");
+    const iso = searchParams.get("lang");
+    const flagParam = searchParams.get("flag");
+    const flagNumber = flagParam !== null ? Number(flagParam) : null;
+
+    if (flagFile) {
+      const isSquare = SQUARE_CUSTOM_FLAG_FILES.has(flagFile);
+      const width = isSquare ? CELL_H : CELL_W;
+      return new ImageResponse(
+        <div
+          style={{
+            display: "flex",
+            width,
+            height: CELL_H,
+            borderRadius: RADIUS,
+            overflow: "hidden",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`${CUSTOM_FLAG_BASE}/${flagFile}`}
+            width={width}
+            height={CELL_H}
+            alt=""
+          />
+        </div>,
+        { width, height: CELL_H },
+      );
+    }
+
+    const flagOffset = getFlagId(
+      iso,
+      Number.isFinite(flagNumber) ? (flagNumber as number) : null,
+    );
+
+    return new ImageResponse(
+      <div
+        style={{
+          display: "flex",
+          width: CELL_W,
+          height: CELL_H,
+          borderRadius: RADIUS,
+          overflow: "hidden",
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: `0px -${CELL_H * flagOffset}px`,
+          backgroundSize: `${CELL_W}px ${SPRITE_TOTAL_H}px`,
+          backgroundImage: `url(${SPRITE_URL})`,
+        }}
+      />,
+      { width: CELL_W, height: CELL_H },
+    );
+  } catch {
+    return new Response("Failed to generate the flag", { status: 500 });
+  }
+}

--- a/src/app/api/widget-flag/route.tsx
+++ b/src/app/api/widget-flag/route.tsx
@@ -120,6 +120,8 @@ export async function GET(request: NextRequest) {
       Number.isFinite(flagNumber) ? (flagNumber as number) : null,
     );
 
+    // Satori ignores backgroundPosition offsets, so crop the sprite by
+    // rendering it as a full-height <img> shifted up inside a clipped box.
     return new ImageResponse(
       <div
         style={{
@@ -128,12 +130,22 @@ export async function GET(request: NextRequest) {
           height: CELL_H,
           borderRadius: RADIUS,
           overflow: "hidden",
-          backgroundRepeat: "no-repeat",
-          backgroundPosition: `0px -${CELL_H * flagOffset}px`,
-          backgroundSize: `${CELL_W}px ${SPRITE_TOTAL_H}px`,
-          backgroundImage: `url(${SPRITE_URL})`,
+          position: "relative",
         }}
-      />,
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={SPRITE_URL}
+          width={CELL_W}
+          height={SPRITE_TOTAL_H}
+          style={{
+            position: "absolute",
+            left: 0,
+            top: -CELL_H * flagOffset,
+          }}
+          alt=""
+        />
+      </div>,
       { width: CELL_W, height: CELL_H },
     );
   } catch {

--- a/src/app/api/widget-flag/route.tsx
+++ b/src/app/api/widget-flag/route.tsx
@@ -52,7 +52,9 @@ const FLAG_ORDER = [
   "la",
   "gd",
   "fi",
-  "yi",
+  // The sprite's Yiddish cell is misaligned; yi uses the custom
+  // flag_yi.svg instead. "yi_old" keeps the later sprite indices intact.
+  "yi_old",
   "ht",
   "tl",
   "zu",

--- a/src/app/api/widget-flag/route.tsx
+++ b/src/app/api/widget-flag/route.tsx
@@ -70,7 +70,10 @@ function getFlagId(iso: string | null, flag: number | null): number {
     if (found >= 0) index = found;
   }
   if (index === 0 && iso !== "en") {
-    index = flag && flag > 0 && flag < 48 ? flag : 37; // "world" fallback
+    index =
+      flag !== null && Number.isInteger(flag) && flag > 0 && flag < 48
+        ? flag
+        : 37; // "world" fallback
   }
   return index;
 }


### PR DESCRIPTION
## Summary
- New `/api/widget-flag` endpoint that serves a single course flag as a transparent PNG — sprite cell by `lang` iso (or numeric `flag` offset), or a custom `flag_file` SVG, with the same rounded-rect geometry as the site's Flag components.
- `getPublicCoursePageData` now returns `learning_language_short`, `learning_language_flag`, and `learning_language_flag_file` so the mobile app can request the right flag.

iOS widgets can't render SVG, so the flag must be rasterized server-side. Split out of #619 so the endpoint can be deployed and tested independently; the widget itself (in #619) treats the flag as optional until this is live.

## Test plan
- [ ] `/api/widget-flag?lang=da` returns a rounded Danish flag PNG (transparent corners)
- [ ] `/api/widget-flag?flag=19` returns the same via numeric offset
- [ ] `/api/widget-flag?flag_file=flag_gsw.svg` returns the square custom flag
- [ ] unknown iso falls back to the world flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Course page data now includes learning-language abbreviation, flag metadata, and optional custom flag assets.
  * Added on-demand widget flag image generation (Edge), supporting both custom flag files and sprite-based language flags.
* **Improvements**
  * Widget flag images are consistently rendered with correct sizing, cropping, and rounded styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->