### PR TITLE
Ignore punctuation-only forced-alignment segments

### DIFF
--- a/scripts/forced-align-story-audio.ts
+++ b/scripts/forced-align-story-audio.ts
@@ -12,7 +12,10 @@ import type {
 } from "../src/components/editor/story/syntax_parser_types";
 import type { Avatar } from "../src/app/editor/story/[story]/types";
 import { timings_to_text } from "../src/lib/editor/audio/audio_edit_tools";
-import { findNextMatchingAlignedWord } from "./lib/forced-alignment-safety";
+import {
+  findNextMatchingAlignedWord,
+  keepLexicalAlignedWords,
+} from "./lib/forced-alignment-safety";
 import { getAudioBackedStoryItems } from "./lib/forced-alignment-story-items";
 
 const DEFAULT_AUDIO_BASE_URL =
@@ -281,7 +284,7 @@ async function readAlignedWords(jsonPath: string) {
   const parsed = JSON.parse(raw) as unknown;
   const candidates = collectWordCandidates(parsed);
 
-  return candidates.flatMap((candidate) => {
+  const alignedWords = candidates.flatMap((candidate) => {
     const word = getString(candidate, ["word", "text", "label", "token"]);
     const start = getNumber(candidate, [
       "start",
@@ -301,6 +304,8 @@ async function readAlignedWords(jsonPath: string) {
       },
     ] satisfies AlignedWord[];
   });
+
+  return keepLexicalAlignedWords(alignedWords);
 }
 
 function collectWordCandidates(value: unknown): Record<string, unknown>[] {

--- a/scripts/lib/forced-alignment-safety.test.ts
+++ b/scripts/lib/forced-alignment-safety.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   findNextMatchingAlignedWord,
+  keepLexicalAlignedWords,
   selectLatestSuccessfulStoryRuns,
   validateAlignmentAudioFile,
   validateAlignmentArtifactStoryIds,
@@ -71,6 +72,29 @@ test("a mismatched aligner token is not accepted as a fallback match", () => {
       0,
     ),
     null,
+  );
+});
+
+test("punctuation-only aligner segments are ignored before warning checks", () => {
+  assert.deepEqual(
+    keepLexicalAlignedWords([
+      { word: "dig", normalized: "dig", startMs: 700 },
+      { word: "…", normalized: "", startMs: 800 },
+    ]),
+    [{ word: "dig", normalized: "dig", startMs: 700 }],
+  );
+});
+
+test("lexical aligner segments remain available to mismatch warnings", () => {
+  assert.deepEqual(
+    keepLexicalAlignedWords([
+      { word: "dig", normalized: "dig", startMs: 700 },
+      { word: "ekstra", normalized: "ekstra", startMs: 800 },
+    ]),
+    [
+      { word: "dig", normalized: "dig", startMs: 700 },
+      { word: "ekstra", normalized: "ekstra", startMs: 800 },
+    ],
   );
 });
 

--- a/scripts/lib/forced-alignment-safety.ts
+++ b/scripts/lib/forced-alignment-safety.ts
@@ -76,3 +76,9 @@ export function findNextMatchingAlignedWord<
   }
   return null;
 }
+
+export function keepLexicalAlignedWords<T extends { normalized: string }>(
+  alignedWords: T[],
+) {
+  return alignedWords.filter((word) => word.normalized.length > 0);
+}


### PR DESCRIPTION
## Summary

- filter forced-alignment segments whose normalized content is empty before warning calculation
- keep lexical segments unchanged so genuine unmatched-word and trailing-word warnings still surface
- add regression coverage for story 7799's punctuation-only ellipsis and for a real trailing lexical segment

## Why

Story 7799's aligner output includes `…` as a separate timed segment. Because punctuation normalizes to an empty token, counting that segment as a word produced a false `1 trailing aligned word(s).` warning and prevented the reviewed artifact from being applied.

## Impact

Only punctuation-only aligner output is ignored. Exact lexical token matching and the dedicated safe batch-apply path from #540 are unchanged.

This is a stacked PR targeting `codex/forced-alignment-admin-workflow`; it should merge after or into #540.

## Verification

- `pnpm exec tsx --test scripts/lib/forced-alignment-safety.test.ts` — 10 passed
- `pnpm test` — 178 passed
- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- standards review — no findings
- spec review — no findings
