### PR TITLE
Add human-audio course tag to skip TTS-voice warnings

### DIFF
--- a/convex/lib/courseTags.ts
+++ b/convex/lib/courseTags.ts
@@ -1,7 +1,15 @@
 export const NO_AUDIO_COURSE_TAG = "no-audio";
+export const HUMAN_AUDIO_COURSE_TAG = "human-audio";
+
+function hasCourseTag(tags: readonly string[] | undefined, wanted: string) {
+  return (tags ?? []).some((tag) => tag.trim().toLowerCase() === wanted);
+}
 
 export function hasNoAudioCourseTag(tags: readonly string[] | undefined) {
-  return (tags ?? []).some(
-    (tag) => tag.trim().toLowerCase() === NO_AUDIO_COURSE_TAG,
-  );
+  return hasCourseTag(tags, NO_AUDIO_COURSE_TAG);
+}
+
+/** Audio is recorded by humans instead of generated with TTS. */
+export function hasHumanAudioCourseTag(tags: readonly string[] | undefined) {
+  return hasCourseTag(tags, HUMAN_AUDIO_COURSE_TAG);
 }

--- a/convex/storyReviewLint.ts
+++ b/convex/storyReviewLint.ts
@@ -9,7 +9,7 @@ import {
   lintStory,
   type LintFinding,
 } from "@/lib/editor/lint";
-import { hasNoAudioCourseTag } from "./lib/courseTags";
+import { hasHumanAudioCourseTag, hasNoAudioCourseTag } from "./lib/courseTags";
 import type { FunctionReturnType } from "convex/server";
 
 // Runs the story parser + lint for the Discord review bot. Lives in the Node
@@ -44,6 +44,7 @@ function lintOne(data: ReviewData, avatars: AvatarRows): ReviewResult {
   const avatarNames: Record<number, AvatarRows[number]> = {};
   for (const row of avatars) avatarNames[row.avatar_id] = row;
   const noAudio = hasNoAudioCourseTag(data.courseTags);
+  const humanAudio = hasHumanAudioCourseTag(data.courseTags);
 
   const [story, meta] = processStoryFile(
     data.text,
@@ -61,6 +62,7 @@ function lintOne(data: ReviewData, avatars: AvatarRows): ReviewResult {
     meta,
     learningLanguage: data.learningLanguageShort,
     noAudio,
+    humanAudio,
   });
   const parserErrors = story.elements.filter(
     (element) => element.type === "ERROR",

--- a/src/app/editor/story/[story]/v2/use_story_editor_model.ts
+++ b/src/app/editor/story/[story]/v2/use_story_editor_model.ts
@@ -10,7 +10,7 @@ import {
 import type { Avatar, StoryData } from "@/app/editor/story/[story]/types";
 import { retryOnceAfterAuthRefresh } from "./save_auth_retry";
 import { checkStoryLineAudio } from "./audio_problem_check";
-import { hasNoAudioCourseTag } from "@/lib/course-tags";
+import { hasHumanAudioCourseTag, hasNoAudioCourseTag } from "@/lib/course-tags";
 import { lintStory, type LintFinding } from "@/lib/editor/lint";
 
 type LanguageLike = {
@@ -235,6 +235,7 @@ export function useStoryEditorModel({
         meta: parsedMeta,
         learningLanguage: learningLanguage?.short,
         noAudio: hasNoAudioCourseTag(storyData.course_tags),
+        humanAudio: hasHumanAudioCourseTag(storyData.course_tags),
       }),
     [
       docText,

--- a/src/lib/course-tags.ts
+++ b/src/lib/course-tags.ts
@@ -1,7 +1,15 @@
 export const NO_AUDIO_COURSE_TAG = "no-audio";
+export const HUMAN_AUDIO_COURSE_TAG = "human-audio";
+
+function hasCourseTag(tags: readonly string[] | undefined, wanted: string) {
+  return (tags ?? []).some((tag) => tag.trim().toLowerCase() === wanted);
+}
 
 export function hasNoAudioCourseTag(tags: readonly string[] | undefined) {
-  return (tags ?? []).some(
-    (tag) => tag.trim().toLowerCase() === NO_AUDIO_COURSE_TAG,
-  );
+  return hasCourseTag(tags, NO_AUDIO_COURSE_TAG);
+}
+
+/** Audio is recorded by humans instead of generated with TTS. */
+export function hasHumanAudioCourseTag(tags: readonly string[] | undefined) {
+  return hasCourseTag(tags, HUMAN_AUDIO_COURSE_TAG);
 }

--- a/src/lib/editor/lint/lint_story.test.ts
+++ b/src/lib/editor/lint/lint_story.test.ts
@@ -26,7 +26,11 @@ const testAvatars = {
 
 function lint(
   text: string,
-  options: { learningLanguage?: string; noAudio?: boolean } = {},
+  options: {
+    learningLanguage?: string;
+    noAudio?: boolean;
+    humanAudio?: boolean;
+  } = {},
 ) {
   const [story, meta] = processStoryFile(
     text,
@@ -44,6 +48,7 @@ function lint(
     meta,
     learningLanguage: options.learningLanguage ?? "fr",
     noAudio: options.noAudio,
+    humanAudio: options.humanAudio,
   });
 }
 
@@ -346,6 +351,29 @@ Speaker414: Bonjour le monde.
   assert.equal(byRule(findings, "no-language-voices").length, 1);
   assert.equal(byRule(findings, "missing-audio").length, 0);
   assert.equal(byRule(findings, "speaker-no-voice").length, 0);
+});
+
+test("keeps audio rules but skips TTS-voice warnings in human-audio courses", () => {
+  const voicelessAvatars = {
+    0: { ...testAvatars[0], speaker: "" },
+    414: { ...testAvatars[414], speaker: "" },
+  };
+  const [story, meta] = processStoryFile(
+    `[LINE]
+Speaker414: Bonjour le monde.
+~ hello the world`,
+    0,
+    voicelessAvatars,
+    { learning_language: "fr", from_language: "en" },
+    "",
+  );
+  const findings = lintStory({ text: "", story, meta, humanAudio: true });
+  assert.equal(byRule(findings, "no-language-voices").length, 0);
+  assert.equal(byRule(findings, "speaker-no-voice").length, 0);
+  // audio is still expected, just recorded instead of generated
+  const missing = byRule(findings, "missing-audio");
+  assert.equal(missing.length, 1);
+  assert.doesNotMatch(missing[0].message, /generate/i);
 });
 
 test("accepts fromLanguageName and non-Latin sentence punctuation", () => {

--- a/src/lib/editor/lint/lint_story.test.ts
+++ b/src/lib/editor/lint/lint_story.test.ts
@@ -358,16 +358,17 @@ test("keeps audio rules but skips TTS-voice warnings in human-audio courses", ()
     0: { ...testAvatars[0], speaker: "" },
     414: { ...testAvatars[414], speaker: "" },
   };
-  const [story, meta] = processStoryFile(
-    `[LINE]
+  const text = `[LINE]
 Speaker414: Bonjour le monde.
-~ hello the world`,
+~ hello the world`;
+  const [story, meta] = processStoryFile(
+    text,
     0,
     voicelessAvatars,
     { learning_language: "fr", from_language: "en" },
     "",
   );
-  const findings = lintStory({ text: "", story, meta, humanAudio: true });
+  const findings = lintStory({ text, story, meta, humanAudio: true });
   assert.equal(byRule(findings, "no-language-voices").length, 0);
   assert.equal(byRule(findings, "speaker-no-voice").length, 0);
   // audio is still expected, just recorded instead of generated

--- a/src/lib/editor/lint/lint_story.ts
+++ b/src/lib/editor/lint/lint_story.ts
@@ -567,13 +567,15 @@ function lintElements(
 
   if (missingAudioLines.length > 0) {
     const n = missingAudioLines.length;
+    // in a human-audio course TTS generation is not an option
+    const verb = input.humanAudio ? "Record" : "Record or generate";
     findings.push({
       rule: "missing-audio",
       severity: "warning",
       message:
         n === 1
-          ? "1 line has no audio ('$' line). Record or generate it with the audio tools."
-          : `${n} lines have no audio ('$' lines). Record or generate them with the audio tools.`,
+          ? `1 line has no audio ('$' line). ${verb} it with the audio tools.`
+          : `${n} lines have no audio ('$' lines). ${verb} them with the audio tools.`,
       lineNumber: missingAudioLines[0] || undefined,
     });
   }
@@ -602,7 +604,12 @@ function lintCast(
         message: `Speaker${id} is not a character of this course. Add it to the course characters, or set icon_${id}= and speaker_${id}= in [DATA].`,
       });
     }
-    if (!input.noAudio && languageHasVoices && !member.speaker) {
+    if (
+      !input.noAudio &&
+      !input.humanAudio &&
+      languageHasVoices &&
+      !member.speaker
+    ) {
       findings.push({
         rule: "speaker-no-voice",
         severity: "warning",
@@ -651,11 +658,14 @@ export function lintStory(input: LintInput): LintFinding[] {
 
   // A language with no TTS voices at all cannot generate audio anywhere, so a
   // single story-level finding replaces the per-line and per-speaker ones.
+  // In a human-audio course TTS is not used, so missing voices are expected
+  // and the per-line rules stay active regardless.
   const cast = Object.values(input.meta.cast ?? {});
   const languageHasVoices =
     cast.length === 0 || cast.some((member) => member.speaker);
-  const audioEnabled = !input.noAudio && languageHasVoices;
-  if (!input.noAudio && !languageHasVoices) {
+  const audioEnabled =
+    !input.noAudio && (languageHasVoices || Boolean(input.humanAudio));
+  if (!input.noAudio && !input.humanAudio && !languageHasVoices) {
     findings.push({
       rule: "no-language-voices",
       severity: "warning",

--- a/src/lib/editor/lint/types.ts
+++ b/src/lib/editor/lint/types.ts
@@ -47,4 +47,10 @@ export type LintInput = {
   learningLanguage?: string;
   /** Course has the no-audio tag: skip all audio rules. */
   noAudio?: boolean;
+  /**
+   * Course has the human-audio tag: audio is recorded by humans instead of
+   * generated with TTS, so missing TTS voices are not a problem. Audio itself
+   * is still expected, so the per-line audio rules stay active.
+   */
+  humanAudio?: boolean;
 };


### PR DESCRIPTION
## Summary

Adds a new `human-audio` course tag (alongside the existing `no-audio` tag) for courses whose audio is recorded by humans instead of generated with TTS.

In such courses, TTS-specific lint warnings don't make sense and are now suppressed:

- **`no-language-voices`** — "No TTS voices are configured for this language — audio cannot be generated. Ask an admin to add voices, or record audio manually."
- **`speaker-no-voice`** — "X has no TTS voice configured — audio cannot be generated."

Unlike `no-audio`, audio is still expected in a `human-audio` course, so:

- Per-line audio rules (`missing-audio`, timemark checks) now run even when the language has no TTS voices at all — previously they were skipped entirely and replaced by the single `no-language-voices` finding.
- The `missing-audio` message says "Record it with the audio tools" instead of "Record or generate it", since generating isn't an option.
- Listening exercises stay allowed, `$` audio lines aren't flagged, and audio-problem counts are computed normally.

## Changes

- `src/lib/course-tags.ts` + `convex/lib/courseTags.ts`: `HUMAN_AUDIO_COURSE_TAG` / `hasHumanAudioCourseTag` (case-insensitive, like `no-audio`)
- `src/lib/editor/lint/types.ts`: optional `humanAudio` flag on `LintInput`
- `src/lib/editor/lint/lint_story.ts`: suppression + message adjustments described above
- Both lint call sites pass the tag: story editor (`use_story_editor_model.ts`) and Discord review bot (`convex/storyReviewLint.ts`)

The admin tag field is free-form, so admins can simply add `human-audio` to a course's tags — no UI change needed.

## Test plan

- New test: voiceless language + `human-audio` → no TTS-voice warnings, `missing-audio` still fires without the word "generate"
- `pnpm test` (166 pass), `pnpm run typecheck`, `pnpm run lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for courses using human-recorded audio.
  * Audio requirements remain active, while text-to-speech voice warnings are suppressed for these courses.
  * Missing audio guidance now recommends recording audio rather than generating it when applicable.

* **Bug Fixes**
  * Improved course-tag matching to handle capitalization, spacing, and missing tags consistently.
  * Updated story linting to correctly recognize human-audio courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->