### PR TITLE
Run codex without a shell tool in the review bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ discord_roles/log-archive/
 */skills/*
 skills/*
 __pycache__/
+discord_roles/.codex_home/

--- a/discord_roles/REVIEW_BOT.md
+++ b/discord_roles/REVIEW_BOT.md
@@ -51,16 +51,15 @@ user running the bot.
 
 ## Security notes
 
-- **Run the bot under a dedicated unix user** that cannot read other
-  services' secrets. This is a requirement, not a suggestion: the AI review
-  feeds *untrusted story text* into the Codex CLI. It runs with
-  `--sandbox read-only`, in an empty working directory, and with a prompt
-  instructing it to ignore instructions inside the story — but prompt-level
-  guards are soft, and read-only still means codex can READ any file the
-  unix user can read (including `~/.codex` credentials and the bot's own
-  `.env.local`).
-- Because of that, the Codex account used on the VPS should be a dedicated
-  one with a hard spend cap, not a personal account.
+- The AI review feeds *untrusted story text* into the Codex CLI, so all
+  codex invocations run with `--disable shell_tool`: codex has no
+  command-execution tool at all and cannot read local files, which makes
+  prompt injection in story text unable to exfiltrate anything from the
+  machine. `--sandbox read-only` and an empty working directory remain as
+  additional layers. Because of this, running under a normal user is
+  acceptable; a dedicated unix user is still nice-to-have defense in depth.
+- A spend cap on the Codex account is still recommended as a general
+  abuse backstop.
 - Bot output is scrubbed for every value from `.env.local` before posting,
   all messages are sent with `AllowedMentions.none()` (injected `@everyone`
   cannot ping), and error details only go to the bot log channel.

--- a/discord_roles/REVIEW_BOT.md
+++ b/discord_roles/REVIEW_BOT.md
@@ -55,9 +55,14 @@ user running the bot.
   codex invocations run with `--disable shell_tool`: codex has no
   command-execution tool at all and cannot read local files, which makes
   prompt injection in story text unable to exfiltrate anything from the
-  machine. `--sandbox read-only` and an empty working directory remain as
-  additional layers. Because of this, running under a normal user is
-  acceptable; a dedicated unix user is still nice-to-have defense in depth.
+  machine. Codex also runs with an isolated `CODEX_HOME`
+  (`discord_roles/.codex_home`, created automatically with a minimal config
+  and a symlink to the real `auth.json`), so the user's own
+  `~/.codex/config.toml` — including any MCP servers that would reintroduce
+  tools — is never inherited. `--sandbox read-only` and an empty working
+  directory remain as additional layers. Because of this, running under a
+  normal user is acceptable; a dedicated unix user is still nice-to-have
+  defense in depth.
 - A spend cap on the Codex account is still recommended as a general
   abuse backstop.
 - Bot output is scrubbed for every value from `.env.local` before posting,

--- a/discord_roles/discord_review_bot.py
+++ b/discord_roles/discord_review_bot.py
@@ -235,6 +235,12 @@ async def run_codex(prompt, timeout, schema=None):
                 "exec",
                 "--sandbox",
                 "read-only",
+                # remove the shell tool entirely: codex physically cannot run
+                # commands or read local files, so prompt injection in story
+                # text cannot exfiltrate anything from this machine (the
+                # review prompts are self-contained and need no tools)
+                "--disable",
+                "shell_tool",
                 # the empty temp dir is not a git repo; without this codex refuses
                 "--skip-git-repo-check",
                 "-m",

--- a/discord_roles/discord_review_bot.py
+++ b/discord_roles/discord_review_bot.py
@@ -15,6 +15,7 @@ here never affects role syncing.
 
 import asyncio
 import json
+import os
 import re
 import tempfile
 import time
@@ -224,6 +225,26 @@ Do not use tools or read files; everything you need is in this prompt."""
 
 codex_semaphore = asyncio.Semaphore(AI_REVIEW_CONCURRENCY)
 
+# Codex runs on untrusted story text, so it gets an isolated CODEX_HOME with
+# a minimal config instead of inheriting the user's ~/.codex configuration
+# (which could define MCP servers that reintroduce tools). Only the login
+# token is shared, via a symlink.
+CODEX_HOME = Path(__file__).parent / ".codex_home"
+
+
+def ensure_codex_home():
+    CODEX_HOME.mkdir(exist_ok=True)
+    (CODEX_HOME / "config.toml").write_text(
+        "# Minimal isolated codex config for the review bot.\n"
+        "# Deliberately empty: no MCP servers, no profiles, defaults only.\n",
+        encoding="utf-8",
+    )
+    auth = CODEX_HOME / "auth.json"
+    real_auth = Path.home() / ".codex" / "auth.json"
+    if not auth.exists() and real_auth.exists():
+        auth.symlink_to(real_auth)
+    return CODEX_HOME
+
 
 async def run_codex(prompt, timeout, schema=None):
     """Run the Codex CLI and return its final message (parsed if schema)."""
@@ -256,6 +277,7 @@ async def run_codex(prompt, timeout, schema=None):
             process = await asyncio.create_subprocess_exec(
                 *args,
                 cwd=tmpdir,
+                env={**os.environ, "CODEX_HOME": str(ensure_codex_home())},
                 # codex blocks waiting on a non-tty stdin if one is left open
                 stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,


### PR DESCRIPTION
Follow-up to #624, from the deployment discussion: the plan is to run the review bot under a normal user rather than a dedicated one.

The premise "codex without tool calls = no problem possible" needed hardening: our "do not use tools" prompt line is only a soft instruction — codex decides for itself, and injected story text could override it. Testing found:

- `-c tools.shell=false` is **silently ignored** by codex (a forceful prompt still made it attempt commands).
- `--disable shell_tool` genuinely removes the command-execution tool: under an adversarial override prompt codex reports it has no shell and cannot comply. Remaining tools (web search, plan bookkeeping) cannot read local files.

The bot now passes `--disable shell_tool` on every codex invocation (intent classification + AI review — both verified to work unchanged), and REVIEW_BOT.md downgrades the dedicated-user requirement to defense-in-depth advice accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Hardened automated story review by running Codex with shell/tool access disabled.
  * Added isolated Codex home at runtime to avoid inheriting user configuration that could reintroduce tools.
  * Updated security documentation to strengthen the threat model and clarify sandboxing and acceptable runtime user guidance, while retaining defense-in-depth recommendations.
* **Chores**
  * Updated version control ignore rules to exclude the generated isolated Codex home directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->