### PR TITLE
Keep inline hint segments together

### DIFF
--- a/src/components/StoryLineHints/StoryLineHints.test.ts
+++ b/src/components/StoryLineHints/StoryLineHints.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import StoryLineHints from "./StoryLineHints";
+
+test("inline hint segments keep multi-word phrases together", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(StoryLineHints, {
+      content: {
+        text: "Ancha k acham",
+        hintMap: [{ hintIndex: 0, rangeFrom: 0, rangeTo: 12 }],
+        hints: ["bonita es"],
+      },
+      showTranslationsInline: true,
+    }),
+  );
+
+  assert.match(
+    html,
+    /my-0\.5 inline-flex grow flex-col whitespace-nowrap/,
+    "the complete hint segment should not wrap internally",
+  );
+  assert.match(
+    html,
+    /<span class="whitespace-nowrap"><span class="select-text">Ancha<\/span><span class="select-text"> <\/span><span class="select-text">k<\/span><span class="select-text"> <\/span><span class="select-text">acham<\/span><\/span>/,
+    "the source phrase should be one flex row",
+  );
+});

--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -330,7 +330,7 @@ function StoryLineHints({
       ? ""
       : showTrans
         ? has_any_hint
-          ? "group/editorhint inline-flex grow flex-col"
+          ? "group/editorhint my-0.5 inline-flex grow flex-col whitespace-nowrap"
           : ""
         : has_translation_hint
           ? cn(
@@ -362,7 +362,11 @@ function StoryLineHints({
           was_hidden_for_challenge && !is_hidden ? true : undefined
         }
       >
-        {word_content}
+        {showTrans && has_any_hint ? (
+          <span className="whitespace-nowrap">{word_content}</span>
+        ) : (
+          word_content
+        )}
         {showTrans ? (
           has_any_hint ? (
             <span className={hintTextClassName} style={editorHintTextStyle}>


### PR DESCRIPTION
## Summary

- keep each inline hint segment on one line and allow only the complete segment to wrap
- group multi-word source phrases into one flex row above their translation
- add a small vertical gap between wrapped hint rows
- add regression coverage for multi-word inline hints

## Root cause

The renderer split hinted phrases into multiple spans, then inserted those spans directly into a column flex container. Each token became its own flex row, so phrases could break vertically inside one hint segment.

## Impact

Multi-word hint segments now remain intact. When space runs out, the complete phrase and its translation move to the next line together, with slightly more breathing room between wrapped rows.

## Validation

- `pnpm test` (169 passing)
- `pnpm run lint`
- `pnpm typecheck`
- constrained-width browser verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline translation hints so multi-word phrases stay together without unwanted wrapping.
  * Refined hint spacing and layout for a more consistent reading experience.

* **Tests**
  * Added coverage to verify inline hints remain intact and each word is rendered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->