### PR TITLE
Show split-word underline gaps

### DIFF
--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -28,14 +28,6 @@ const editorHintTextStyle: CSSProperties = {
   backgroundColor: "var(--editor-hints-background)",
   fontSize: "0.9em",
 };
-const tooltipContainerStyle = {
-  ...underlineBaseStyle,
-  "--story-hint-underline": "var(--underline-dashed)",
-  paddingBottom: "5px",
-  backgroundImage:
-    "linear-gradient(to right, var(--story-hint-underline) 60%, rgba(255, 255, 255, 0) 0%)",
-  outlineColor: "var(--tooltip-border)",
-} as CSSProperties;
 const tooltipContentStyle: CSSProperties = {
   bottom: "100%",
   left: "50%",
@@ -309,19 +301,17 @@ function StoryLineHints({
     const was_hidden_for_challenge = hideRangesForChallenge?.some((range) =>
       getOverlap(hint.rangeFrom, hint.rangeTo + 1, range.start, range.end),
     );
-    const inlineHintUnderlineStyle =
+    const hintUnderline =
       !showTrans &&
       has_translation_hint &&
       !is_hidden &&
       !was_hidden_for_challenge
-        ? tooltipContainerStyle
+        ? "hint"
         : undefined;
 
     const word_content = hint_pronunciation ? (
       <span className="group/pronunciation relative inline-block">
-        <span style={inlineHintUnderlineStyle}>
-          {addSplitWord(hint.rangeFrom, hint.rangeTo + 1)}
-        </span>
+        {addSplitWord(hint.rangeFrom, hint.rangeTo + 1)}
         <span
           className={cn(
             "pointer-events-none invisible absolute whitespace-nowrap leading-none opacity-0 transition-opacity duration-200",
@@ -342,9 +332,7 @@ function StoryLineHints({
         </span>
       </span>
     ) : (
-      <span style={inlineHintUnderlineStyle}>
-        {addSplitWord(hint.rangeFrom, hint.rangeTo + 1)}
-      </span>
+      addSplitWord(hint.rangeFrom, hint.rangeTo + 1)
     );
     const hintContainerClassName = is_hidden
       ? ""
@@ -355,6 +343,7 @@ function StoryLineHints({
         : has_translation_hint
           ? cn(
               "group/tooltip relative inline-block align-baseline",
+              hintUnderline && "story-hint-underline",
               "focus:outline-none focus-visible:rounded focus-visible:outline-2 focus-visible:outline-offset-2",
             )
           : "";
@@ -364,8 +353,6 @@ function StoryLineHints({
           "pointer-events-none invisible absolute block w-auto whitespace-nowrap text-center font-normal not-italic opacity-0 transition-opacity duration-300 group-hover/tooltip:visible group-hover/tooltip:opacity-100 group-focus-within/tooltip:visible group-focus-within/tooltip:opacity-100",
           visibleContent.lang_hints,
         );
-    const hintHasChallengeUnderline =
-      Boolean(was_hidden_for_challenge) || Boolean(is_hidden);
     const hintContainerStyle =
       showTrans && has_any_hint ? editorHintContainerStyle : undefined;
     const tooltipStyle =

--- a/src/components/ui/flag.tsx
+++ b/src/components/ui/flag.tsx
@@ -86,12 +86,8 @@ export default function Flag(props: {
   const height = Math.round(props.height ?? width * aspectRatio);
   const renderedWidth = isSquareCustomFlag ? height : width;
   const customScale = width / 88;
-  const outlineWidth = isCustomFlag
-      ? 7 * customScale
-      : 5 * scale;
-  const outlineOffset = isCustomFlag
-      ? -6 * customScale
-      : -6 * scale;
+  const outlineWidth = isCustomFlag ? 7 * customScale : 5 * scale;
+  const outlineOffset = isCustomFlag ? -6 * customScale : -6 * scale;
   const flagImageStyle: React.CSSProperties = {
     width: renderedWidth,
     height,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,6 +46,31 @@
   }
 }
 
+@layer components {
+  .story-hint-underline {
+    --story-hint-underline: var(--underline-dashed);
+    padding-bottom: 5px;
+    outline-color: var(--tooltip-border);
+  }
+
+  .story-hint-underline::after {
+    position: absolute;
+    right: 0.18em;
+    bottom: 5px;
+    left: 0.18em;
+    height: 2px;
+    background-image: linear-gradient(
+      to right,
+      var(--story-hint-underline) 60%,
+      transparent 0%
+    );
+    background-repeat: repeat-x;
+    background-size: 5px 2px;
+    content: "";
+    pointer-events: none;
+  }
+}
+
 .duostories_title {
   width: 160px;
   display: block;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -49,6 +49,7 @@
 @layer components {
   .story-hint-underline {
     --story-hint-underline: var(--underline-dashed);
+
     padding-bottom: 5px;
     outline-color: var(--tooltip-border);
   }


### PR DESCRIPTION
## Summary

- Move story hint underlines into a reusable CSS class with an inset pseudo-element so adjacent split-word hint ranges show a visible underline gap without adding extra text spacing.
- Keep single hint ranges visually continuous while simplifying the rendered hint DOM.
- Include Biome formatting cleanup for `src/components/ui/flag.tsx` after merging `main`.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`

## Screenshot

http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260727T184950Z-story-underline-after-bottom-fix.png

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved inline translation and pronunciation hints with a consistent custom underline using a shared utility class.
  * Kept hint, tooltip, and translation rendering and behavior the same.
  * Made minor formatting adjustments to flag outline/positioning logic without changing its look or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->