### PR TITLE
SEO: noindex draft story pages, redirect deleted stories

### DIFF
--- a/convex/storyRead.test.ts
+++ b/convex/storyRead.test.ts
@@ -9,6 +9,7 @@ const modules = import.meta.glob("./**/*.ts");
 async function seedCourseWithStory(
   t: ReturnType<typeof convexTest>,
   isPublic: boolean,
+  opts: { deleted?: boolean; coursePublic?: boolean } = {},
 ) {
   return await t.run(async (ctx) => {
     const learningLanguageId = await ctx.db.insert("languages", {
@@ -38,7 +39,7 @@ async function seedCourseWithStory(
       short: "es-en",
       learningLanguageId,
       fromLanguageId,
-      public: true,
+      public: opts.coursePublic ?? true,
       official: false,
     });
     await ctx.db.insert("stories", {
@@ -51,7 +52,7 @@ async function seedCourseWithStory(
       imageId,
       courseId,
       status: isPublic ? "finished" : "draft",
-      deleted: false,
+      deleted: opts.deleted ?? false,
       todo_count: 0,
     });
   });
@@ -66,7 +67,8 @@ describe("getStoryMetaByLegacyId", () => {
       storyId: 10,
     });
 
-    expect(meta?.public).toBe(true);
+    if (!meta || "deleted" in meta) throw new Error("expected story meta");
+    expect(meta.public).toBe(true);
     expect(meta).toMatchObject({
       from_language_name: "Public Story",
       image: "story-image",
@@ -83,12 +85,54 @@ describe("getStoryMetaByLegacyId", () => {
       storyId: 11,
     });
 
-    expect(meta?.public).toBe(false);
+    if (!meta || "deleted" in meta) throw new Error("expected story meta");
+    expect(meta.public).toBe(false);
     expect(meta).toMatchObject({
       from_language_name: "Draft Story",
       image: "story-image",
       from_language_long: "English",
       learning_language_long: "Spanish",
     });
+  });
+
+  test("returns redirect info for deleted stories in public courses", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t, true, { deleted: true });
+
+    const meta = await t.query(api.storyRead.getStoryMetaByLegacyId, {
+      storyId: 10,
+    });
+
+    expect(meta).toEqual({
+      deleted: true,
+      courseShort: "es-en",
+      coursePublic: true,
+    });
+  });
+
+  test("returns redirect info with coursePublic false for deleted stories in private courses", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t, true, { deleted: true, coursePublic: false });
+
+    const meta = await t.query(api.storyRead.getStoryMetaByLegacyId, {
+      storyId: 10,
+    });
+
+    expect(meta).toEqual({
+      deleted: true,
+      courseShort: "es-en",
+      coursePublic: false,
+    });
+  });
+
+  test("returns null for unknown legacy ids", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t, true);
+
+    const meta = await t.query(api.storyRead.getStoryMetaByLegacyId, {
+      storyId: 999,
+    });
+
+    expect(meta).toBeNull();
   });
 });

--- a/convex/storyRead.test.ts
+++ b/convex/storyRead.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedCourseWithStory(
+  t: ReturnType<typeof convexTest>,
+  isPublic: boolean,
+) {
+  return await t.run(async (ctx) => {
+    const learningLanguageId = await ctx.db.insert("languages", {
+      legacyId: 1,
+      name: "Spanish",
+      short: "es",
+      public: true,
+      rtl: false,
+    });
+    const fromLanguageId = await ctx.db.insert("languages", {
+      legacyId: 2,
+      name: "English",
+      short: "en",
+      public: true,
+      rtl: false,
+    });
+    const imageId = await ctx.db.insert("images", {
+      legacyId: "story-image",
+      active: "active.png",
+      gilded: "gilded.png",
+      locked: "locked.png",
+      active_lip: "active-lip.png",
+      gilded_lip: "gilded-lip.png",
+    });
+    const courseId = await ctx.db.insert("courses", {
+      legacyId: 100,
+      short: "es-en",
+      learningLanguageId,
+      fromLanguageId,
+      public: true,
+      official: false,
+    });
+    await ctx.db.insert("stories", {
+      legacyId: isPublic ? 10 : 11,
+      duo_id: "story-duo-" + (isPublic ? 10 : 11),
+      name: isPublic ? "Public Story" : "Draft Story",
+      set_id: 1,
+      set_index: 1,
+      public: isPublic,
+      imageId,
+      courseId,
+      status: isPublic ? "finished" : "draft",
+      deleted: false,
+      todo_count: 0,
+    });
+  });
+}
+
+describe("getStoryMetaByLegacyId", () => {
+  test("returns public true for public stories", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t, true);
+
+    const meta = await t.query(api.storyRead.getStoryMetaByLegacyId, {
+      storyId: 10,
+    });
+
+    expect(meta?.public).toBe(true);
+    expect(meta).toMatchObject({
+      from_language_name: "Public Story",
+      image: "story-image",
+      from_language_long: "English",
+      learning_language_long: "Spanish",
+    });
+  });
+
+  test("returns public false for non-public stories", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourseWithStory(t, false);
+
+    const meta = await t.query(api.storyRead.getStoryMetaByLegacyId, {
+      storyId: 11,
+    });
+
+    expect(meta?.public).toBe(false);
+    expect(meta).toMatchObject({
+      from_language_name: "Draft Story",
+      image: "story-image",
+      from_language_long: "English",
+      learning_language_long: "Spanish",
+    });
+  });
+});

--- a/convex/storyRead.ts
+++ b/convex/storyRead.ts
@@ -33,6 +33,15 @@ const storyMetaResultValidator = v.union(
     image: v.string(),
     from_language_long: v.string(),
     learning_language_long: v.string(),
+    public: v.boolean(),
+  }),
+  v.null(),
+);
+
+const deletedStoryRedirectInfoResultValidator = v.union(
+  v.object({
+    courseShort: v.string(),
+    coursePublic: v.boolean(),
   }),
   v.null(),
 );
@@ -149,6 +158,29 @@ export const getStoryMetaByLegacyId = query({
       image: image?.legacyId ?? "",
       from_language_long: fromLanguage.name,
       learning_language_long: learningLanguage.name,
+      public: story.public,
+    };
+  },
+});
+
+export const getDeletedStoryRedirectInfoByLegacyId = query({
+  args: {
+    storyId: v.number(),
+  },
+  returns: deletedStoryRedirectInfoResultValidator,
+  handler: async (ctx, args) => {
+    const story = await ctx.db
+      .query("stories")
+      .withIndex("by_legacy_id", (q) => q.eq("legacyId", args.storyId))
+      .unique();
+    if (!story || !story.deleted) return null;
+
+    const course = await ctx.db.get(story.courseId);
+    if (!course) return null;
+
+    return {
+      courseShort: course.short ?? "",
+      coursePublic: course.public,
     };
   },
 });

--- a/convex/storyRead.ts
+++ b/convex/storyRead.ts
@@ -35,11 +35,10 @@ const storyMetaResultValidator = v.union(
     learning_language_long: v.string(),
     public: v.boolean(),
   }),
-  v.null(),
-);
-
-const deletedStoryRedirectInfoResultValidator = v.union(
+  // Deleted stories resolve to their course so the page can 308 there
+  // instead of 404ing; never-existing ids stay null.
   v.object({
+    deleted: v.literal(true),
     courseShort: v.string(),
     coursePublic: v.boolean(),
   }),
@@ -140,10 +139,18 @@ export const getStoryMetaByLegacyId = query({
       .query("stories")
       .withIndex("by_legacy_id", (q) => q.eq("legacyId", args.storyId))
       .unique();
-    if (!story || story.deleted) return null;
+    if (!story) return null;
 
     const course = await ctx.db.get(story.courseId);
     if (!course) return null;
+
+    if (story.deleted) {
+      return {
+        deleted: true as const,
+        courseShort: course.short ?? "",
+        coursePublic: course.public,
+      };
+    }
 
     const [fromLanguage, learningLanguage, image] = await Promise.all([
       ctx.db.get(course.fromLanguageId),
@@ -159,28 +166,6 @@ export const getStoryMetaByLegacyId = query({
       from_language_long: fromLanguage.name,
       learning_language_long: learningLanguage.name,
       public: story.public,
-    };
-  },
-});
-
-export const getDeletedStoryRedirectInfoByLegacyId = query({
-  args: {
-    storyId: v.number(),
-  },
-  returns: deletedStoryRedirectInfoResultValidator,
-  handler: async (ctx, args) => {
-    const story = await ctx.db
-      .query("stories")
-      .withIndex("by_legacy_id", (q) => q.eq("legacyId", args.storyId))
-      .unique();
-    if (!story || !story.deleted) return null;
-
-    const course = await ctx.db.get(story.courseId);
-    if (!course) return null;
-
-    return {
-      courseShort: course.short ?? "",
-      coursePublic: course.public,
     };
   },
 });

--- a/src/app/(stories)/story/[story_id]/auto_play/page.tsx
+++ b/src/app/(stories)/story/[story_id]/auto_play/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({
     storyId: story_id,
   });
 
-  if (!story) notFound();
+  if (!story || "deleted" in story) notFound();
 
   return {
     title: `${story.from_language_name} - Duostories ${story.learning_language_long} from ${story.from_language_long}`,

--- a/src/app/(stories)/story/[story_id]/page.tsx
+++ b/src/app/(stories)/story/[story_id]/page.tsx
@@ -26,6 +26,24 @@ if (!convexUrl) {
 
 const convex = new ConvexHttpClient(convexUrl);
 
+// Deleted stories 308 to their course page (when the course is public) so
+// accumulated links keep working; unknown ids 404. Shared by generateMetadata
+// and Page — generateMetadata runs first, so it must redirect too or the
+// notFound there would win before Page gets a chance.
+async function resolveStoryMeta(story_id: number) {
+  const storyMeta = await fetchQuery(api.storyRead.getStoryMetaByLegacyId, {
+    storyId: story_id,
+  });
+  if (storyMeta && "deleted" in storyMeta) {
+    if (storyMeta.coursePublic && storyMeta.courseShort) {
+      permanentRedirect(`/${storyMeta.courseShort}`);
+    }
+    notFound();
+  }
+  if (!storyMeta) notFound();
+  return storyMeta;
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -34,12 +52,10 @@ export async function generateMetadata({
   const story_id = parseInt((await params).story_id);
   const [story, storyMeta] = await Promise.all([
     get_story(story_id),
-    fetchQuery(api.storyRead.getStoryMetaByLegacyId, {
-      storyId: story_id,
-    }),
+    resolveStoryMeta(story_id),
   ]);
 
-  if (!story || !storyMeta) notFound();
+  if (!story) notFound();
 
   const title = getStoryTitle(storyMeta);
   const description = getStoryDescription(story);
@@ -101,15 +117,7 @@ export default async function Page({
 
   const story = await get_story(story_id);
   if (!story) {
-    const redirectInfo = await fetchQuery(
-      api.storyRead.getDeletedStoryRedirectInfoByLegacyId,
-      {
-        storyId: story_id,
-      },
-    );
-    if (redirectInfo?.coursePublic && redirectInfo.courseShort) {
-      permanentRedirect(`/${redirectInfo.courseShort}`);
-    }
+    await resolveStoryMeta(story_id); // redirects deleted stories, else 404s
     notFound();
   }
   const course_id = story.course_id;

--- a/src/app/(stories)/story/[story_id]/page.tsx
+++ b/src/app/(stories)/story/[story_id]/page.tsx
@@ -26,6 +26,15 @@ if (!convexUrl) {
 
 const convex = new ConvexHttpClient(convexUrl);
 
+// parseInt would accept alias slugs like "1abc" and serve story 1's content
+// at infinitely many crawlable URLs; only pure integer slugs may resolve.
+function parseStoryId(slug: string) {
+  if (!/^\d+$/.test(slug)) notFound();
+  const story_id = Number(slug);
+  if (!Number.isSafeInteger(story_id)) notFound();
+  return story_id;
+}
+
 // Deleted stories 308 to their course page (when the course is public) so
 // accumulated links keep working; unknown ids 404. Shared by generateMetadata
 // and Page — generateMetadata runs first, so it must redirect too or the
@@ -49,7 +58,7 @@ export async function generateMetadata({
 }: {
   params: Promise<{ story_id: string }>;
 }) {
-  const story_id = parseInt((await params).story_id);
+  const story_id = parseStoryId((await params).story_id);
   const [story, storyMeta] = await Promise.all([
     get_story(story_id),
     resolveStoryMeta(story_id),
@@ -113,7 +122,7 @@ export default async function Page({
   params: Promise<{ story_id: string }>;
 }) {
   const cookieStore = await cookies();
-  const story_id = parseInt((await params).story_id);
+  const story_id = parseStoryId((await params).story_id);
 
   const story = await get_story(story_id);
   if (!story) {

--- a/src/app/(stories)/story/[story_id]/page.tsx
+++ b/src/app/(stories)/story/[story_id]/page.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from "react";
 import { cookies } from "next/headers";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { fetchAuthQuery } from "@/lib/auth-server";
 import getUserId from "@/lib/getUserId";
 import {
@@ -44,6 +44,30 @@ export async function generateMetadata({
   const title = getStoryTitle(storyMeta);
   const description = getStoryDescription(story);
 
+  if (!storyMeta.public) {
+    return {
+      title,
+      description,
+      robots: { index: false, follow: false },
+      keywords: [
+        storyMeta.learning_language_long,
+        storyMeta.from_language_long,
+      ],
+      openGraph: {
+        images: [
+          `/api/og-story?title=${storyMeta.from_language_name}&image=${storyMeta.image}&name=${storyMeta.learning_language_long}`,
+        ],
+        type: "website",
+        title,
+        description,
+      },
+      twitter: {
+        title,
+        description,
+      },
+    };
+  }
+
   return {
     title,
     description,
@@ -76,7 +100,18 @@ export default async function Page({
   const story_id = parseInt((await params).story_id);
 
   const story = await get_story(story_id);
-  if (!story) notFound();
+  if (!story) {
+    const redirectInfo = await fetchQuery(
+      api.storyRead.getDeletedStoryRedirectInfoByLegacyId,
+      {
+        storyId: story_id,
+      },
+    );
+    if (redirectInfo?.coursePublic && redirectInfo.courseShort) {
+      permanentRedirect(`/${redirectInfo.courseShort}`);
+    }
+    notFound();
+  }
   const course_id = story.course_id;
 
   const user_id = await getUserId();

--- a/src/app/(stories)/story/[story_id]/script/page.tsx
+++ b/src/app/(stories)/story/[story_id]/script/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({
     storyId: story_id,
   });
 
-  if (!story) notFound();
+  if (!story || "deleted" in story) notFound();
 
   return {
     title: `Duostories ${story.learning_language_long} from ${story.from_language_long}: ${story.from_language_name}`,


### PR DESCRIPTION
## Summary

Only ~48% of published story pages are currently indexed. A large chunk of crawl budget is being spent on ~5k reachable draft/non-public story URLs that serve full indexable SEO metadata (canonical, OpenGraph url, etc.) even though they're not meant to be indexed.

Direct-link access to draft stories is intentional — contributors share draft links with unregistered language experts for review — so this change does **not** touch rendering or the HTTP status for those pages. It only changes the metadata:

- `generateMetadata` in `src/app/(stories)/story/[story_id]/page.tsx` now returns `robots: { index: false, follow: false }` and omits `alternates.canonical` / `openGraph.url` when the story's `public` flag is `false`.
- `getStoryMetaByLegacyId` (convex/storyRead.ts) now also returns the story's `public` flag so the page can branch on it.
- Public stories are unaffected — the public-metadata code path is untouched, same canonical/OG/title/description as before.

## Task 2: redirect deleted stories

Also included: deleted stories (`deleted: true`) previously 404'd exactly like never-existing IDs. This PR adds a small Convex query (`getDeletedStoryRedirectInfoByLegacyId`) that, for a legacy ID belonging to a deleted story, returns the owning course's `short` and `public` flags. If the story is deleted and its course is public, the page now issues a `permanentRedirect()` to `/{course.short}` instead of 404ing. IDs that never existed still 404 as before, and deleted stories under a non-public course still 404 (no redirect to an inaccessible course).

This landed cleanly without needing routing/middleware changes, so it's included rather than skipped.

## Test plan
- [x] `pnpm convex dev --once` — schema/function changes deployed to dev
- [x] `pnpm typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm test` — 166 passed
- [x] `pnpm test:convex` — 40 passed, including new `convex/storyRead.test.ts` covering `public: true`/`false` metadata
- [x] Manual diff review confirming public-story metadata is byte-identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permanent redirects for soft-deleted stories when the associated course destination can be determined.
  * Exposed story privacy in the returned story metadata to support consistent handling across pages.
* **Bug Fixes**
  * Updated metadata generation to treat soft-deleted stories as 404s.
  * Non-public stories now suppress indexing/social canonical fields while still rendering available preview text.
* **Tests**
  * Expanded coverage for public, private, deleted-redirect, and unknown legacy ID scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->