### PR TITLE
Suppress inherited root canonical on noindex story pages

### DIFF
--- a/src/app/(stories)/story/[story_id]/page.tsx
+++ b/src/app/(stories)/story/[story_id]/page.tsx
@@ -75,6 +75,9 @@ export async function generateMetadata({
       title,
       description,
       robots: { index: false, follow: false },
+      // Explicit null: otherwise the story layout's site-root canonical is
+      // inherited, and noindex pages would claim the homepage as canonical.
+      alternates: { canonical: null },
       keywords: [
         storyMeta.learning_language_long,
         storyMeta.from_language_long,


### PR DESCRIPTION
Found while verifying today's merged SEO changes in production: draft/unpublished story pages (e.g. /story/9866, /story/1) render `<link rel="canonical" href="https://duostories.org"/>` next to their `noindex` — the story segment layout (`src/app/(stories)/story/layout.tsx`) declares the site root as a blanket canonical, and since #635's noindex branch omits `alternates`, Next's metadata merging inherits it. Telling Google "this page is a duplicate of the homepage" alongside noindex is a conflicting signal.

Fix: explicit `alternates: { canonical: null }` in the noindex branch — no canonical tag renders at all. Public story pages already override the layout value and are unaffected.

Worth considering separately: whether the layout-level root canonical should exist at all — any future page under /story that forgets to set its own canonical silently claims the homepage.

Verified: typecheck + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)