### PR TITLE
Add web feedback line deep links

### DIFF
--- a/src/components/StoryFeedback/StoryFeedback.tsx
+++ b/src/components/StoryFeedback/StoryFeedback.tsx
@@ -26,6 +26,7 @@ import { createOperationKey } from "@/lib/operation-key";
 type StoryFeedbackProps = {
   storyId: number;
   line?: number;
+  lineIndex?: number;
   lineText?: string;
   lineElement?: StoryElementLine;
   settings: StorySettings;
@@ -45,6 +46,7 @@ type FeedbackCategory = (typeof feedbackCategories)[number]["value"];
 export default function StoryFeedback({
   storyId,
   line,
+  lineIndex,
   lineText,
   lineElement,
   settings,
@@ -141,6 +143,7 @@ export default function StoryFeedback({
                 operationKey,
                 source: "web",
                 line,
+                lineIndex,
                 lineText,
                 category,
                 comment,

--- a/src/components/StoryFeedback/feedbackContext.test.ts
+++ b/src/components/StoryFeedback/feedbackContext.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { StoryElement } from "@/components/editor/story/syntax_parser_types";
+import { getParts } from "@/components/StoryProgress/parts";
+import { getFeedbackLineIndex } from "./feedbackContext";
+
+function storyElement(
+  type: StoryElement["type"],
+  lineIndex: number,
+  sourceLineIndex?: number,
+) {
+  return {
+    type,
+    trackingProperties: {
+      line_index: lineIndex,
+      ...(type === "MULTIPLE_CHOICE"
+        ? { challenge_type: "multiple-choice" }
+        : {}),
+      ...(sourceLineIndex !== undefined
+        ? { source_line_index: sourceLineIndex }
+        : {}),
+    },
+  } as StoryElement;
+}
+
+test("web feedback uses the visible story element tracking index", () => {
+  const currentPart = [
+    storyElement("LINE", 4),
+    storyElement("MULTIPLE_CHOICE", 5),
+  ];
+
+  assert.equal(getFeedbackLineIndex(currentPart, 0), 4);
+  assert.equal(getFeedbackLineIndex(currentPart, 1), 5);
+});
+
+test("web feedback prefers the source tracking index used by the backend", () => {
+  const parts = getParts([
+    storyElement("LINE", 0),
+    storyElement("LINE", 1),
+    storyElement("CHALLENGE_PROMPT", 1),
+    storyElement("MULTIPLE_CHOICE", 1),
+    storyElement("LINE", 2),
+  ]);
+
+  assert.equal(parts[2][0].trackingProperties.line_index, 2);
+  assert.equal(getFeedbackLineIndex(parts[2], 0), 1);
+});
+
+test("web feedback omits the tracking index without a visible story element", () => {
+  assert.equal(getFeedbackLineIndex(undefined, 0), undefined);
+});

--- a/src/components/StoryFeedback/feedbackContext.test.ts
+++ b/src/components/StoryFeedback/feedbackContext.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { StoryElement } from "@/components/editor/story/syntax_parser_types";
 import { getParts } from "@/components/StoryProgress/parts";
-import { getFeedbackLineIndex } from "./feedbackContext";
+import { getFeedbackLineIndex } from "@/components/StoryFeedback/feedbackContext";
 
 function storyElement(
   type: StoryElement["type"],
@@ -33,6 +33,15 @@ test("web feedback uses the visible story element tracking index", () => {
   assert.equal(getFeedbackLineIndex(currentPart, 1), 5);
 });
 
+test("web feedback prefers the source index on the visible challenge", () => {
+  const currentPart = [
+    storyElement("LINE", 4),
+    storyElement("MULTIPLE_CHOICE", 5, 2),
+  ];
+
+  assert.equal(getFeedbackLineIndex(currentPart, 1), 2);
+});
+
 test("web feedback prefers the source tracking index used by the backend", () => {
   const parts = getParts([
     storyElement("LINE", 0),
@@ -48,4 +57,10 @@ test("web feedback prefers the source tracking index used by the backend", () =>
 
 test("web feedback omits the tracking index without a visible story element", () => {
   assert.equal(getFeedbackLineIndex(undefined, 0), undefined);
+});
+
+test("web feedback ignores a visible element without tracking metadata", () => {
+  const untrackedElement = { type: "LINE" } as StoryElement;
+
+  assert.equal(getFeedbackLineIndex([untrackedElement], 0), undefined);
 });

--- a/src/components/StoryFeedback/feedbackContext.ts
+++ b/src/components/StoryFeedback/feedbackContext.ts
@@ -14,11 +14,8 @@ export function getFeedbackLineIndex(
       lastElement.type === "POINT_TO_PHRASE")
       ? lastElement
       : currentPart[0];
-  const sourceLineIndex = (
-    visibleElement.trackingProperties as {
-      source_line_index?: number;
-    }
-  ).source_line_index;
+  const trackingProperties = visibleElement.trackingProperties;
+  if (!trackingProperties) return undefined;
 
-  return sourceLineIndex ?? visibleElement.trackingProperties.line_index;
+  return trackingProperties.source_line_index ?? trackingProperties.line_index;
 }

--- a/src/components/StoryFeedback/feedbackContext.ts
+++ b/src/components/StoryFeedback/feedbackContext.ts
@@ -1,0 +1,24 @@
+import type { StoryElement } from "@/components/editor/story/syntax_parser_types";
+
+export function getFeedbackLineIndex(
+  currentPart: StoryElement[] | undefined,
+  partProgress: number,
+) {
+  if (!currentPart?.length) return undefined;
+
+  const lastElement = currentPart.at(-1);
+  const visibleElement =
+    partProgress > 0 &&
+    lastElement &&
+    (lastElement.type === "MULTIPLE_CHOICE" ||
+      lastElement.type === "POINT_TO_PHRASE")
+      ? lastElement
+      : currentPart[0];
+  const sourceLineIndex = (
+    visibleElement.trackingProperties as {
+      source_line_index?: number;
+    }
+  ).source_line_index;
+
+  return sourceLineIndex ?? visibleElement.trackingProperties.line_index;
+}

--- a/src/components/StoryProgress/StoryProgress.tsx
+++ b/src/components/StoryProgress/StoryProgress.tsx
@@ -12,10 +12,11 @@ import StoryHeader from "../StoryHeader";
 import StoryHeaderProgress from "../StoryHeaderProgress";
 import StoryFooter from "../StoryFooter";
 import StoryFeedback from "../StoryFeedback/StoryFeedback";
-import { getFeedbackLineIndex } from "../StoryFeedback/feedbackContext";
 import StoryFinishedScreen from "../StoryFinishedScreen";
 import StoryTitlePage from "../StoryTitlePage";
 import { playSoundEffect } from "@/lib/sound-effects";
+import { getFeedbackLineIndex } from "@/components/StoryFeedback/feedbackContext";
+import { getParts } from "@/components/StoryProgress/parts";
 import {
   StoryElement,
   StoryElementHeader,
@@ -24,7 +25,6 @@ import {
 import { StoryData } from "@/app/(stories)/story/[story_id]/getStory";
 import { isTypingTarget } from "@/lib/is-typing-target";
 import { cn } from "@/lib/utils";
-import { getParts } from "./parts";
 
 function getComponent(parts: StoryElement[]) {
   const last_part = parts[parts.length - 1];

--- a/src/components/StoryProgress/StoryProgress.tsx
+++ b/src/components/StoryProgress/StoryProgress.tsx
@@ -12,10 +12,10 @@ import StoryHeader from "../StoryHeader";
 import StoryHeaderProgress from "../StoryHeaderProgress";
 import StoryFooter from "../StoryFooter";
 import StoryFeedback from "../StoryFeedback/StoryFeedback";
+import { getFeedbackLineIndex } from "../StoryFeedback/feedbackContext";
 import StoryFinishedScreen from "../StoryFinishedScreen";
 import StoryTitlePage from "../StoryTitlePage";
 import { playSoundEffect } from "@/lib/sound-effects";
-import { StoryType } from "@/components/editor/story/syntax_parser_new";
 import {
   StoryElement,
   StoryElementHeader,
@@ -24,6 +24,7 @@ import {
 import { StoryData } from "@/app/(stories)/story/[story_id]/getStory";
 import { isTypingTarget } from "@/lib/is-typing-target";
 import { cn } from "@/lib/utils";
+import { getParts } from "./parts";
 
 function getComponent(parts: StoryElement[]) {
   const last_part = parts[parts.length - 1];
@@ -107,33 +108,6 @@ function Line({
     );
   }
   return <div>error</div>;
-}
-
-function GetParts(story: StoryType) {
-  const parts: StoryElement[][] = [];
-  let last_id = -1;
-  for (let element of story.elements) {
-    if (element.trackingProperties === undefined) {
-      continue;
-    }
-    if (last_id !== element.trackingProperties.line_index) {
-      parts.push([]);
-      last_id = element.trackingProperties.line_index;
-    }
-    if (
-      element.type === "MULTIPLE_CHOICE" &&
-      (parts.at(-1)?.length ?? 0) > 1 &&
-      element.trackingProperties.challenge_type === "multiple-choice"
-    )
-      parts.push([]);
-    parts[parts.length - 1].push(element);
-  }
-  for (let i = 0; i < parts.length; i++) {
-    for (let j = 0; j < parts[i].length; j++) {
-      parts[i][j].trackingProperties.line_index = i;
-    }
-  }
-  return parts;
 }
 
 function getCharacter(parts: StoryElement[]) {
@@ -456,7 +430,7 @@ function StoryProgress({
 }) {
   const parts_list = React.useMemo(() => {
     if (providedPartsList) return providedPartsList;
-    if (story) return GetParts(story);
+    if (story) return getParts(story.elements);
     return undefined;
   }, [providedPartsList, story]);
   const initialStoryProgress = getInitialStoryProgress({
@@ -583,6 +557,10 @@ function StoryProgress({
     currentPart,
     partProgress,
   });
+  const currentFeedbackLineIndex = getFeedbackLineIndex(
+    currentPart,
+    partProgress,
+  );
   const currentFeedbackLineText = getFeedbackLineText(currentPart);
   const currentFeedbackLineElement = getFeedbackLineElement({
     currentPart,
@@ -739,6 +717,7 @@ function StoryProgress({
                 <StoryFeedback
                   storyId={story.id}
                   line={currentEditorLine}
+                  lineIndex={currentFeedbackLineIndex}
                   lineText={currentFeedbackLineText}
                   lineElement={currentFeedbackLineElement}
                   settings={settings}

--- a/src/components/StoryProgress/parts.ts
+++ b/src/components/StoryProgress/parts.ts
@@ -21,10 +21,7 @@ export function getParts(elements: StoryElement[]): StoryElement[][] {
 
   for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
     for (const element of parts[partIndex]) {
-      const trackingProperties = element.trackingProperties as {
-        line_index: number;
-        source_line_index?: number;
-      };
+      const trackingProperties = element.trackingProperties;
       trackingProperties.source_line_index ??= trackingProperties.line_index;
       trackingProperties.line_index = partIndex;
     }

--- a/src/components/StoryProgress/parts.ts
+++ b/src/components/StoryProgress/parts.ts
@@ -1,0 +1,34 @@
+import type { StoryElement } from "@/components/editor/story/syntax_parser_types";
+
+export function getParts(elements: StoryElement[]): StoryElement[][] {
+  const parts: StoryElement[][] = [];
+  let lastId = -1;
+  for (const element of elements) {
+    if (element.trackingProperties === undefined) continue;
+    if (lastId !== element.trackingProperties.line_index) {
+      parts.push([]);
+      lastId = element.trackingProperties.line_index;
+    }
+    if (
+      element.type === "MULTIPLE_CHOICE" &&
+      (parts.at(-1)?.length ?? 0) > 1 &&
+      element.trackingProperties.challenge_type === "multiple-choice"
+    ) {
+      parts.push([]);
+    }
+    parts[parts.length - 1].push(element);
+  }
+
+  for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+    for (const element of parts[partIndex]) {
+      const trackingProperties = element.trackingProperties as {
+        line_index: number;
+        source_line_index?: number;
+      };
+      trackingProperties.source_line_index ??= trackingProperties.line_index;
+      trackingProperties.line_index = partIndex;
+    }
+  }
+
+  return parts;
+}

--- a/src/components/editor/story/syntax_parser_types.ts
+++ b/src/components/editor/story/syntax_parser_types.ts
@@ -60,12 +60,18 @@ export type LineElement =
   | LineElementProse
   | LineElementTitle;
 
+type TrackingProperties<TLineIndex extends number = number> = {
+  line_index: TLineIndex;
+  source_line_index?: number;
+  [key: string]: unknown;
+};
+
 export type StoryElementHeader = {
   type: "HEADER";
   illustrationUrl: string;
   title: string;
   learningLanguageTitleContent: ContentWithHints;
-  trackingProperties: { line_index: 0 };
+  trackingProperties: TrackingProperties<0>;
   audio?: Audio;
   lang: string;
   editor: {
@@ -80,7 +86,7 @@ export type StoryElementLine = {
   type: "LINE";
   hideRangesForChallenge?: HideRange[];
   line: LineElement;
-  trackingProperties: { line_index: number; [key: string]: any };
+  trackingProperties: TrackingProperties;
   audio?: Audio;
   lang: string;
   editor: {
@@ -96,8 +102,7 @@ export type StoryElementMultipleChoice = {
   answers: (string | HintMapResult)[];
   correctAnswerIndex: number;
   question?: ContentWithHints;
-  trackingProperties: {
-    line_index: number;
+  trackingProperties: TrackingProperties & {
     challenge_type: "multiple-choice" | "continuation";
   };
   lang: string;
@@ -112,8 +117,7 @@ export type StoryElementMultipleChoice = {
 export type StoryElementChallengePrompt = {
   type: "CHALLENGE_PROMPT";
   prompt: ContentWithHints;
-  trackingProperties: {
-    line_index: number;
+  trackingProperties: TrackingProperties & {
     challenge_type: "select-phrases" | "continuation" | "arrange";
   };
   lang: string;
@@ -129,8 +133,7 @@ export type StoryElementSelectPhrase = {
   type: "SELECT_PHRASE";
   answers: (string | HintMapResult)[];
   correctAnswerIndex: number;
-  trackingProperties: {
-    line_index: number;
+  trackingProperties: TrackingProperties & {
     challenge_type: "select-phrases";
   };
   lang: string;
@@ -142,8 +145,7 @@ export type StoryElementArrange = {
   characterPositions?: number[];
   phraseOrder: number[];
   selectablePhrases: string[];
-  trackingProperties: {
-    line_index: number;
+  trackingProperties: TrackingProperties & {
     challenge_type: "arrange";
   };
   lang: string;
@@ -155,8 +157,7 @@ export type StoryElementPointToPhrase = {
   correctAnswerIndex: number;
   transcriptParts: { selectable: boolean; text: string }[];
   question: ContentWithHints;
-  trackingProperties: {
-    line_index: number;
+  trackingProperties: TrackingProperties & {
     challenge_type: "point-to-phrase";
   };
   lang_question: string;
@@ -173,8 +174,7 @@ export type StoryElementMatch = {
   type: "MATCH";
   fallbackHints: { phrase: string; translation: string }[];
   prompt: string;
-  trackingProperties: {
-    line_index: number;
+  trackingProperties: TrackingProperties & {
     challenge_type: "match";
   };
   lang: string;
@@ -200,8 +200,7 @@ export type StoryElementError = {
     end_no?: number;
     active_no?: number;
   };
-  trackingProperties: {
-    line_index: number;
+  trackingProperties: TrackingProperties & {
     challenge_type: "error";
   };
 };


### PR DESCRIPTION
## What changed

- preserve each web story element’s original tracking index before reader UI reindexing
- submit the active element’s tracking index with web feedback, matching mobile behavior
- add regression coverage for split multiple-choice challenges

## Why

Web feedback reports included the visible text but often omitted the canonical editor line. Public story content strips editor metadata, and the web reader did not send the surviving tracking index as mobile does. As a result, **Open in editor** could not deep-link to the reported line.

The backend already translates a public tracking index into the canonical editor line. This change supplies that index from web submissions and preserves it when story parts are regrouped.

## Impact

New web feedback reports now include the canonical editor line, so contributors can open the report directly at the relevant line in the story editor. Mobile behavior is unchanged.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm exec tsx --test src/components/StoryFeedback/feedbackContext.test.ts`
- `pnpm test`
- `pnpm test:convex`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story feedback can now be tied to an optional specific line within the source content, improving precision for interactive elements.
* **Bug Fixes**
  * Improved feedback attribution by deriving the correct source/visible line index when content is partitioned into parts and when backend-generated segments are present.
* **Tests**
  * Expanded test coverage for line-index selection across visible, backend-provided, and incomplete metadata scenarios.  
* **Refactor**
  * Introduced shared helpers for part building and standardized tracking property typing across story element definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->