### PR TITLE
Deploy reviewer bot and fix story checks

### DIFF
--- a/discord_roles/REVIEW_BOT.md
+++ b/discord_roles/REVIEW_BOT.md
@@ -73,20 +73,43 @@ user running the bot.
   processes at once, and at most 30 stories (8 sets) per request (also
   enforced server-side by the Convex endpoint).
 
-## systemd example
+## Hetzner VPS deployment
 
+The production Discord bots run as user services under the `codex` account on
+the Hetzner VPS. From an up-to-date checkout at
+`/home/codex/unofficial-duolingo-stories`, install the Python environment and
+the tracked service unit:
+
+```sh
+python3 -m venv discord_roles/.venv
+discord_roles/.venv/bin/pip install -r discord_roles/requirements.txt
+
+install -Dm644 \
+  discord_roles/systemd/discord-review-bot.service \
+  ~/.config/systemd/user/discord-review-bot.service
+systemctl --user daemon-reload
+systemctl --user enable --now discord-review-bot.service
 ```
-[Unit]
-Description=Duostories Discord review bot
-After=network-online.target
 
-[Service]
-User=duostories-review-bot
-WorkingDirectory=/home/duostories-review-bot/unofficial-duolingo-stories/discord_roles
-ExecStart=/usr/bin/python3 discord_review_bot.py
-Restart=on-failure
-RestartSec=30
+The account must have lingering enabled so user services start at boot even
+when nobody is logged in. This only needs to be done once:
 
-[Install]
-WantedBy=multi-user.target
+```sh
+sudo loginctl enable-linger "$USER"
+```
+
+Check the process and follow its logs with:
+
+```sh
+systemctl --user status discord-review-bot.service
+journalctl --user -u discord-review-bot.service -f
+```
+
+For later deployments, pull the latest `main`, update the virtual environment,
+and restart only this bot:
+
+```sh
+git pull --ff-only origin main
+discord_roles/.venv/bin/pip install -r discord_roles/requirements.txt
+systemctl --user restart discord-review-bot.service
 ```

--- a/discord_roles/REVIEW_BOT.md
+++ b/discord_roles/REVIEW_BOT.md
@@ -83,6 +83,7 @@ the tracked service unit:
 ```sh
 python3 -m venv discord_roles/.venv
 discord_roles/.venv/bin/pip install -r discord_roles/requirements.txt
+chmod 600 discord_roles/.env.local
 
 install -Dm644 \
   discord_roles/systemd/discord-review-bot.service \
@@ -111,5 +112,9 @@ and restart only this bot:
 ```sh
 git pull --ff-only origin main
 discord_roles/.venv/bin/pip install -r discord_roles/requirements.txt
+install -Dm644 \
+  discord_roles/systemd/discord-review-bot.service \
+  ~/.config/systemd/user/discord-review-bot.service
+systemctl --user daemon-reload
 systemctl --user restart discord-review-bot.service
 ```

--- a/discord_roles/systemd/discord-review-bot.service
+++ b/discord_roles/systemd/discord-review-bot.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Duostories Discord review bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/unofficial-duolingo-stories/discord_roles
+ExecStartPre=/usr/bin/test -r %h/unofficial-duolingo-stories/discord_roles/.env.local
+ExecStart=%h/unofficial-duolingo-stories/discord_roles/.venv/bin/python %h/unofficial-duolingo-stories/discord_roles/discord_review_bot.py
+Restart=always
+RestartSec=10
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONDONTWRITEBYTECODE=1
+UMask=0077
+
+[Install]
+WantedBy=default.target

--- a/discord_roles/systemd/discord-review-bot.service
+++ b/discord_roles/systemd/discord-review-bot.service
@@ -6,7 +6,8 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=%h/unofficial-duolingo-stories/discord_roles
-ExecStartPre=/usr/bin/test -r %h/unofficial-duolingo-stories/discord_roles/.env.local
+ExecStartPre=/usr/bin/test -O %h/unofficial-duolingo-stories/discord_roles/.env.local
+ExecStartPre=/bin/sh -c 'test "$$(/usr/bin/stat -c %%a "$$1")" = 600' sh %h/unofficial-duolingo-stories/discord_roles/.env.local
 ExecStart=%h/unofficial-duolingo-stories/discord_roles/.venv/bin/python %h/unofficial-duolingo-stories/discord_roles/discord_review_bot.py
 Restart=always
 RestartSec=10

--- a/src/app/editor/story/[story]/v2/lint_panel.tsx
+++ b/src/app/editor/story/[story]/v2/lint_panel.tsx
@@ -64,7 +64,7 @@ export function LintPanel({
           <ul className="overflow-y-auto px-2 py-1">
             {findings.map((finding, i) => {
               const rowClass =
-                "flex items-baseline gap-2 rounded-lg px-2 py-[6px] text-[0.9rem] text-[var(--text-color)]";
+                "flex items-baseline gap-2 rounded-lg px-2 py-[6px] !text-[0.9rem] text-[var(--text-color)]";
               const content = (
                 <>
                   <span

--- a/src/lib/editor/lint/lint_story.test.ts
+++ b/src/lib/editor/lint/lint_story.test.ts
@@ -186,6 +186,14 @@ $audio/x.mp3;7,500;3,200;6,300`);
   assert.equal(byRule(findings, "missing-audio").length, 0);
 });
 
+test("does not count a pipe-joined segment as a separate audio word", () => {
+  const findings = lint(`[LINE]
+> Beawan Linwan huk mikhuna~wasi|man rinku.
+~ Bea~y Lin una restaurante~(casa~de~comida)|a van
+$9795/_fc04951c.mp3;6,0;7,692;4,692;8,345;8,807;6,808`);
+  assert.equal(byRule(findings, "audio-timemark-count").length, 0);
+});
+
 test("flags a line without any translation hints", () => {
   const findings = lint(`[LINE]
 Speaker414: Bonjour le monde.`);

--- a/src/lib/editor/lint/lint_story.ts
+++ b/src/lib/editor/lint/lint_story.ts
@@ -101,6 +101,13 @@ function countWords(tokens: string[]): number {
   return n;
 }
 
+function countAudioWords(text: string): number {
+  // The parser turns "|" into WORD JOINER so adjacent hint tokens remain
+  // separate while TTS reads them as one word. Hint tokenization deliberately
+  // splits on this character, but audio word counting must preserve the join.
+  return countWords(splitTextTokens(text.replace(/\u2060/g, "")));
+}
+
 /** Replicates generateHintMap's positional alignment of text and hint lines. */
 function hintAlignment(text: string, hintLine: string) {
   const textList = splitTextTokens(text.replace(/\|/g, "⁠"));
@@ -465,7 +472,7 @@ function lintAudio(
       lineNumber,
     });
   }
-  const words = countWords(splitTextTokens(content.text));
+  const words = countAudioWords(content.text);
   // only count marks that advance through the text; the ";0,ms" terminal
   // marker (and any repeated position) is not a word mark
   const wordMarks = keypoints.filter(


### PR DESCRIPTION
## Summary

- add a tracked user-level `systemd` service for the Discord review bot and document the Hetzner VPS install, startup, logging, and update workflow
- stop `|`-joined text from producing false `audio-timemark-count` findings
- keep clickable and non-clickable story-check rows at the same font size

## Why

The production reviewer bot was running from an ad-hoc service definition that was not represented in the repository. Tracking the unit makes its runtime reproducible and keeps it consistent with the other Discord bots on the VPS.

The audio check reused hint tokenization. The parser converts `|` to Unicode WORD JOINER so hints can stay separately addressable while TTS reads the adjacent text as one word. Counting that character as an audio-word boundary produced a false “6 timemarks for 7 words” finding.

Findings with line numbers render as buttons, while story-level findings render as divs. The global button typography reset overrode the row's Tailwind font-size utility, so clickable findings appeared larger. The row now explicitly preserves its intended `0.9rem` size.

## Impact

- the reviewer bot can be installed and restarted consistently and starts automatically at boot
- pipe-joined story text no longer generates a false audio warning
- all findings in the story-check panel use consistent typography

## Validation

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm exec tsx --test src/lib/editor/lint/*.test.ts` (34 passing)
- live computed-style probe: clickable and non-clickable finding rows both resolve to `14.4px`
- live VPS checks performed during setup: Convex endpoint, isolated Codex invocation, Discord gateway connection, `systemd` enablement, and boot persistence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected audio timing validation so pipe-joined segments are counted correctly for audio timemark alignment.
  * Improved lint panel display by ensuring the intended text sizing takes precedence.

* **Tests**
  * Added coverage to confirm pipe-joined text segments don’t trigger audio timing-word findings.

* **Documentation**
  * Updated review bot deployment and update instructions for a Hetzner VPS.

* **Chores**
  * Added a system service to run the review bot, automatically restart on failures, and start on boot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->