### PR TITLE
Add spam and not relevant feedback statuses

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -43,6 +43,7 @@ import type * as roles from "../roles.js";
 import type * as storyApproval from "../storyApproval.js";
 import type * as storyDone from "../storyDone.js";
 import type * as storyFeedback from "../storyFeedback.js";
+import type * as storyFeedbackStatus from "../storyFeedbackStatus.js";
 import type * as storyPublicContent from "../storyPublicContent.js";
 import type * as storyRead from "../storyRead.js";
 import type * as storyTables from "../storyTables.js";
@@ -91,6 +92,7 @@ declare const fullApi: ApiFromModules<{
   storyApproval: typeof storyApproval;
   storyDone: typeof storyDone;
   storyFeedback: typeof storyFeedback;
+  storyFeedbackStatus: typeof storyFeedbackStatus;
   storyPublicContent: typeof storyPublicContent;
   storyRead: typeof storyRead;
   storyTables: typeof storyTables;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,5 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
+import { feedbackStatusValidator } from "./storyFeedbackStatus";
 
 const courseContributorDetailsValidator = v.object({
   legacyUserId: v.number(),
@@ -259,11 +260,7 @@ export default defineSchema({
     userId: v.union(v.string(), v.null()),
     userName: v.union(v.string(), v.null()),
     userEmail: v.union(v.string(), v.null()),
-    status: v.union(
-      v.literal("open"),
-      v.literal("reviewed"),
-      v.literal("resolved"),
-    ),
+    status: feedbackStatusValidator,
     createdAt: v.number(),
   })
     .index("by_story_id", ["storyId"])

--- a/convex/storyFeedback.test.ts
+++ b/convex/storyFeedback.test.ts
@@ -401,6 +401,28 @@ describe("course feedback stats", () => {
 
     await asContributor.mutation(api.storyFeedback.updateStoryFeedbackStatus, {
       reportId,
+      status: "not_relevant",
+    });
+
+    await t.run(async (ctx) => {
+      const [stats] = await ctx.db.query("course_feedback_stats").collect();
+      expect(stats.openCount).toBe(0);
+      expect(stats.reviewedCount).toBe(0);
+    });
+
+    await asContributor.mutation(api.storyFeedback.updateStoryFeedbackStatus, {
+      reportId,
+      status: "spam",
+    });
+
+    await t.run(async (ctx) => {
+      const [stats] = await ctx.db.query("course_feedback_stats").collect();
+      expect(stats.openCount).toBe(0);
+      expect(stats.reviewedCount).toBe(0);
+    });
+
+    await asContributor.mutation(api.storyFeedback.updateStoryFeedbackStatus, {
+      reportId,
       status: "resolved",
     });
 

--- a/convex/storyFeedback.ts
+++ b/convex/storyFeedback.ts
@@ -6,18 +6,17 @@ import { ConvexError, v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import { mutation, query, type MutationCtx } from "./_generated/server";
 import { requireAdmin, requireContributorOrAdmin } from "./lib/authorization";
+import {
+  type FeedbackStatus,
+  feedbackStatuses,
+  feedbackStatusValidator,
+} from "./storyFeedbackStatus";
 
 const feedbackCategoryValidator = v.union(
   v.literal("Text"),
   v.literal("Translation hints"),
   v.literal("Audio"),
   v.literal("Other"),
-);
-
-const feedbackStatusValidator = v.union(
-  v.literal("open"),
-  v.literal("reviewed"),
-  v.literal("resolved"),
 );
 
 const feedbackSourceValidator = v.union(
@@ -46,7 +45,6 @@ const feedbackReportValidator = v.object({
   createdAt: v.number(),
 });
 
-type FeedbackStatus = "open" | "reviewed" | "resolved";
 type CourseDoc = Doc<"courses">;
 type StoryContentDoc = Doc<"story_content">;
 
@@ -508,7 +506,7 @@ export const recomputeCourseFeedbackStats = mutation({
         const legacyStoryId = story.legacyId;
         if (legacyStoryId === undefined) continue;
 
-        for (const status of ["open", "reviewed", "resolved"] as const) {
+        for (const status of feedbackStatuses) {
           const reports = ctx.db
             .query("story_feedback_reports")
             .withIndex("by_story_and_status", (q) =>

--- a/convex/storyFeedbackStatus.ts
+++ b/convex/storyFeedbackStatus.ts
@@ -1,0 +1,19 @@
+import { v } from "convex/values";
+
+export const feedbackStatuses = [
+  "open",
+  "reviewed",
+  "resolved",
+  "not_relevant",
+  "spam",
+] as const;
+
+export type FeedbackStatus = (typeof feedbackStatuses)[number];
+
+export const feedbackStatusValidator = v.union(
+  v.literal("open"),
+  v.literal("reviewed"),
+  v.literal("resolved"),
+  v.literal("not_relevant"),
+  v.literal("spam"),
+);

--- a/src/app/editor/feedback/feedback_review_view.tsx
+++ b/src/app/editor/feedback/feedback_review_view.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import {
+  BanIcon,
   CheckCircle2Icon,
+  CircleOffIcon,
   CircleDotIcon,
   ExternalLinkIcon,
   EyeIcon,
@@ -9,7 +11,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import React from "react";
-import type { Id } from "@convex/_generated/dataModel";
+import type { Doc, Id } from "@convex/_generated/dataModel";
 import StoryTextLine from "@/components/StoryTextLine";
 import type { StorySettings } from "@/components/StoryProgress";
 import type { StoryElementLine } from "@/components/editor/story/syntax_parser_types";
@@ -17,7 +19,7 @@ import Button from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 
-export type FeedbackStatus = "open" | "reviewed" | "resolved";
+export type FeedbackStatus = Doc<"story_feedback_reports">["status"];
 
 export type FeedbackReport = {
   _id: Id<"story_feedback_reports">;
@@ -45,13 +47,9 @@ const statusOptions: Array<{
   { value: "open", label: "Open", icon: CircleDotIcon },
   { value: "reviewed", label: "Reviewed", icon: EyeIcon },
   { value: "resolved", label: "Resolved", icon: CheckCircle2Icon },
+  { value: "not_relevant", label: "Not relevant", icon: CircleOffIcon },
+  { value: "spam", label: "Spam", icon: BanIcon },
 ];
-
-const statusLabels: Record<FeedbackStatus, string> = {
-  open: "Open",
-  reviewed: "Reviewed",
-  resolved: "Resolved",
-};
 
 const sourceLabels = {
   web: "Web",
@@ -181,7 +179,7 @@ export default function FeedbackReviewView({
         <Spinner />
       ) : reports.length === 0 ? (
         <div className="rounded-[8px] border-2 border-[var(--overview-hr)] bg-[var(--body-background-faint)] px-5 py-8 text-center text-[var(--text-color-dim)]">
-          No {statusLabels[status].toLowerCase()} feedback reports.
+          No {getStatusLabel(status).toLowerCase()} feedback reports.
         </div>
       ) : (
         <>
@@ -274,7 +272,7 @@ function FeedbackReportRow({
               : report.category}
           </span>
           <span className="rounded-full bg-[var(--body-background-faint)] px-3 py-1 text-[0.78rem] font-bold text-[var(--text-color-dim)]">
-            {statusLabels[report.status]}
+            {getStatusLabel(report.status)}
           </span>
           <time className="text-[0.82rem] text-[var(--text-color-dim)]">
             {formatDateTime(report.createdAt)}
@@ -324,30 +322,17 @@ function FeedbackReportRow({
         </Link>
 
         <div className="grid grid-cols-2 gap-2 min-[900px]:grid-cols-1">
-          {report.status !== "open" ? (
-            <StatusButton
-              disabled={updating}
-              onClick={() => onSetStatus("open")}
-            >
-              Open
-            </StatusButton>
-          ) : null}
-          {report.status !== "reviewed" ? (
-            <StatusButton
-              disabled={updating}
-              onClick={() => onSetStatus("reviewed")}
-            >
-              Reviewed
-            </StatusButton>
-          ) : null}
-          {report.status !== "resolved" ? (
-            <StatusButton
-              disabled={updating}
-              onClick={() => onSetStatus("resolved")}
-            >
-              Resolved
-            </StatusButton>
-          ) : null}
+          {statusOptions.map((option) =>
+            report.status === option.value ? null : (
+              <StatusButton
+                key={option.value}
+                disabled={updating}
+                onClick={() => onSetStatus(option.value)}
+              >
+                {option.label}
+              </StatusButton>
+            ),
+          )}
         </div>
       </div>
     </article>
@@ -481,6 +466,12 @@ function StatusButton({
     >
       {disabled ? "Updating" : children}
     </Button>
+  );
+}
+
+function getStatusLabel(status: FeedbackStatus) {
+  return (
+    statusOptions.find((option) => option.value === status)?.label ?? status
   );
 }
 


### PR DESCRIPTION
## What changed

- add `Spam` and `Not relevant` as feedback moderation statuses
- expose both statuses in editor filters and report actions
- treat both as terminal outcomes that do not contribute to unresolved feedback counts
- centralize feedback status validation and derive the editor type from the Convex schema
- cover status transitions and course feedback statistics in Convex tests

## Why

Some learner feedback is spam or reflects a learner misconception rather than a defect in the story. Contributors need distinct outcomes for those reports instead of marking them generically resolved.

## Impact

Contributors can classify, filter, audit, and later re-open these reports without inflating unresolved feedback badges.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm test`
- `pnpm test:convex`
- `pnpm build`
- deployed successfully to the development Convex deployment

`pnpm test:mobile` could not collect tests in this worktree because mobile dependencies are not installed, leaving `expo/tsconfig.base` unresolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for “Not relevant” and “Spam” feedback report statuses.
  * Feedback status options, labels, icons, badges, and status-change actions now reflect all available statuses.
* **Bug Fixes**
  * Updated feedback statistics so non-active statuses are excluded from open and reviewed counts.
  * Standardized status validation across feedback reporting and review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->