### PR TITLE
Support danda punctuation in story hints

### DIFF
--- a/src/components/editor/story/parser.test.ts
+++ b/src/components/editor/story/parser.test.ts
@@ -263,6 +263,42 @@ Speaker414: hello`);
   assert.equal(element?.text, 'Unknown block type "NOT_A_BLOCK"');
 });
 
+test("LINE treats a spaced danda as sentence punctuation", () => {
+  const element = parseLine(`[LINE]
+Speaker414: କାମକୁ ଯିବାକୁ ପଡିବ ।
+~            to~work is~needed must`);
+
+  assert.equal(element?.type, "LINE");
+  assert.deepEqual(element?.line.content.hints, [
+    "to work",
+    "is needed",
+    "must",
+  ]);
+  assert.deepEqual(
+    element?.line.content.hintMap.map(
+      ({ rangeFrom, rangeTo }: { rangeFrom: number; rangeTo: number }) =>
+        element.line.content.text.slice(rangeFrom, rangeTo + 1),
+    ),
+    ["କାମକୁ", "ଯିବାକୁ", "ପଡିବ"],
+  );
+});
+
+test("LINE does not confuse double danda with danda punctuation", () => {
+  const element = parseLine(`[LINE]
+Speaker414: ଶବ୍ଦ ॥
+~            word marker`);
+
+  assert.equal(element?.type, "LINE");
+  assert.deepEqual(element?.line.content.hints, ["word", "marker"]);
+  assert.deepEqual(
+    element?.line.content.hintMap.map(
+      ({ rangeFrom, rangeTo }: { rangeFrom: number; rangeTo: number }) =>
+        element.line.content.text.slice(rangeFrom, rangeTo + 1),
+    ),
+    ["ଶବ୍ଦ", "॥"],
+  );
+});
+
 test("unknown blocks only emit one error and skip to the next valid block", () => {
   const [story] = processStoryFile(
     `[LINEX]

--- a/src/components/editor/story/syntax_parser_new.ts
+++ b/src/components/editor/story/syntax_parser_new.ts
@@ -327,7 +327,7 @@ function processBlockData(line_iter: LineIterator, story: StoryWithMeta) {
 }
 
 let punctuation_chars =
-  "\\/¡!\"'`#$%&*,.:;<=>¿?@^_`{|}…" + "。、，！？；：（）～—·《…》〈…〉﹏……——";
+  "\\/¡!\"'`#$%&*,.:;<=>¿?@^_`{|}…" + "。、，！？；：（）～—·《…》〈…〉﹏……——।";
 //punctuation_chars = "\\\\¡!\"#$%&*,、，.。\\/:：;<=>¿?@^_`{|}…"
 
 let regex_split_token = new RegExp(


### PR DESCRIPTION
## Summary

- Treat the Indian danda (`।`) as sentence punctuation during story hint tokenization
- Prevent a spaced danda from consuming an extra translation-hint slot
- Keep the double danda (`॥`) distinct
- Add Odia regression coverage for both characters

## Why

Odia and other Indic-language stories commonly write `।` with a preceding space. The story parser treated that character as a separate word, even though it serves the same sentence-ending role as a period, which shifted translation-hint alignment.

## Validation

- `pnpm run test` — 160 tests passed
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm run format`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text parsing and syntax highlighting for Hindi danda punctuation.
  * Correctly handles spaced danda punctuation and distinguishes double danda (`॥`) from single danda marks.
  * Ensures punctuation and word segments receive accurate prompt hints and text ranges.

* **Tests**
  * Added coverage for danda-related parsing and highlighting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->