### PR TITLE
Story pages: large Twitter card + article og:type

### DIFF
--- a/src/app/(stories)/story/[story_id]/page.tsx
+++ b/src/app/(stories)/story/[story_id]/page.tsx
@@ -83,11 +83,12 @@ export async function generateMetadata({
         images: [
           `/api/og-story?title=${storyMeta.from_language_name}&image=${storyMeta.image}&name=${storyMeta.learning_language_long}`,
         ],
-        type: "website",
+        type: "article",
         title,
         description,
       },
       twitter: {
+        card: "summary_large_image",
         title,
         description,
       },
@@ -106,11 +107,12 @@ export async function generateMetadata({
         `/api/og-story?title=${storyMeta.from_language_name}&image=${storyMeta.image}&name=${storyMeta.learning_language_long}`,
       ],
       url: `https://duostories.org/story/${story_id}`,
-      type: "website",
+      type: "article",
       title,
       description,
     },
     twitter: {
+      card: "summary_large_image",
       title,
       description,
     },


### PR DESCRIPTION
Closes the last metadata-polish TODO from the SEO review: story pages generate per-story OG images but still declared `twitter:card: summary`, so shares on X rendered the small thumbnail card. Course pages already use `summary_large_image` — this brings story pages in line, and switches `og:type` from `website` to `article` (both the public and the noindex metadata branches).

Verified: typecheck + lint green. Two-line semantic change, no behavior beyond metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)