### PR TITLE
Honor explicit empty translation hint placeholders

### DIFF
--- a/src/components/editor/story/syntax_parser_new.ts
+++ b/src/components/editor/story/syntax_parser_new.ts
@@ -376,6 +376,7 @@ function speaker_text_trans(
   text = inlineTtsData.normalizedText;
   const ipa_replacements = inlineTtsData.replacements;
   let content = generateHintMap(text, translation, pronunciation);
+  content.hasTranslationLine = Boolean(data.trans?.slice(1).trim());
 
   let selectablePhrases, characterPositions;
   if (use_buttons)

--- a/src/components/editor/story/syntax_parser_types.ts
+++ b/src/components/editor/story/syntax_parser_types.ts
@@ -23,6 +23,7 @@ export interface HintMapResult {
   hintMap: HintMapItem[];
   hints: string[];
   hints_pronunciation?: string[];
+  hasTranslationLine?: boolean;
   text: string;
   audio?: Audio;
   lang_hints?: string;
@@ -31,6 +32,7 @@ export interface HintMapResult {
 
 export interface ContentWithHints {
   hintMap: HintMapItem[];
+  hasTranslationLine?: boolean;
   text: string;
   [key: string]: any; // For additional properties
 }

--- a/src/lib/editor/lint/lint_story.test.ts
+++ b/src/lib/editor/lint/lint_story.test.ts
@@ -205,6 +205,21 @@ Speaker414: Bonjour le monde.`);
   assert.equal(byRule(findings, "missing-hints").length, 1);
 });
 
+test("accepts an explicit placeholder for a line without a translation hint", () => {
+  const findings = lint(`[LINE]
+Speaker414: Grrrr!
+~ ~
+$audio/growl.mp3;5,189`);
+  assert.equal(byRule(findings, "missing-hints").length, 0);
+});
+
+test("does not treat an empty translation line as an explicit placeholder", () => {
+  const findings = lint(`[LINE]
+Speaker414: Grrrr!
+~`);
+  assert.equal(byRule(findings, "missing-hints").length, 1);
+});
+
 test("flags an unknown speaker", () => {
   const findings = lint(`[LINE]
 Speaker999: Bonjour.

--- a/src/lib/editor/lint/lint_story.ts
+++ b/src/lib/editor/lint/lint_story.ts
@@ -515,7 +515,11 @@ function lintElements(
     if (text.includes('"')) hasStraightQuotes = true;
     if (/[“”„]/.test(text)) hasCurlyQuotes = true;
 
-    if (content.hintMap.length === 0 && countWords(splitTextTokens(text)) > 0) {
+    if (
+      !content.hasTranslationLine &&
+      content.hintMap.length === 0 &&
+      countWords(splitTextTokens(text)) > 0
+    ) {
       findings.push({
         rule: "missing-hints",
         severity: "warning",


### PR DESCRIPTION
## Summary

- preserve whether a story line contains an explicit translation-hint line
- treat `~ ~` as an intentional no-hint placeholder in story checks
- keep warning for a missing hint line or a bare, empty `~` line
- add regression coverage for both cases

## Why

The parser intentionally produces an empty hint map for `~ ~`. The lint rule previously used only that empty map to decide that the hint line was missing, so intentional placeholders incorrectly triggered “This line has no translation hints.”

The parser now retains the presence of a meaningful translation line separately from its rendered hint mappings. This lets contributors explicitly suppress a hint for non-lexical dialogue such as `Grrrr!` without weakening the missing-hint check.

## Validation

- `pnpm test` — 168 tests passed
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm run format`
