### PR TITLE
Add mobile split-word underline gaps

### DIFF
--- a/app-mobile/src/story/HintText.test.ts
+++ b/app-mobile/src/story/HintText.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { buildHintTextTokens } from "./HintTextTokens";
 import {
   buildUnderlineSegments,
+  getDottedUnderlineDotCenters,
   splitNativeTokenParts,
   UNDERLINE_DOT_GAP,
   UNDERLINE_HINT_EDGE_INSET,
@@ -100,6 +101,19 @@ describe("native hint underlines", () => {
       UNDERLINE_DOT_GAP,
     );
     expect(UNDERLINE_HINT_EDGE_INSET * 2).toBe(UNDERLINE_DOT_GAP);
+  });
+
+  test("centers dotted underlines within their drawable span", () => {
+    const dots = getDottedUnderlineDotCenters({
+      x1: 103.5,
+      x2: 176.5,
+      dotGap: UNDERLINE_DOT_GAP,
+    });
+
+    expect(dots).toHaveLength(11);
+    expect(dots[0]).toBeCloseTo(105);
+    expect(dots.at(-1)).toBeCloseTo(175);
+    expect(dots[0]! - 103.5).toBeCloseTo(176.5 - dots.at(-1)!);
   });
 
   test("keeps hidden challenge native underline pieces continuous", () => {

--- a/app-mobile/src/story/HintText.test.ts
+++ b/app-mobile/src/story/HintText.test.ts
@@ -85,23 +85,25 @@ describe("native hint underlines", () => {
           ...hintedSegment({
             key: "joiner",
             x: 180,
-            width: 0,
+            width: 4.5,
             group: undefined,
           }),
           text: "\u2060",
           hint: undefined,
         },
-        hintedSegment({ key: "pim", x: 180, width: 60, group: "hint:1" }),
+        hintedSegment({ key: "pim", x: 184.5, width: 60, group: "hint:1" }),
       ],
       colors: { border: "#ccd6dd", hiddenUnderline: "#ccd6dd" },
     });
 
     expect(underlines).toHaveLength(2);
-    expect(underlines[1]!.x1 - underlines[0]!.x2).toBeCloseTo(
-      UNDERLINE_DOT_GAP,
-    );
     expect(underlines[0]!.dotAnchor).toBe("end");
     expect(underlines[1]!.dotAnchor).toBe("start");
+    expect(underlines[0]!.dotAnchorBoundary).toBe(180);
+    expect(underlines[1]!.dotAnchorBoundary).toBe(180);
+    expect(underlines[1]!.x1 - underlines[0]!.x2).toBeGreaterThan(
+      UNDERLINE_DOT_GAP,
+    );
     expect(UNDERLINE_HINT_EDGE_INSET * 2).toBe(UNDERLINE_DOT_GAP);
   });
 
@@ -112,13 +114,15 @@ describe("native hint underlines", () => {
       dotGap: UNDERLINE_DOT_GAP,
       edgeInset: UNDERLINE_HINT_EDGE_INSET,
       anchor: "end",
+      anchorBoundary: 180,
     });
     const right = getDottedUnderlineDotCenters({
-      x1: 183.5,
-      x2: 236.5,
+      x1: 188,
+      x2: 241,
       dotGap: UNDERLINE_DOT_GAP,
       edgeInset: UNDERLINE_HINT_EDGE_INSET,
       anchor: "start",
+      anchorBoundary: 180,
     });
 
     expect(left.at(-1)).toBeCloseTo(173);

--- a/app-mobile/src/story/HintText.test.ts
+++ b/app-mobile/src/story/HintText.test.ts
@@ -4,7 +4,6 @@ import {
   buildUnderlineSegments,
   getDottedUnderlineDotCenters,
   splitNativeTokenParts,
-  UNDERLINE_DOT_EDGE_INSET,
   UNDERLINE_DOT_GAP,
   UNDERLINE_HINT_EDGE_INSET,
 } from "./HintTextUnderline";
@@ -101,7 +100,30 @@ describe("native hint underlines", () => {
     expect(underlines[1]!.x1 - underlines[0]!.x2).toBeCloseTo(
       UNDERLINE_DOT_GAP,
     );
+    expect(underlines[0]!.dotAnchor).toBe("end");
+    expect(underlines[1]!.dotAnchor).toBe("start");
     expect(UNDERLINE_HINT_EDGE_INSET * 2).toBe(UNDERLINE_DOT_GAP);
+  });
+
+  test("keeps one skipped dot position between split dotted underlines", () => {
+    const left = getDottedUnderlineDotCenters({
+      x1: 103.5,
+      x2: 176.5,
+      dotGap: UNDERLINE_DOT_GAP,
+      edgeInset: UNDERLINE_HINT_EDGE_INSET,
+      anchor: "end",
+    });
+    const right = getDottedUnderlineDotCenters({
+      x1: 183.5,
+      x2: 236.5,
+      dotGap: UNDERLINE_DOT_GAP,
+      edgeInset: UNDERLINE_HINT_EDGE_INSET,
+      anchor: "start",
+    });
+
+    expect(left.at(-1)).toBeCloseTo(173);
+    expect(right[0]).toBeCloseTo(187);
+    expect(right[0]! - left.at(-1)!).toBeCloseTo(UNDERLINE_DOT_GAP * 2);
   });
 
   test("centers dotted underlines within their drawable span", () => {
@@ -109,14 +131,14 @@ describe("native hint underlines", () => {
       x1: 100,
       x2: 180,
       dotGap: UNDERLINE_DOT_GAP,
-      edgeInset: UNDERLINE_DOT_EDGE_INSET,
+      edgeInset: UNDERLINE_HINT_EDGE_INSET,
     });
 
-    expect(dots).toHaveLength(10);
-    expect(dots[0]).toBeCloseTo(108.5);
-    expect(dots.at(-1)).toBeCloseTo(171.5);
+    expect(dots).toHaveLength(11);
+    expect(dots[0]).toBeCloseTo(105);
+    expect(dots.at(-1)).toBeCloseTo(175);
     expect(dots[0]! - 100).toBeCloseTo(180 - dots.at(-1)!);
-    expect(dots[0]).toBeGreaterThan(100 + UNDERLINE_DOT_EDGE_INSET);
+    expect(dots[0]).toBeGreaterThan(100 + UNDERLINE_HINT_EDGE_INSET);
   });
 
   test("keeps hidden challenge native underline pieces continuous", () => {

--- a/app-mobile/src/story/HintText.test.ts
+++ b/app-mobile/src/story/HintText.test.ts
@@ -3,6 +3,7 @@ import { buildHintTextTokens } from "./HintTextTokens";
 import {
   buildUnderlineSegments,
   splitNativeTokenParts,
+  UNDERLINE_DOT_GAP,
   UNDERLINE_HINT_EDGE_INSET,
 } from "./HintTextUnderline";
 
@@ -75,7 +76,7 @@ describe("native hint underlines", () => {
     ]);
   });
 
-  test("keeps a visible gap between adjacent hinted native underline pieces", () => {
+  test("keeps a one-dot gap between adjacent hinted native underline pieces", () => {
     const underlines = buildUnderlineSegments({
       computedSegments: [
         hintedSegment({ key: "wasi", x: 100, width: 80, group: "hint:0" }),
@@ -95,9 +96,10 @@ describe("native hint underlines", () => {
     });
 
     expect(underlines).toHaveLength(2);
-    expect(underlines[1]!.x1 - underlines[0]!.x2).toBe(
-      UNDERLINE_HINT_EDGE_INSET * 2,
+    expect(underlines[1]!.x1 - underlines[0]!.x2).toBeCloseTo(
+      UNDERLINE_DOT_GAP,
     );
+    expect(UNDERLINE_HINT_EDGE_INSET * 2).toBe(UNDERLINE_DOT_GAP);
   });
 
   test("keeps hidden challenge native underline pieces continuous", () => {

--- a/app-mobile/src/story/HintText.test.ts
+++ b/app-mobile/src/story/HintText.test.ts
@@ -4,6 +4,7 @@ import {
   buildUnderlineSegments,
   getDottedUnderlineDotCenters,
   splitNativeTokenParts,
+  UNDERLINE_DOT_EDGE_INSET,
   UNDERLINE_DOT_GAP,
   UNDERLINE_HINT_EDGE_INSET,
 } from "./HintTextUnderline";
@@ -105,15 +106,17 @@ describe("native hint underlines", () => {
 
   test("centers dotted underlines within their drawable span", () => {
     const dots = getDottedUnderlineDotCenters({
-      x1: 103.5,
-      x2: 176.5,
+      x1: 100,
+      x2: 180,
       dotGap: UNDERLINE_DOT_GAP,
+      edgeInset: UNDERLINE_DOT_EDGE_INSET,
     });
 
-    expect(dots).toHaveLength(11);
-    expect(dots[0]).toBeCloseTo(105);
-    expect(dots.at(-1)).toBeCloseTo(175);
-    expect(dots[0]! - 103.5).toBeCloseTo(176.5 - dots.at(-1)!);
+    expect(dots).toHaveLength(10);
+    expect(dots[0]).toBeCloseTo(108.5);
+    expect(dots.at(-1)).toBeCloseTo(171.5);
+    expect(dots[0]! - 100).toBeCloseTo(180 - dots.at(-1)!);
+    expect(dots[0]).toBeGreaterThan(100 + UNDERLINE_DOT_EDGE_INSET);
   });
 
   test("keeps hidden challenge native underline pieces continuous", () => {

--- a/app-mobile/src/story/HintText.test.ts
+++ b/app-mobile/src/story/HintText.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { buildHintTextTokens } from "./HintTextTokens";
+import {
+  buildUnderlineSegments,
+  splitNativeTokenParts,
+  UNDERLINE_HINT_EDGE_INSET,
+} from "./HintTextUnderline";
 
 const content = {
   text: "alpha beta gamma",
@@ -39,3 +44,121 @@ describe("buildHintTextTokens", () => {
     ]);
   });
 });
+
+describe("native hint underlines", () => {
+  test("splits hinted native text at word-joiner boundaries", () => {
+    const parts = splitNativeTokenParts({
+      token: {
+        text: "wasi\u2060pim",
+        start: 0,
+        hidden: false,
+        revealed: false,
+        dimmed: false,
+        hint: { translation: "restaurant" },
+        hintGroupKey: "hint:0:7:0",
+      },
+      displayText: "wasi\u2060pim",
+      shouldSplitIntoGraphemes: false,
+      splitIntoGraphemes: (text) => [text],
+    });
+
+    expect(
+      parts.map((part) => ({
+        text: part.text,
+        hint: Boolean(part.hint),
+        group: part.underlineGroupKey,
+      })),
+    ).toEqual([
+      { text: "wasi", hint: true, group: "hint:0:7:0:0" },
+      { text: "\u2060", hint: false, group: undefined },
+      { text: "pim", hint: true, group: "hint:0:7:0:1" },
+    ]);
+  });
+
+  test("keeps a visible gap between adjacent hinted native underline pieces", () => {
+    const underlines = buildUnderlineSegments({
+      computedSegments: [
+        hintedSegment({ key: "wasi", x: 100, width: 80, group: "hint:0" }),
+        {
+          ...hintedSegment({
+            key: "joiner",
+            x: 180,
+            width: 0,
+            group: undefined,
+          }),
+          text: "\u2060",
+          hint: undefined,
+        },
+        hintedSegment({ key: "pim", x: 180, width: 60, group: "hint:1" }),
+      ],
+      colors: { border: "#ccd6dd", hiddenUnderline: "#ccd6dd" },
+    });
+
+    expect(underlines).toHaveLength(2);
+    expect(underlines[1]!.x1 - underlines[0]!.x2).toBe(
+      UNDERLINE_HINT_EDGE_INSET * 2,
+    );
+  });
+
+  test("keeps hidden challenge native underline pieces continuous", () => {
+    const underlines = buildUnderlineSegments({
+      computedSegments: [
+        hiddenSegment({ key: "first", x: 100, width: 80 }),
+        hiddenSegment({ key: "second", x: 180, width: 60 }),
+      ],
+      colors: { border: "#ccd6dd", hiddenUnderline: "#ccd6dd" },
+    });
+
+    expect(underlines).toHaveLength(1);
+    expect(underlines[0]).toMatchObject({
+      x1: 102,
+      x2: 238,
+      dotted: false,
+    });
+  });
+});
+
+function hintedSegment({
+  key,
+  x,
+  width,
+  group,
+}: {
+  key: string;
+  x: number;
+  width: number;
+  group?: string;
+}) {
+  return {
+    key,
+    start: 0,
+    x,
+    y: 0,
+    width,
+    height: 40,
+    ascender: 30,
+    descender: 10,
+    text: key,
+    hidden: false,
+    revealed: false,
+    hint: { translation: "restaurant" },
+    tokenKey: key,
+    underlineGroupKey: group,
+  };
+}
+
+function hiddenSegment({
+  key,
+  x,
+  width,
+}: {
+  key: string;
+  x: number;
+  width: number;
+}) {
+  return {
+    ...hintedSegment({ key, x, width, group: "hidden:0:10" }),
+    hidden: true,
+    hint: undefined,
+  };
+}

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -26,6 +26,7 @@ import {
   splitNativeTokenParts,
   UNDERLINE_BASELINE_GAP,
   UNDERLINE_BOTTOM_INSET,
+  UNDERLINE_DOT_EDGE_INSET,
   UNDERLINE_DOT_GAP,
   UNDERLINE_DOT_RADIUS,
   UNDERLINE_EDGE_INSET,
@@ -864,9 +865,10 @@ function NativeHintOverlay({
           <React.Fragment key={segment.key}>
             {segment.dotted ? (
               getDottedUnderlineDotCenters({
-                x1: segment.x1,
-                x2: segment.x2,
+                x1: segment.debugX,
+                x2: segment.debugX + segment.debugWidth,
                 dotGap: UNDERLINE_DOT_GAP,
+                edgeInset: UNDERLINE_DOT_EDGE_INSET,
               }).map((cx, index) => {
                 return (
                   <Circle

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -21,6 +21,7 @@ import { HintLookupContext, HintPopupContext } from "./HintPopup";
 import { buildHintTextTokens, type Token } from "./HintTextTokens";
 import {
   buildUnderlineSegments,
+  getDottedUnderlineDotCenters,
   HINT_SPLIT_MARKER,
   splitNativeTokenParts,
   UNDERLINE_BASELINE_GAP,
@@ -862,16 +863,11 @@ function NativeHintOverlay({
         underlineSegments.map((segment) => (
           <React.Fragment key={segment.key}>
             {segment.dotted ? (
-              Array.from({
-                length: Math.max(
-                  1,
-                  Math.floor((segment.x2 - segment.x1) / UNDERLINE_DOT_GAP) + 1,
-                ),
-              }).map((_, index) => {
-                const cx = Math.min(
-                  segment.x2,
-                  segment.x1 + index * UNDERLINE_DOT_GAP,
-                );
+              getDottedUnderlineDotCenters({
+                x1: segment.x1,
+                x2: segment.x2,
+                dotGap: UNDERLINE_DOT_GAP,
+              }).map((cx, index) => {
                 return (
                   <Circle
                     key={`${segment.key}:${index}`}

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -663,7 +663,14 @@ function HintTokenBox({
         >
           {displayText}
         </Text>
-        <View style={{ height: 2, marginTop: -2, overflow: "hidden" }}>
+        <View
+          style={{
+            height: 2,
+            marginHorizontal: UNDERLINE_EDGE_INSET,
+            marginTop: -2,
+            overflow: "hidden",
+          }}
+        >
           {underline && (
             <View
               style={{
@@ -764,7 +771,14 @@ function HintPhraseBox({
             );
           })}
         </View>
-        <View style={{ height: 2, marginTop: -2, overflow: "hidden" }}>
+        <View
+          style={{
+            height: 2,
+            marginHorizontal: UNDERLINE_EDGE_INSET,
+            marginTop: -2,
+            overflow: "hidden",
+          }}
+        >
           {underline && (
             <View
               style={{

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -19,6 +19,17 @@ import {
 } from "./elements/PlayAudioButton";
 import { HintLookupContext, HintPopupContext } from "./HintPopup";
 import { buildHintTextTokens, type Token } from "./HintTextTokens";
+import {
+  buildUnderlineSegments,
+  HINT_SPLIT_MARKER,
+  splitNativeTokenParts,
+  UNDERLINE_BASELINE_GAP,
+  UNDERLINE_BOTTOM_INSET,
+  UNDERLINE_DOT_GAP,
+  UNDERLINE_DOT_RADIUS,
+  UNDERLINE_EDGE_INSET,
+  type UnderlineSegment,
+} from "./HintTextUnderline";
 import type { ContentWithHints, HideRange } from "./types";
 
 // Web-parity text renderer (StoryLineHints): hinted words get a dashed
@@ -28,12 +39,7 @@ import type { ContentWithHints, HideRange } from "./types";
 // underlines are real (dashed) bottom borders.
 
 const WRAPPED_LINE_GAP = 3;
-const UNDERLINE_EDGE_INSET = 2;
-const UNDERLINE_DOT_RADIUS = 1.2;
-const UNDERLINE_DOT_GAP = 7;
 const INLINE_AUDIO_SPACE = "\u2002";
-const UNDERLINE_BASELINE_GAP = 4;
-const UNDERLINE_BOTTOM_INSET = 2;
 
 type HintTextRenderMode = "auto" | "native" | "tokenized";
 
@@ -95,20 +101,6 @@ type HiddenCover = {
   y: number;
   width: number;
   height: number;
-};
-
-type UnderlineSegment = {
-  key: string;
-  x1: number;
-  x2: number;
-  y: number;
-  color: string;
-  dotted: boolean;
-  underlineGroupKey?: string;
-  debugX: number;
-  debugY: number;
-  debugWidth: number;
-  debugHeight: number;
 };
 
 type DebugRect = {
@@ -236,20 +228,28 @@ function buildNativeSegments(tokens: Token[]): NativeSegment[] {
 
   for (const token of tokens) {
     const displayText = getDisplayText(token);
-    const parts = shouldMeasureTokenAsGraphemes(displayText)
-      ? splitIntoGraphemes(displayText)
-      : [displayText];
+    const parts = splitNativeTokenParts({
+      token,
+      displayText,
+      shouldSplitIntoGraphemes: shouldMeasureTokenAsGraphemes(displayText),
+      splitIntoGraphemes,
+    });
     for (const part of parts) {
       segments.push({
         ...token,
-        text: part,
+        text: part.text,
+        hint: part.hint === null ? undefined : (part.hint ?? token.hint),
         key: `${token.start}:${segments.length}`,
         tokenKey: `${token.start}:${token.text}`,
-        underlineGroupKey: token.hidden
-          ? token.hiddenGroupKey
-          : token.revealed
-            ? `revealed:${token.start}`
-            : token.hintGroupKey,
+        underlineGroupKey:
+          part.underlineGroupKey ??
+          (part.text === HINT_SPLIT_MARKER
+            ? undefined
+            : token.hidden
+              ? token.hiddenGroupKey
+              : token.revealed
+                ? `revealed:${token.start}`
+                : token.hintGroupKey),
       });
     }
   }
@@ -426,122 +426,6 @@ function getUnderlineY(segment: ComputedSegment) {
   const minY = segment.y + UNDERLINE_BOTTOM_INSET;
   const maxY = segment.y + segment.height - UNDERLINE_BOTTOM_INSET;
   return Math.max(minY, Math.min(preferredY, maxY));
-}
-
-function buildUnderlineSegments({
-  computedSegments,
-  colors,
-}: {
-  computedSegments: ComputedSegment[];
-  colors: ThemeColors;
-}): UnderlineSegment[] {
-  const segmentsToDraw: UnderlineSegment[] = [];
-  const hiddenGroupSpans = new Map<string, UnderlineSegment>();
-  for (const segment of computedSegments) {
-    const interactive = Boolean(segment.hint) && !segment.hidden;
-    const underline = segment.hidden
-      ? colors.hiddenUnderline
-      : segment.revealed || interactive
-        ? colors.border
-        : undefined;
-    if (!underline) continue;
-
-    if (segment.hidden && segment.underlineGroupKey) {
-      const y = getUnderlineY(segment);
-      const lineKey = `${segment.underlineGroupKey}:${Math.round(y)}`;
-      const existing = hiddenGroupSpans.get(lineKey);
-      if (existing) {
-        const right = Math.max(existing.x2, segment.x + segment.width);
-        existing.x1 = Math.min(existing.x1, segment.x);
-        existing.x2 = right;
-        existing.debugX = Math.min(existing.debugX, segment.x);
-        existing.debugWidth = right - existing.debugX;
-        existing.debugHeight = Math.max(existing.debugHeight, segment.height);
-      } else {
-        hiddenGroupSpans.set(lineKey, {
-          key: lineKey,
-          x1: segment.x,
-          x2: segment.x + segment.width,
-          y,
-          color: underline,
-          dotted: false,
-          underlineGroupKey: segment.underlineGroupKey,
-          debugX: segment.x,
-          debugY: segment.y,
-          debugWidth: segment.width,
-          debugHeight: segment.height,
-        });
-      }
-      continue;
-    }
-
-    if (/^\s+$/.test(segment.text) && !segment.underlineGroupKey) continue;
-    if (
-      /^[,.:;!?%)}\]\u3001\u3002\u30fb\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(
-        segment.text,
-      )
-    )
-      continue;
-    segmentsToDraw.push({
-      key: segment.key,
-      x1: segment.x + UNDERLINE_EDGE_INSET,
-      x2:
-        segment.x +
-        Math.max(
-          segment.width - UNDERLINE_EDGE_INSET,
-          UNDERLINE_EDGE_INSET * 2,
-        ),
-      y: getUnderlineY(segment),
-      color: underline,
-      dotted: !segment.hidden,
-      underlineGroupKey: segment.underlineGroupKey,
-      debugX: segment.x,
-      debugY: segment.y,
-      debugWidth: segment.width,
-      debugHeight: segment.height,
-    });
-  }
-  for (const segment of hiddenGroupSpans.values()) {
-    segmentsToDraw.push({
-      ...segment,
-      x1: segment.x1 + UNDERLINE_EDGE_INSET,
-      x2: segment.x2 - UNDERLINE_EDGE_INSET,
-    });
-  }
-
-  segmentsToDraw.sort((a, b) => {
-    if (Math.abs(a.y - b.y) > 2) return a.y - b.y;
-    return a.x1 - b.x1;
-  });
-
-  const merged: UnderlineSegment[] = [];
-  for (const segment of segmentsToDraw) {
-    const last = merged[merged.length - 1];
-    const sameGroupOnSameLine =
-      last &&
-      Math.abs(last.y - segment.y) <= 2 &&
-      last.color === segment.color &&
-      last.dotted === segment.dotted &&
-      last.underlineGroupKey !== undefined &&
-      last.underlineGroupKey === segment.underlineGroupKey;
-    if (
-      sameGroupOnSameLine ||
-      (last &&
-        Math.abs(last.y - segment.y) <= 2 &&
-        Math.abs(last.x2 - segment.x1) <= 4 &&
-        last.color === segment.color &&
-        last.dotted === segment.dotted &&
-        last.underlineGroupKey === segment.underlineGroupKey)
-    ) {
-      last.x2 = segment.x2;
-      last.debugWidth = segment.debugX + segment.debugWidth - last.debugX;
-      last.debugHeight = Math.max(last.debugHeight, segment.debugHeight);
-      continue;
-    }
-    merged.push(segment);
-  }
-
-  return merged;
 }
 
 function buildDebugRects(

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -26,10 +26,10 @@ import {
   splitNativeTokenParts,
   UNDERLINE_BASELINE_GAP,
   UNDERLINE_BOTTOM_INSET,
-  UNDERLINE_DOT_EDGE_INSET,
   UNDERLINE_DOT_GAP,
   UNDERLINE_DOT_RADIUS,
   UNDERLINE_EDGE_INSET,
+  UNDERLINE_HINT_EDGE_INSET,
   type UnderlineSegment,
 } from "./HintTextUnderline";
 import type { ContentWithHints, HideRange } from "./types";
@@ -865,10 +865,13 @@ function NativeHintOverlay({
           <React.Fragment key={segment.key}>
             {segment.dotted ? (
               getDottedUnderlineDotCenters({
-                x1: segment.debugX,
-                x2: segment.debugX + segment.debugWidth,
+                x1: segment.dotAnchor ? segment.x1 : segment.debugX,
+                x2: segment.dotAnchor
+                  ? segment.x2
+                  : segment.debugX + segment.debugWidth,
                 dotGap: UNDERLINE_DOT_GAP,
-                edgeInset: UNDERLINE_DOT_EDGE_INSET,
+                edgeInset: UNDERLINE_HINT_EDGE_INSET,
+                anchor: segment.dotAnchor,
               }).map((cx, index) => {
                 return (
                   <Circle

--- a/app-mobile/src/story/HintText.tsx
+++ b/app-mobile/src/story/HintText.tsx
@@ -872,6 +872,7 @@ function NativeHintOverlay({
                 dotGap: UNDERLINE_DOT_GAP,
                 edgeInset: UNDERLINE_HINT_EDGE_INSET,
                 anchor: segment.dotAnchor,
+                anchorBoundary: segment.dotAnchorBoundary,
               }).map((cx, index) => {
                 return (
                   <Circle

--- a/app-mobile/src/story/HintTextUnderline.ts
+++ b/app-mobile/src/story/HintTextUnderline.ts
@@ -4,7 +4,6 @@ export const UNDERLINE_EDGE_INSET = 2;
 export const UNDERLINE_DOT_RADIUS = 1.2;
 export const UNDERLINE_DOT_GAP = 7;
 export const UNDERLINE_HINT_EDGE_INSET = UNDERLINE_DOT_GAP / 2;
-export const UNDERLINE_DOT_EDGE_INSET = UNDERLINE_DOT_GAP;
 export const HINT_SPLIT_MARKER = "\u2060";
 export const UNDERLINE_BASELINE_GAP = 5;
 export const UNDERLINE_BOTTOM_INSET = 2;
@@ -36,6 +35,7 @@ export type UnderlineSegment = {
   y: number;
   color: string;
   dotted: boolean;
+  dotAnchor?: "start" | "end";
   underlineGroupKey?: string;
   debugX: number;
   debugY: number;
@@ -53,17 +53,24 @@ export function getDottedUnderlineDotCenters({
   x2,
   dotGap = UNDERLINE_DOT_GAP,
   edgeInset = 0,
+  anchor,
 }: {
   x1: number;
   x2: number;
   dotGap?: number;
   edgeInset?: number;
+  anchor?: "start" | "end";
 }): number[] {
   const width = Math.max(0, x2 - x1);
   const drawableWidth = Math.max(0, width - edgeInset * 2);
   const dotCount = Math.max(1, Math.floor(drawableWidth / dotGap) + 1);
   const dotSpan = (dotCount - 1) * dotGap;
-  const startX = x1 + (width - dotSpan) / 2;
+  const startX =
+    anchor === "start"
+      ? x1 + edgeInset
+      : anchor === "end"
+        ? x2 - edgeInset - dotSpan
+        : x1 + (width - dotSpan) / 2;
 
   return Array.from(
     { length: dotCount },
@@ -128,7 +135,8 @@ export function buildUnderlineSegments({
 }): UnderlineSegment[] {
   const segmentsToDraw: UnderlineSegment[] = [];
   const hiddenGroupSpans = new Map<string, UnderlineSegment>();
-  for (const segment of computedSegments) {
+  for (let index = 0; index < computedSegments.length; index += 1) {
+    const segment = computedSegments[index]!;
     const interactive = Boolean(segment.hint) && !segment.hidden;
     const underline = segment.hidden
       ? colors.hiddenUnderline
@@ -156,6 +164,7 @@ export function buildUnderlineSegments({
           y,
           color: underline,
           dotted: false,
+          dotAnchor: undefined,
           underlineGroupKey: segment.underlineGroupKey,
           debugX: segment.x,
           debugY: segment.y,
@@ -176,6 +185,12 @@ export function buildUnderlineSegments({
 
     const dotted = !segment.hidden;
     const edgeInset = dotted ? UNDERLINE_HINT_EDGE_INSET : UNDERLINE_EDGE_INSET;
+    const dotAnchor =
+      computedSegments[index - 1]?.text === HINT_SPLIT_MARKER
+        ? "start"
+        : computedSegments[index + 1]?.text === HINT_SPLIT_MARKER
+          ? "end"
+          : undefined;
     segmentsToDraw.push({
       key: segment.key,
       x1: segment.x + edgeInset,
@@ -183,6 +198,7 @@ export function buildUnderlineSegments({
       y: getUnderlineY(segment),
       color: underline,
       dotted,
+      dotAnchor,
       underlineGroupKey: segment.underlineGroupKey,
       debugX: segment.x,
       debugY: segment.y,

--- a/app-mobile/src/story/HintTextUnderline.ts
+++ b/app-mobile/src/story/HintTextUnderline.ts
@@ -36,6 +36,7 @@ export type UnderlineSegment = {
   color: string;
   dotted: boolean;
   dotAnchor?: "start" | "end";
+  dotAnchorBoundary?: number;
   underlineGroupKey?: string;
   debugX: number;
   debugY: number;
@@ -54,23 +55,40 @@ export function getDottedUnderlineDotCenters({
   dotGap = UNDERLINE_DOT_GAP,
   edgeInset = 0,
   anchor,
+  anchorBoundary,
 }: {
   x1: number;
   x2: number;
   dotGap?: number;
   edgeInset?: number;
   anchor?: "start" | "end";
+  anchorBoundary?: number;
 }): number[] {
   const width = Math.max(0, x2 - x1);
+
+  if (anchor === "start" && anchorBoundary !== undefined) {
+    const startX = anchorBoundary + dotGap;
+    const dotCount = Math.max(1, Math.floor((x2 - startX) / dotGap) + 1);
+    return Array.from(
+      { length: dotCount },
+      (_, index) => startX + index * dotGap,
+    );
+  }
+
+  if (anchor === "end" && anchorBoundary !== undefined) {
+    const endX = anchorBoundary - dotGap;
+    const dotCount = Math.max(1, Math.floor((endX - x1) / dotGap) + 1);
+    const startX = endX - (dotCount - 1) * dotGap;
+    return Array.from(
+      { length: dotCount },
+      (_, index) => startX + index * dotGap,
+    );
+  }
+
   const drawableWidth = Math.max(0, width - edgeInset * 2);
   const dotCount = Math.max(1, Math.floor(drawableWidth / dotGap) + 1);
   const dotSpan = (dotCount - 1) * dotGap;
-  const startX =
-    anchor === "start"
-      ? x1 + edgeInset
-      : anchor === "end"
-        ? x2 - edgeInset - dotSpan
-        : x1 + (width - dotSpan) / 2;
+  const startX = x1 + (width - dotSpan) / 2;
 
   return Array.from(
     { length: dotCount },
@@ -165,6 +183,7 @@ export function buildUnderlineSegments({
           color: underline,
           dotted: false,
           dotAnchor: undefined,
+          dotAnchorBoundary: undefined,
           underlineGroupKey: segment.underlineGroupKey,
           debugX: segment.x,
           debugY: segment.y,
@@ -191,6 +210,12 @@ export function buildUnderlineSegments({
         : computedSegments[index + 1]?.text === HINT_SPLIT_MARKER
           ? "end"
           : undefined;
+    const dotAnchorBoundary =
+      computedSegments[index - 1]?.text === HINT_SPLIT_MARKER
+        ? computedSegments[index - 1]?.x
+        : computedSegments[index + 1]?.text === HINT_SPLIT_MARKER
+          ? computedSegments[index + 1]?.x
+          : undefined;
     segmentsToDraw.push({
       key: segment.key,
       x1: segment.x + edgeInset,
@@ -199,6 +224,7 @@ export function buildUnderlineSegments({
       color: underline,
       dotted,
       dotAnchor,
+      dotAnchorBoundary,
       underlineGroupKey: segment.underlineGroupKey,
       debugX: segment.x,
       debugY: segment.y,

--- a/app-mobile/src/story/HintTextUnderline.ts
+++ b/app-mobile/src/story/HintTextUnderline.ts
@@ -3,7 +3,7 @@ import type { Token } from "./HintTextTokens";
 export const UNDERLINE_EDGE_INSET = 2;
 export const UNDERLINE_DOT_RADIUS = 1.2;
 export const UNDERLINE_DOT_GAP = 7;
-export const UNDERLINE_HINT_EDGE_INSET = UNDERLINE_DOT_GAP;
+export const UNDERLINE_HINT_EDGE_INSET = UNDERLINE_DOT_GAP / 2;
 export const HINT_SPLIT_MARKER = "\u2060";
 export const UNDERLINE_BASELINE_GAP = 4;
 export const UNDERLINE_BOTTOM_INSET = 2;

--- a/app-mobile/src/story/HintTextUnderline.ts
+++ b/app-mobile/src/story/HintTextUnderline.ts
@@ -4,6 +4,7 @@ export const UNDERLINE_EDGE_INSET = 2;
 export const UNDERLINE_DOT_RADIUS = 1.2;
 export const UNDERLINE_DOT_GAP = 7;
 export const UNDERLINE_HINT_EDGE_INSET = UNDERLINE_DOT_GAP / 2;
+export const UNDERLINE_DOT_EDGE_INSET = UNDERLINE_DOT_GAP;
 export const HINT_SPLIT_MARKER = "\u2060";
 export const UNDERLINE_BASELINE_GAP = 5;
 export const UNDERLINE_BOTTOM_INSET = 2;
@@ -51,13 +52,16 @@ export function getDottedUnderlineDotCenters({
   x1,
   x2,
   dotGap = UNDERLINE_DOT_GAP,
+  edgeInset = 0,
 }: {
   x1: number;
   x2: number;
   dotGap?: number;
+  edgeInset?: number;
 }): number[] {
   const width = Math.max(0, x2 - x1);
-  const dotCount = Math.max(1, Math.floor(width / dotGap) + 1);
+  const drawableWidth = Math.max(0, width - edgeInset * 2);
+  const dotCount = Math.max(1, Math.floor(drawableWidth / dotGap) + 1);
   const dotSpan = (dotCount - 1) * dotGap;
   const startX = x1 + (width - dotSpan) / 2;
 

--- a/app-mobile/src/story/HintTextUnderline.ts
+++ b/app-mobile/src/story/HintTextUnderline.ts
@@ -1,9 +1,9 @@
 import type { Token } from "./HintTextTokens";
 
 export const UNDERLINE_EDGE_INSET = 2;
-export const UNDERLINE_HINT_EDGE_INSET = 10;
 export const UNDERLINE_DOT_RADIUS = 1.2;
 export const UNDERLINE_DOT_GAP = 7;
+export const UNDERLINE_HINT_EDGE_INSET = UNDERLINE_DOT_GAP;
 export const HINT_SPLIT_MARKER = "\u2060";
 export const UNDERLINE_BASELINE_GAP = 4;
 export const UNDERLINE_BOTTOM_INSET = 2;

--- a/app-mobile/src/story/HintTextUnderline.ts
+++ b/app-mobile/src/story/HintTextUnderline.ts
@@ -5,7 +5,7 @@ export const UNDERLINE_DOT_RADIUS = 1.2;
 export const UNDERLINE_DOT_GAP = 7;
 export const UNDERLINE_HINT_EDGE_INSET = UNDERLINE_DOT_GAP / 2;
 export const HINT_SPLIT_MARKER = "\u2060";
-export const UNDERLINE_BASELINE_GAP = 4;
+export const UNDERLINE_BASELINE_GAP = 5;
 export const UNDERLINE_BOTTOM_INSET = 2;
 
 export type NativeTokenPart = {
@@ -46,6 +46,26 @@ export type UnderlineColors = {
   border: string;
   hiddenUnderline: string;
 };
+
+export function getDottedUnderlineDotCenters({
+  x1,
+  x2,
+  dotGap = UNDERLINE_DOT_GAP,
+}: {
+  x1: number;
+  x2: number;
+  dotGap?: number;
+}): number[] {
+  const width = Math.max(0, x2 - x1);
+  const dotCount = Math.max(1, Math.floor(width / dotGap) + 1);
+  const dotSpan = (dotCount - 1) * dotGap;
+  const startX = x1 + (width - dotSpan) / 2;
+
+  return Array.from(
+    { length: dotCount },
+    (_, index) => startX + index * dotGap,
+  );
+}
 
 export function splitNativeTokenParts({
   token,

--- a/app-mobile/src/story/HintTextUnderline.ts
+++ b/app-mobile/src/story/HintTextUnderline.ts
@@ -1,0 +1,210 @@
+import type { Token } from "./HintTextTokens";
+
+export const UNDERLINE_EDGE_INSET = 2;
+export const UNDERLINE_HINT_EDGE_INSET = 10;
+export const UNDERLINE_DOT_RADIUS = 1.2;
+export const UNDERLINE_DOT_GAP = 7;
+export const HINT_SPLIT_MARKER = "\u2060";
+export const UNDERLINE_BASELINE_GAP = 4;
+export const UNDERLINE_BOTTOM_INSET = 2;
+
+export type NativeTokenPart = {
+  text: string;
+  underlineGroupKey?: string;
+  hint?: Token["hint"] | null;
+};
+
+export type MeasuredUnderlineSegment = {
+  key: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  ascender: number;
+  hidden: boolean;
+  revealed: boolean;
+  hint?: Token["hint"];
+  text: string;
+  underlineGroupKey?: string;
+};
+
+export type UnderlineSegment = {
+  key: string;
+  x1: number;
+  x2: number;
+  y: number;
+  color: string;
+  dotted: boolean;
+  underlineGroupKey?: string;
+  debugX: number;
+  debugY: number;
+  debugWidth: number;
+  debugHeight: number;
+};
+
+export type UnderlineColors = {
+  border: string;
+  hiddenUnderline: string;
+};
+
+export function splitNativeTokenParts({
+  token,
+  displayText,
+  shouldSplitIntoGraphemes,
+  splitIntoGraphemes,
+}: {
+  token: Token;
+  displayText: string;
+  shouldSplitIntoGraphemes: boolean;
+  splitIntoGraphemes: (text: string) => string[];
+}): NativeTokenPart[] {
+  if (token.hidden || !displayText.includes(HINT_SPLIT_MARKER)) {
+    return shouldSplitIntoGraphemes
+      ? splitIntoGraphemes(displayText).map((text) => ({ text }))
+      : [{ text: displayText }];
+  }
+
+  const rawParts = displayText.split(new RegExp(`(${HINT_SPLIT_MARKER})`, "u"));
+  let underlinePart = 0;
+  return rawParts
+    .filter((text) => text !== "")
+    .map((text) => {
+      if (text === HINT_SPLIT_MARKER) {
+        return { text, hint: null, underlineGroupKey: undefined };
+      }
+
+      const underlineGroupKey = token.revealed
+        ? `revealed:${token.start}:${underlinePart}`
+        : token.hintGroupKey
+          ? `${token.hintGroupKey}:${underlinePart}`
+          : undefined;
+      underlinePart += 1;
+      return { text, hint: token.hint, underlineGroupKey };
+    });
+}
+
+function getBaselineY(segment: MeasuredUnderlineSegment) {
+  return segment.y + segment.ascender;
+}
+
+function getUnderlineY(segment: MeasuredUnderlineSegment) {
+  const baselineY = getBaselineY(segment);
+  const preferredY = baselineY + UNDERLINE_BASELINE_GAP;
+  const minY = segment.y + UNDERLINE_BOTTOM_INSET;
+  const maxY = segment.y + segment.height - UNDERLINE_BOTTOM_INSET;
+  return Math.max(minY, Math.min(preferredY, maxY));
+}
+
+export function buildUnderlineSegments({
+  computedSegments,
+  colors,
+}: {
+  computedSegments: MeasuredUnderlineSegment[];
+  colors: UnderlineColors;
+}): UnderlineSegment[] {
+  const segmentsToDraw: UnderlineSegment[] = [];
+  const hiddenGroupSpans = new Map<string, UnderlineSegment>();
+  for (const segment of computedSegments) {
+    const interactive = Boolean(segment.hint) && !segment.hidden;
+    const underline = segment.hidden
+      ? colors.hiddenUnderline
+      : segment.revealed || interactive
+        ? colors.border
+        : undefined;
+    if (!underline) continue;
+
+    if (segment.hidden && segment.underlineGroupKey) {
+      const y = getUnderlineY(segment);
+      const lineKey = `${segment.underlineGroupKey}:${Math.round(y)}`;
+      const existing = hiddenGroupSpans.get(lineKey);
+      if (existing) {
+        const right = Math.max(existing.x2, segment.x + segment.width);
+        existing.x1 = Math.min(existing.x1, segment.x);
+        existing.x2 = right;
+        existing.debugX = Math.min(existing.debugX, segment.x);
+        existing.debugWidth = right - existing.debugX;
+        existing.debugHeight = Math.max(existing.debugHeight, segment.height);
+      } else {
+        hiddenGroupSpans.set(lineKey, {
+          key: lineKey,
+          x1: segment.x,
+          x2: segment.x + segment.width,
+          y,
+          color: underline,
+          dotted: false,
+          underlineGroupKey: segment.underlineGroupKey,
+          debugX: segment.x,
+          debugY: segment.y,
+          debugWidth: segment.width,
+          debugHeight: segment.height,
+        });
+      }
+      continue;
+    }
+
+    if (/^\s+$/.test(segment.text) && !segment.underlineGroupKey) continue;
+    if (
+      /^[,.:;!?%)}\]\u3001\u3002\u30fb\uff01\uff1f\uff09\uff0c\uff0e\u200b-\u200d\ufeff]+$/u.test(
+        segment.text,
+      )
+    )
+      continue;
+
+    const dotted = !segment.hidden;
+    const edgeInset = dotted ? UNDERLINE_HINT_EDGE_INSET : UNDERLINE_EDGE_INSET;
+    segmentsToDraw.push({
+      key: segment.key,
+      x1: segment.x + edgeInset,
+      x2: segment.x + Math.max(segment.width - edgeInset, edgeInset * 2),
+      y: getUnderlineY(segment),
+      color: underline,
+      dotted,
+      underlineGroupKey: segment.underlineGroupKey,
+      debugX: segment.x,
+      debugY: segment.y,
+      debugWidth: segment.width,
+      debugHeight: segment.height,
+    });
+  }
+  for (const segment of hiddenGroupSpans.values()) {
+    segmentsToDraw.push({
+      ...segment,
+      x1: segment.x1 + UNDERLINE_EDGE_INSET,
+      x2: segment.x2 - UNDERLINE_EDGE_INSET,
+    });
+  }
+
+  segmentsToDraw.sort((a, b) => {
+    if (Math.abs(a.y - b.y) > 2) return a.y - b.y;
+    return a.x1 - b.x1;
+  });
+
+  const merged: UnderlineSegment[] = [];
+  for (const segment of segmentsToDraw) {
+    const last = merged[merged.length - 1];
+    const sameGroupOnSameLine =
+      last &&
+      Math.abs(last.y - segment.y) <= 2 &&
+      last.color === segment.color &&
+      last.dotted === segment.dotted &&
+      last.underlineGroupKey !== undefined &&
+      last.underlineGroupKey === segment.underlineGroupKey;
+    if (
+      sameGroupOnSameLine ||
+      (last &&
+        Math.abs(last.y - segment.y) <= 2 &&
+        Math.abs(last.x2 - segment.x1) <= 4 &&
+        last.color === segment.color &&
+        last.dotted === segment.dotted &&
+        last.underlineGroupKey === segment.underlineGroupKey)
+    ) {
+      last.x2 = segment.x2;
+      last.debugWidth = segment.debugX + segment.debugWidth - last.debugX;
+      last.debugHeight = Math.max(last.debugHeight, segment.debugHeight);
+      continue;
+    }
+    merged.push(segment);
+  }
+
+  return merged;
+}


### PR DESCRIPTION
## Summary

- Add mobile support for split-word hint underlines using the existing `\u2060` split marker.
- Keep hidden challenge underlines continuous while allowing hinted split words to show a small visual underline gap.
- Anchor dotted underline placement to the split marker boundary so Android's measured width for the invisible joiner does not create an oversized gap.
- Center normal dotted underline cadence while preserving a one-missing-dot gap at split boundaries.

## Root Cause

Android native text layout can assign non-zero width to the invisible `\u2060` joiner. The underline dots were previously placed from the next visible segment's measured `x`, so the visual gap included that invisible width and looked like two missing dots.

## Validation

- `pnpm --dir app-mobile format`
- `pnpm exec vitest run --config vitest.mobile.config.ts app-mobile/src/story/HintText.test.ts`
- `pnpm --dir app-mobile lint`
- `pnpm --dir app-mobile typecheck`
- Android emulator screenshot measurement on story 7734:
  - before latest fix: normal dot pitch `~73.4 px`, split gap `~194.4 px`, `2` missing dot slots
  - after latest fix: normal dot pitch `~73.3 px`, split gap `~136.6 px`, `1` missing dot slot

## Screenshots

- Full Android capture: http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260730T185322Z-android-story-7734-boundary-measured-after.png
- `wasi⁠pim` zoom: http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260730T185322Z-android-story-7734-boundary-measured-after-wasipim-zoom.png