### PR TITLE
Preserve silence edits when joining audio segments

### DIFF
--- a/src/app/editor/story/[story]/audio-cutter-dialog.tsx
+++ b/src/app/editor/story/[story]/audio-cutter-dialog.tsx
@@ -47,6 +47,7 @@ import {
   detectSpeechSegmentsFromAnalysis,
   getKeepRangeEnd,
   getKeepRanges,
+  getJoinedSegmentSkipRanges,
   moveRangeWithinBounds,
   normalizeRanges,
   resizeRangeWithinBounds,
@@ -1828,6 +1829,9 @@ export default function AudioCutterDialog({
           ? targetId
           : activeId;
       const removedId = survivingId === activeId ? targetId : activeId;
+      const joinedSegments = segments.filter(
+        (segment) => segment.id === activeId || segment.id === targetId,
+      );
       const preservedLabel =
         labelsById[survivingId] || labelsById[removedId] || "";
 
@@ -1857,6 +1861,10 @@ export default function AudioCutterDialog({
             id: survivingId,
             start: mergedStart,
             end: mergedEnd,
+            skipRanges: getJoinedSegmentSkipRanges(joinedSegments, {
+              start: mergedStart,
+              end: mergedEnd,
+            }),
           }),
         );
         return sortSegments(next);
@@ -2928,6 +2936,11 @@ export default function AudioCutterDialog({
     const removedId = nextSegment.id;
     const mergedStart = Math.min(currentSegment.start, nextSegment.start);
     const mergedEnd = Math.max(currentSegment.end, nextSegment.end);
+    const joinedSkipRanges = getJoinedSegmentSkipRanges(
+      [currentSegment, nextSegment],
+      { start: mergedStart, end: mergedEnd },
+      true,
+    );
     const preservedLabel =
       labelsById[survivingId] || labelsById[removedId] || "";
 
@@ -2960,6 +2973,7 @@ export default function AudioCutterDialog({
           id: survivingId,
           start: mergedStart,
           end: mergedEnd,
+          skipRanges: joinedSkipRanges,
         }),
       ]),
     );

--- a/src/lib/editor/audio/segments.test.ts
+++ b/src/lib/editor/audio/segments.test.ts
@@ -10,6 +10,7 @@ import {
   getEffectiveSegmentDuration,
   getKeepRangeEnd,
   getKeepRanges,
+  getJoinedSegmentSkipRanges,
   getSegmentSkipRangesFromAnalysis,
   getTotalRangeDuration,
   mapPlayableOffsetToAbsoluteTime,
@@ -54,6 +55,36 @@ test("normalizeRanges sorts unsorted input", () => {
 test("normalizeRanges returns empty for empty/undefined input", () => {
   assert.deepEqual(normalizeRanges([], bounds), []);
   assert.deepEqual(normalizeRanges(undefined, bounds), []);
+});
+
+const segmentsToJoin: Segment[] = [
+  {
+    id: "first",
+    start: 0,
+    end: 4,
+    skipRanges: [{ start: 1.25, end: 1.75 }],
+  },
+  {
+    id: "second",
+    start: 6,
+    end: 10,
+    skipRanges: [{ start: 8, end: 9 }],
+  },
+];
+
+test("getJoinedSegmentSkipRanges preserves edits without cutting gaps by default", () => {
+  assert.deepEqual(getJoinedSegmentSkipRanges(segmentsToJoin, bounds), [
+    { start: 1.25, end: 1.75 },
+    { start: 8, end: 9 },
+  ]);
+});
+
+test("getJoinedSegmentSkipRanges can cut the gap for an explicit join", () => {
+  assert.deepEqual(getJoinedSegmentSkipRanges(segmentsToJoin, bounds, true), [
+    { start: 1.25, end: 1.75 },
+    { start: 4, end: 6 },
+    { start: 8, end: 9 },
+  ]);
 });
 
 test("moveRangeWithinBounds preserves duration and clamps at both edges", () => {

--- a/src/lib/editor/audio/segments.ts
+++ b/src/lib/editor/audio/segments.ts
@@ -92,6 +92,27 @@ export function normalizeRanges(
   return normalized;
 }
 
+export function getJoinedSegmentSkipRanges(
+  segments: Segment[],
+  bounds: TimeRange,
+  cutGaps = false,
+) {
+  const sorted = sortSegments(segments);
+  const ranges = sorted.flatMap((segment) => segment.skipRanges);
+
+  if (cutGaps) {
+    for (let index = 1; index < sorted.length; index += 1) {
+      const previous = sorted[index - 1];
+      const current = sorted[index];
+      if (previous && current && current.start > previous.end) {
+        ranges.push({ start: previous.end, end: current.start });
+      }
+    }
+  }
+
+  return normalizeRanges(ranges, bounds);
+}
+
 export function moveRangeWithinBounds(
   range: TimeRange,
   deltaSeconds: number,


### PR DESCRIPTION
## Summary

- preserve manually adjusted silence/cut ranges when audio segments are joined
- keep drag-to-merge gaps playable, matching the intent to expand the selected range
- convert gaps into cuts only for the explicit join action, preserving the original two selections
- add regression coverage for both join behaviors

## Root cause

Both join paths rebuilt the merged segment without passing its existing skip ranges. That caused automatic silence detection to replace manual edits.

## User impact

Admins can join audio without losing silence adjustments they already made. Dragging a region into another includes the intervening audio, while the explicit join command cuts the intervening gap.

## Validation

- pnpm test — 158 tests passed
- pnpm run lint
- pnpm typecheck
- pnpm run format
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio segment merging to preserve existing skip edits.
  * Ensured joined segments correctly handle gaps, with optional gap cutting when segments are explicitly joined.

* **Tests**
  * Added coverage for preserving skip ranges and inserting boundaries across joined gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->