### PR TITLE
Add learner interest signals for courses

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as authMigration from "../authMigration.js";
 import type * as authProviderConfig from "../authProviderConfig.js";
 import type * as authProviders from "../authProviders.js";
 import type * as courseContributorBackfill from "../courseContributorBackfill.js";
+import type * as courseInterest from "../courseInterest.js";
 import type * as courseWrite from "../courseWrite.js";
 import type * as discordAvatarSync from "../discordAvatarSync.js";
 import type * as discordBot from "../discordBot.js";
@@ -74,6 +75,7 @@ declare const fullApi: ApiFromModules<{
   authProviderConfig: typeof authProviderConfig;
   authProviders: typeof authProviders;
   courseContributorBackfill: typeof courseContributorBackfill;
+  courseInterest: typeof courseInterest;
   courseWrite: typeof courseWrite;
   discordAvatarSync: typeof discordAvatarSync;
   discordBot: typeof discordBot;

--- a/convex/courseInterest.test.ts
+++ b/convex/courseInterest.test.ts
@@ -1,0 +1,163 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function seedCourse(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const learningLanguageId = await ctx.db.insert("languages", {
+      legacyId: 1,
+      name: "Welsh",
+      short: "cy",
+      public: true,
+      rtl: false,
+    });
+    const fromLanguageId = await ctx.db.insert("languages", {
+      legacyId: 2,
+      name: "English",
+      short: "en",
+      public: true,
+      rtl: false,
+    });
+    const courseId = await ctx.db.insert("courses", {
+      legacyId: 100,
+      short: "cy-en",
+      learningLanguageId,
+      fromLanguageId,
+      public: true,
+      official: false,
+      count: 2,
+    });
+    const firstStoryId = await ctx.db.insert("stories", {
+      legacyId: 10,
+      name: "First",
+      public: true,
+      deleted: false,
+      courseId,
+      status: "finished",
+      todo_count: 0,
+    });
+    const secondStoryId = await ctx.db.insert("stories", {
+      legacyId: 11,
+      name: "Second",
+      public: true,
+      deleted: false,
+      courseId,
+      status: "finished",
+      todo_count: 0,
+    });
+    return { courseId, firstStoryId, secondStoryId };
+  });
+}
+
+describe("course interest", () => {
+  test("an anonymous learner can add and remove one signal", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourse(t);
+    const args = {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+    };
+
+    expect(await t.query(api.courseInterest.getForLearner, args)).toEqual({
+      interested: false,
+      completedAllAtSignal: false,
+      totalCount: 0,
+    });
+
+    expect(
+      await t.mutation(api.courseInterest.setForLearner, {
+        ...args,
+        interested: true,
+      }),
+    ).toEqual({
+      interested: true,
+      completedAllAtSignal: false,
+      totalCount: 1,
+    });
+    expect(
+      await t.mutation(api.courseInterest.setForLearner, {
+        ...args,
+        interested: true,
+      }),
+    ).toMatchObject({ totalCount: 1 });
+
+    expect(
+      await t.mutation(api.courseInterest.setForLearner, {
+        ...args,
+        interested: false,
+      }),
+    ).toEqual({
+      interested: false,
+      completedAllAtSignal: false,
+      totalCount: 0,
+    });
+  });
+
+  test("marks a signed-in signal when every story is complete", async () => {
+    const t = convexTest(schema, modules);
+    const { courseId, firstStoryId, secondStoryId } = await seedCourse(t);
+    await t.run(async (ctx) => {
+      for (const [storyId, legacyStoryId] of [
+        [firstStoryId, 10],
+        [secondStoryId, 11],
+      ] as const) {
+        await ctx.db.insert("story_done_state", {
+          storyId,
+          courseId,
+          legacyStoryId,
+          legacyCourseId: 100,
+          legacyUserId: 7,
+          lastDoneAt: Date.now(),
+        });
+      }
+    });
+
+    const learner = t.withIdentity({ userId: "7", role: "user" });
+    const result = await learner.mutation(api.courseInterest.setForLearner, {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+      interested: true,
+    });
+    expect(result).toMatchObject({
+      interested: true,
+      completedAllAtSignal: true,
+      totalCount: 1,
+    });
+
+    const editor = t.withIdentity({ userId: "8", role: "contributor" });
+    expect(
+      await editor.query(api.courseInterest.getForEditor, {
+        courseIdentifier: "cy-en",
+      }),
+    ).toMatchObject({
+      totalCount: 1,
+      completedAllCount: 1,
+    });
+  });
+
+  test("merges a browser signal into the signed-in learner", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourse(t);
+    const args = {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+      interested: true,
+    };
+    await t.mutation(api.courseInterest.setForLearner, args);
+
+    const learner = t.withIdentity({ userId: "7", role: "user" });
+    expect(
+      await learner.mutation(api.courseInterest.setForLearner, args),
+    ).toMatchObject({ totalCount: 1 });
+
+    const signals = await t.run(async (ctx) => {
+      return await ctx.db.query("course_interest_signals").collect();
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.supporterKey).toBe("user:7");
+  });
+});

--- a/convex/courseInterest.test.ts
+++ b/convex/courseInterest.test.ts
@@ -22,6 +22,14 @@ async function seedCourse(t: ReturnType<typeof convexTest>) {
       public: true,
       rtl: false,
     });
+    const imageId = await ctx.db.insert("images", {
+      legacyId: "welsh-interest",
+      active: "active.svg",
+      gilded: "gilded.svg",
+      locked: "locked.svg",
+      active_lip: "active-lip.svg",
+      gilded_lip: "gilded-lip.svg",
+    });
     const courseId = await ctx.db.insert("courses", {
       legacyId: 100,
       short: "cy-en",
@@ -37,6 +45,7 @@ async function seedCourse(t: ReturnType<typeof convexTest>) {
       public: true,
       deleted: false,
       courseId,
+      imageId,
       status: "finished",
       todo_count: 0,
     });
@@ -46,10 +55,11 @@ async function seedCourse(t: ReturnType<typeof convexTest>) {
       public: true,
       deleted: false,
       courseId,
+      imageId,
       status: "finished",
       todo_count: 0,
     });
-    return { courseId, firstStoryId, secondStoryId };
+    return { courseId, firstStoryId, secondStoryId, imageId };
   });
 }
 
@@ -64,8 +74,7 @@ describe("course interest", () => {
 
     expect(await t.query(api.courseInterest.getForLearner, args)).toEqual({
       interested: false,
-      completedAllAtSignal: false,
-      totalCount: 0,
+      completedAllAvailableStories: false,
     });
 
     expect(
@@ -75,15 +84,17 @@ describe("course interest", () => {
       }),
     ).toEqual({
       interested: true,
-      completedAllAtSignal: false,
-      totalCount: 1,
+      completedAllAvailableStories: false,
     });
     expect(
       await t.mutation(api.courseInterest.setForLearner, {
         ...args,
         interested: true,
       }),
-    ).toMatchObject({ totalCount: 1 });
+    ).toEqual({
+      interested: true,
+      completedAllAvailableStories: false,
+    });
 
     expect(
       await t.mutation(api.courseInterest.setForLearner, {
@@ -92,8 +103,7 @@ describe("course interest", () => {
       }),
     ).toEqual({
       interested: false,
-      completedAllAtSignal: false,
-      totalCount: 0,
+      completedAllAvailableStories: false,
     });
   });
 
@@ -124,8 +134,7 @@ describe("course interest", () => {
     });
     expect(result).toMatchObject({
       interested: true,
-      completedAllAtSignal: true,
-      totalCount: 1,
+      completedAllAvailableStories: true,
     });
 
     const editor = t.withIdentity({ userId: "8", role: "contributor" });
@@ -134,9 +143,127 @@ describe("course interest", () => {
         courseIdentifier: "cy-en",
       }),
     ).toMatchObject({
-      totalCount: 1,
+      authenticatedCount: 1,
+      browserCount: 0,
       completedAllCount: 1,
     });
+  });
+
+  test("does not substitute a deleted completion for a visible story", async () => {
+    const t = convexTest(schema, modules);
+    const { courseId, firstStoryId, imageId } = await seedCourse(t);
+    const deletedStoryId = await t.run(async (ctx) => {
+      return await ctx.db.insert("stories", {
+        legacyId: 12,
+        name: "Deleted",
+        public: true,
+        deleted: true,
+        courseId,
+        imageId,
+        status: "finished",
+        todo_count: 0,
+      });
+    });
+    await t.run(async (ctx) => {
+      for (const [storyId, legacyStoryId] of [
+        [firstStoryId, 10],
+        [deletedStoryId, 12],
+      ] as const) {
+        await ctx.db.insert("story_done_state", {
+          storyId,
+          courseId,
+          legacyStoryId,
+          legacyCourseId: 100,
+          legacyUserId: 7,
+          lastDoneAt: Date.now(),
+        });
+      }
+    });
+
+    const learner = t.withIdentity({ userId: "7", role: "user" });
+    expect(
+      await learner.mutation(api.courseInterest.setForLearner, {
+        courseShort: "cy-en",
+        anonymousId: "browser_supporter_123456",
+        interested: true,
+      }),
+    ).toMatchObject({ completedAllAvailableStories: false });
+  });
+
+  test("upgrades an existing signal when the learner finishes the final story", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourse(t);
+    const learner = t.withIdentity({ userId: "7", role: "user" });
+    await learner.mutation(api.storyDone.recordStoryDone, {
+      legacyStoryId: 10,
+    });
+    await learner.mutation(api.courseInterest.setForLearner, {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+      interested: true,
+    });
+
+    await learner.mutation(api.storyDone.recordStoryDone, {
+      legacyStoryId: 11,
+    });
+
+    const editor = t.withIdentity({ userId: "8", role: "contributor" });
+    expect(
+      await editor.query(api.courseInterest.getForEditor, {
+        courseIdentifier: "cy-en",
+      }),
+    ).toMatchObject({
+      authenticatedCount: 1,
+      browserCount: 0,
+      completedAllCount: 1,
+    });
+  });
+
+  test("keeps qualification as a historical achievement after publication", async () => {
+    const t = convexTest(schema, modules);
+    const { courseId, firstStoryId, secondStoryId, imageId } =
+      await seedCourse(t);
+    await t.run(async (ctx) => {
+      for (const [storyId, legacyStoryId] of [
+        [firstStoryId, 10],
+        [secondStoryId, 11],
+      ] as const) {
+        await ctx.db.insert("story_done_state", {
+          storyId,
+          courseId,
+          legacyStoryId,
+          legacyCourseId: 100,
+          legacyUserId: 7,
+          lastDoneAt: Date.now(),
+        });
+      }
+    });
+    const learner = t.withIdentity({ userId: "7", role: "user" });
+    await learner.mutation(api.courseInterest.setForLearner, {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+      interested: true,
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("stories", {
+        legacyId: 13,
+        name: "Newly published",
+        public: true,
+        deleted: false,
+        courseId,
+        imageId,
+        status: "finished",
+        todo_count: 0,
+      });
+    });
+
+    const editor = t.withIdentity({ userId: "8", role: "contributor" });
+    expect(
+      await editor.query(api.courseInterest.getForEditor, {
+        courseIdentifier: "cy-en",
+      }),
+    ).toMatchObject({ completedAllCount: 1 });
   });
 
   test("merges a browser signal into the signed-in learner", async () => {
@@ -152,12 +279,62 @@ describe("course interest", () => {
     const learner = t.withIdentity({ userId: "7", role: "user" });
     expect(
       await learner.mutation(api.courseInterest.setForLearner, args),
-    ).toMatchObject({ totalCount: 1 });
+    ).toEqual({
+      interested: true,
+      completedAllAvailableStories: false,
+    });
 
     const signals = await t.run(async (ctx) => {
       return await ctx.db.query("course_interest_signals").collect();
     });
     expect(signals).toHaveLength(1);
     expect(signals[0]?.supporterKey).toBe("user:7");
+  });
+
+  test("separates browser and authenticated evidence", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourse(t);
+    await t.mutation(api.courseInterest.setForLearner, {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+      interested: true,
+    });
+    const learner = t.withIdentity({ userId: "7", role: "user" });
+    await learner.mutation(api.courseInterest.setForLearner, {
+      courseShort: "cy-en",
+      anonymousId: "another_browser_123456",
+      interested: true,
+    });
+
+    const editor = t.withIdentity({ userId: "8", role: "contributor" });
+    expect(
+      await editor.query(api.courseInterest.getForEditor, {
+        courseIdentifier: "cy-en",
+      }),
+    ).toMatchObject({
+      authenticatedCount: 1,
+      browserCount: 1,
+      completedAllCount: 0,
+    });
+  });
+
+  test("limits bursts of new browser signals for one course", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourse(t);
+    for (let index = 0; index < 30; index += 1) {
+      await t.mutation(api.courseInterest.setForLearner, {
+        courseShort: "cy-en",
+        anonymousId: `browser_supporter_${String(index).padStart(6, "0")}`,
+        interested: true,
+      });
+    }
+
+    await expect(
+      t.mutation(api.courseInterest.setForLearner, {
+        courseShort: "cy-en",
+        anonymousId: "browser_supporter_over_limit",
+        interested: true,
+      }),
+    ).rejects.toThrow("Too many new interest signals");
   });
 });

--- a/convex/courseInterest.ts
+++ b/convex/courseInterest.ts
@@ -1,30 +1,54 @@
 import { v } from "convex/values";
-import type { Id } from "./_generated/dataModel";
-import { mutation, query, type MutationCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
 import {
   getSessionLegacyUserId,
   requireContributorOrAdmin,
 } from "./lib/authorization";
+import { listPublicCourseStories } from "./lib/publicCourseStories";
 
 const ANONYMOUS_ID_PATTERN = /^[a-zA-Z0-9_-]{16,100}$/;
+const BROWSER_SIGNAL_WINDOW_MS = 60 * 60 * 1000;
+const MAX_BROWSER_SIGNALS_PER_COURSE_PER_WINDOW = 30;
+const MAX_COMPLETION_ROWS_PER_COURSE = 500;
+
+type ReadCtx = QueryCtx | MutationCtx;
+type InterestSignal = Doc<"course_interest_signals">;
 
 const learnerInterestValidator = v.union(
   v.object({
     interested: v.boolean(),
-    completedAllAtSignal: v.boolean(),
-    totalCount: v.number(),
+    completedAllAvailableStories: v.boolean(),
   }),
   v.null(),
 );
 
 const editorInterestValidator = v.union(
   v.object({
-    totalCount: v.number(),
+    browserCount: v.number(),
+    authenticatedCount: v.number(),
     completedAllCount: v.number(),
-    lastSignalAt: v.union(v.number(), v.null()),
   }),
   v.null(),
 );
+
+type SupporterKeys = {
+  anonymousKey: string;
+  legacyUserId: number | null;
+  primaryKey: string;
+  primaryKind: "browser" | "account";
+};
+
+type StatsDelta = {
+  browser: number;
+  authenticated: number;
+  completedAll: number;
+};
 
 function anonymousSupporterKey(anonymousId: string) {
   if (!ANONYMOUS_ID_PATTERN.test(anonymousId)) {
@@ -33,24 +57,28 @@ function anonymousSupporterKey(anonymousId: string) {
   return `anonymous:${anonymousId}`;
 }
 
+function accountSupporterKey(legacyUserId: number) {
+  return `user:${legacyUserId}`;
+}
+
 async function getSupporterKeys(
-  ctx: Parameters<typeof getSessionLegacyUserId>[0],
+  ctx: ReadCtx,
   anonymousId: string,
-) {
+): Promise<SupporterKeys> {
   const anonymousKey = anonymousSupporterKey(anonymousId);
   const legacyUserId = await getSessionLegacyUserId(ctx);
   return {
     anonymousKey,
     legacyUserId,
     primaryKey:
-      typeof legacyUserId === "number" ? `user:${legacyUserId}` : anonymousKey,
+      typeof legacyUserId === "number"
+        ? accountSupporterKey(legacyUserId)
+        : anonymousKey,
+    primaryKind: typeof legacyUserId === "number" ? "account" : "browser",
   };
 }
 
-async function getCourseByShort(
-  ctx: Parameters<typeof getSessionLegacyUserId>[0],
-  courseShort: string,
-) {
+async function getCourseByShort(ctx: ReadCtx, courseShort: string) {
   return await ctx.db
     .query("courses")
     .withIndex("by_short", (q) => q.eq("short", courseShort))
@@ -58,7 +86,7 @@ async function getCourseByShort(
 }
 
 async function getSignal(
-  ctx: Parameters<typeof getSessionLegacyUserId>[0],
+  ctx: ReadCtx,
   courseId: Id<"courses">,
   supporterKey: string,
 ) {
@@ -70,63 +98,146 @@ async function getSignal(
     .unique();
 }
 
-async function hasCompletedAllPublishedStories(
+async function getSupporterSignals(
+  ctx: ReadCtx,
+  courseId: Id<"courses">,
+  keys: SupporterKeys,
+) {
+  const primarySignal = await getSignal(ctx, courseId, keys.primaryKey);
+  const anonymousSignal =
+    keys.primaryKey === keys.anonymousKey
+      ? null
+      : await getSignal(ctx, courseId, keys.anonymousKey);
+  return { anonymousSignal, primarySignal };
+}
+
+async function hasCompletedAllVisibleStories(
   ctx: MutationCtx,
   courseId: Id<"courses">,
   legacyUserId: number | null,
-  publishedStoryCount: number,
 ) {
-  if (legacyUserId === null || publishedStoryCount === 0) return false;
+  if (legacyUserId === null) return false;
+
+  const visibleStories = await listPublicCourseStories(ctx, courseId);
+  if (visibleStories.length === 0) return false;
 
   const completionRows = await ctx.db
     .query("story_done_state")
     .withIndex("by_user_and_course", (q) =>
       q.eq("legacyUserId", legacyUserId).eq("courseId", courseId),
     )
-    .collect();
-  return (
-    new Set(completionRows.map((row) => row.storyId)).size >=
-    publishedStoryCount
-  );
+    .take(MAX_COMPLETION_ROWS_PER_COURSE + 1);
+  if (completionRows.length > MAX_COMPLETION_ROWS_PER_COURSE) return false;
+
+  const completedStoryIds = new Set(completionRows.map((row) => row.storyId));
+  return visibleStories.every(({ story }) => completedStoryIds.has(story._id));
 }
 
-async function getStats(
-  ctx: Parameters<typeof getSessionLegacyUserId>[0],
-  courseId: Id<"courses">,
-) {
+async function getStats(ctx: ReadCtx, courseId: Id<"courses">) {
   return await ctx.db
     .query("course_interest_stats")
     .withIndex("by_course_id", (q) => q.eq("courseId", courseId))
     .unique();
 }
 
-async function updateStats(
+function assertBrowserSignalAllowance(
+  stats: Doc<"course_interest_stats"> | null,
+  now: number,
+) {
+  if (
+    stats &&
+    now - stats.browserWindowStartedAt < BROWSER_SIGNAL_WINDOW_MS &&
+    stats.browserAddsInWindow >= MAX_BROWSER_SIGNALS_PER_COURSE_PER_WINDOW
+  ) {
+    throw new Error(
+      "Too many new interest signals for this course. Please try again later.",
+    );
+  }
+}
+
+async function applyStatsDelta(
   ctx: MutationCtx,
   courseId: Id<"courses">,
-  changes: { total: number; completedAll: number },
-  lastSignalAt?: number,
+  delta: StatsDelta,
+  options: { consumeBrowserAllowance?: boolean } = {},
 ) {
   const existing = await getStats(ctx, courseId);
   const now = Date.now();
+  if (options.consumeBrowserAllowance) {
+    assertBrowserSignalAllowance(existing, now);
+  }
+
+  const windowExpired =
+    !existing ||
+    now - existing.browserWindowStartedAt >= BROWSER_SIGNAL_WINDOW_MS;
+  const browserWindowStartedAt = windowExpired
+    ? now
+    : existing.browserWindowStartedAt;
+  const browserAddsInWindow = options.consumeBrowserAllowance
+    ? windowExpired
+      ? 1
+      : (existing?.browserAddsInWindow ?? 0) + 1
+    : (existing?.browserAddsInWindow ?? 0);
+
   if (!existing) {
     await ctx.db.insert("course_interest_stats", {
       courseId,
-      totalCount: Math.max(0, changes.total),
-      completedAllCount: Math.max(0, changes.completedAll),
-      lastSignalAt: lastSignalAt ?? null,
+      browserCount: Math.max(0, delta.browser),
+      authenticatedCount: Math.max(0, delta.authenticated),
+      completedAllCount: Math.max(0, delta.completedAll),
+      browserWindowStartedAt,
+      browserAddsInWindow,
       updatedAt: now,
     });
     return;
   }
 
   await ctx.db.patch(existing._id, {
-    totalCount: Math.max(0, existing.totalCount + changes.total),
+    browserCount: Math.max(0, existing.browserCount + delta.browser),
+    authenticatedCount: Math.max(
+      0,
+      existing.authenticatedCount + delta.authenticated,
+    ),
     completedAllCount: Math.max(
       0,
-      existing.completedAllCount + changes.completedAll,
+      existing.completedAllCount + delta.completedAll,
     ),
-    lastSignalAt: lastSignalAt ?? existing.lastSignalAt,
+    browserWindowStartedAt,
+    browserAddsInWindow,
     updatedAt: now,
+  });
+}
+
+function signalStatsDelta(signal: InterestSignal, direction: 1 | -1) {
+  return {
+    browser: signal.supporterKind === "browser" ? direction : 0,
+    authenticated: signal.supporterKind === "account" ? direction : 0,
+    completedAll: signal.completedAllAvailableStoriesAt ? direction : 0,
+  };
+}
+
+export async function maybeQualifyCourseInterestSignal(
+  ctx: MutationCtx,
+  courseId: Id<"courses">,
+  legacyUserId: number,
+) {
+  const signal = await getSignal(
+    ctx,
+    courseId,
+    accountSupporterKey(legacyUserId),
+  );
+  if (!signal || signal.completedAllAvailableStoriesAt) return;
+  if (!(await hasCompletedAllVisibleStories(ctx, courseId, legacyUserId))) {
+    return;
+  }
+
+  await ctx.db.patch(signal._id, {
+    completedAllAvailableStoriesAt: Date.now(),
+  });
+  await applyStatsDelta(ctx, courseId, {
+    browser: 0,
+    authenticated: 0,
+    completedAll: 1,
   });
 }
 
@@ -141,18 +252,16 @@ export const getForLearner = query({
     if (!course?.public) return null;
 
     const keys = await getSupporterKeys(ctx, args.anonymousId);
-    const primarySignal = await getSignal(ctx, course._id, keys.primaryKey);
-    const anonymousSignal =
-      keys.primaryKey === keys.anonymousKey
-        ? null
-        : await getSignal(ctx, course._id, keys.anonymousKey);
+    const { anonymousSignal, primarySignal } = await getSupporterSignals(
+      ctx,
+      course._id,
+      keys,
+    );
     const signal = primarySignal ?? anonymousSignal;
-    const stats = await getStats(ctx, course._id);
-
     return {
       interested: signal !== null,
-      completedAllAtSignal: signal?.completedAllAtSignal ?? false,
-      totalCount: stats?.totalCount ?? 0,
+      completedAllAvailableStories:
+        signal?.completedAllAvailableStoriesAt !== undefined,
     };
   },
 });
@@ -165,97 +274,102 @@ export const setForLearner = mutation({
   },
   returns: v.object({
     interested: v.boolean(),
-    completedAllAtSignal: v.boolean(),
-    totalCount: v.number(),
+    completedAllAvailableStories: v.boolean(),
   }),
   handler: async (ctx, args) => {
     const course = await getCourseByShort(ctx, args.courseShort);
     if (!course?.public) throw new Error("Course not found.");
 
     const keys = await getSupporterKeys(ctx, args.anonymousId);
-    const primarySignal = await getSignal(ctx, course._id, keys.primaryKey);
-    const anonymousSignal =
-      keys.primaryKey === keys.anonymousKey
-        ? null
-        : await getSignal(ctx, course._id, keys.anonymousKey);
+    const { anonymousSignal, primarySignal } = await getSupporterSignals(
+      ctx,
+      course._id,
+      keys,
+    );
     const existingSignals = [primarySignal, anonymousSignal].filter(
-      (signal) => signal !== null,
+      (signal): signal is InterestSignal => signal !== null,
     );
 
     if (!args.interested) {
       for (const signal of existingSignals) {
         await ctx.db.delete(signal._id);
+        await applyStatsDelta(ctx, course._id, signalStatsDelta(signal, -1));
       }
-      if (existingSignals.length > 0) {
-        await updateStats(ctx, course._id, {
-          total: -existingSignals.length,
-          completedAll: -existingSignals.filter(
-            (signal) => signal.completedAllAtSignal,
-          ).length,
-        });
-      }
-      const stats = await getStats(ctx, course._id);
       return {
         interested: false,
-        completedAllAtSignal: false,
-        totalCount: stats?.totalCount ?? 0,
+        completedAllAvailableStories: false,
       };
     }
 
-    const completedAllAtSignal = await hasCompletedAllPublishedStories(
-      ctx,
-      course._id,
-      keys.legacyUserId,
-      course.count ?? 0,
-    );
+    const completedAllAvailableStories =
+      keys.primaryKind === "account" &&
+      (await hasCompletedAllVisibleStories(ctx, course._id, keys.legacyUserId));
     const now = Date.now();
 
     if (primarySignal) {
-      if (completedAllAtSignal && !primarySignal.completedAllAtSignal) {
-        await ctx.db.patch(primarySignal._id, { completedAllAtSignal: true });
-        await updateStats(ctx, course._id, { total: 0, completedAll: 1 }, now);
+      if (
+        completedAllAvailableStories &&
+        !primarySignal.completedAllAvailableStoriesAt
+      ) {
+        await ctx.db.patch(primarySignal._id, {
+          completedAllAvailableStoriesAt: now,
+        });
+        await applyStatsDelta(ctx, course._id, {
+          browser: 0,
+          authenticated: 0,
+          completedAll: 1,
+        });
       }
       if (anonymousSignal) {
         await ctx.db.delete(anonymousSignal._id);
-        await updateStats(ctx, course._id, {
-          total: -1,
-          completedAll: anonymousSignal.completedAllAtSignal ? -1 : 0,
-        });
+        await applyStatsDelta(
+          ctx,
+          course._id,
+          signalStatsDelta(anonymousSignal, -1),
+        );
       }
     } else if (anonymousSignal) {
-      const wasCompleted = anonymousSignal.completedAllAtSignal;
+      const alreadyQualified =
+        anonymousSignal.completedAllAvailableStoriesAt !== undefined;
       await ctx.db.patch(anonymousSignal._id, {
         supporterKey: keys.primaryKey,
-        legacyUserId: keys.legacyUserId ?? undefined,
-        completedAllAtSignal: wasCompleted || completedAllAtSignal,
+        supporterKind: keys.primaryKind,
+        completedAllAvailableStoriesAt:
+          alreadyQualified || completedAllAvailableStories ? now : undefined,
       });
-      if (completedAllAtSignal && !wasCompleted) {
-        await updateStats(ctx, course._id, { total: 0, completedAll: 1 }, now);
-      }
+      await applyStatsDelta(ctx, course._id, {
+        browser: -1,
+        authenticated: 1,
+        completedAll: completedAllAvailableStories && !alreadyQualified ? 1 : 0,
+      });
     } else {
+      await applyStatsDelta(
+        ctx,
+        course._id,
+        {
+          browser: keys.primaryKind === "browser" ? 1 : 0,
+          authenticated: keys.primaryKind === "account" ? 1 : 0,
+          completedAll: completedAllAvailableStories ? 1 : 0,
+        },
+        { consumeBrowserAllowance: keys.primaryKind === "browser" },
+      );
       await ctx.db.insert("course_interest_signals", {
         courseId: course._id,
         supporterKey: keys.primaryKey,
-        legacyUserId: keys.legacyUserId ?? undefined,
-        completedAllAtSignal,
+        supporterKind: keys.primaryKind,
+        completedAllAvailableStoriesAt: completedAllAvailableStories
+          ? now
+          : undefined,
         createdAt: now,
       });
-      await updateStats(
-        ctx,
-        course._id,
-        { total: 1, completedAll: completedAllAtSignal ? 1 : 0 },
-        now,
-      );
     }
 
-    const stats = await getStats(ctx, course._id);
     return {
       interested: true,
-      completedAllAtSignal:
-        completedAllAtSignal ||
-        primarySignal?.completedAllAtSignal === true ||
-        anonymousSignal?.completedAllAtSignal === true,
-      totalCount: stats?.totalCount ?? 0,
+      completedAllAvailableStories:
+        completedAllAvailableStories ||
+        primarySignal?.completedAllAvailableStoriesAt !== undefined ||
+        anonymousSignal?.completedAllAvailableStoriesAt !== undefined,
     };
   },
 });
@@ -271,9 +385,9 @@ export const getForEditor = query({
     if (!course) return null;
     const stats = await getStats(ctx, course._id);
     return {
-      totalCount: stats?.totalCount ?? 0,
+      browserCount: stats?.browserCount ?? 0,
+      authenticatedCount: stats?.authenticatedCount ?? 0,
       completedAllCount: stats?.completedAllCount ?? 0,
-      lastSignalAt: stats?.lastSignalAt ?? null,
     };
   },
 });

--- a/convex/courseInterest.ts
+++ b/convex/courseInterest.ts
@@ -1,0 +1,279 @@
+import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
+import { mutation, query, type MutationCtx } from "./_generated/server";
+import {
+  getSessionLegacyUserId,
+  requireContributorOrAdmin,
+} from "./lib/authorization";
+
+const ANONYMOUS_ID_PATTERN = /^[a-zA-Z0-9_-]{16,100}$/;
+
+const learnerInterestValidator = v.union(
+  v.object({
+    interested: v.boolean(),
+    completedAllAtSignal: v.boolean(),
+    totalCount: v.number(),
+  }),
+  v.null(),
+);
+
+const editorInterestValidator = v.union(
+  v.object({
+    totalCount: v.number(),
+    completedAllCount: v.number(),
+    lastSignalAt: v.union(v.number(), v.null()),
+  }),
+  v.null(),
+);
+
+function anonymousSupporterKey(anonymousId: string) {
+  if (!ANONYMOUS_ID_PATTERN.test(anonymousId)) {
+    throw new Error("Invalid anonymous supporter identifier.");
+  }
+  return `anonymous:${anonymousId}`;
+}
+
+async function getSupporterKeys(
+  ctx: Parameters<typeof getSessionLegacyUserId>[0],
+  anonymousId: string,
+) {
+  const anonymousKey = anonymousSupporterKey(anonymousId);
+  const legacyUserId = await getSessionLegacyUserId(ctx);
+  return {
+    anonymousKey,
+    legacyUserId,
+    primaryKey:
+      typeof legacyUserId === "number" ? `user:${legacyUserId}` : anonymousKey,
+  };
+}
+
+async function getCourseByShort(
+  ctx: Parameters<typeof getSessionLegacyUserId>[0],
+  courseShort: string,
+) {
+  return await ctx.db
+    .query("courses")
+    .withIndex("by_short", (q) => q.eq("short", courseShort))
+    .unique();
+}
+
+async function getSignal(
+  ctx: Parameters<typeof getSessionLegacyUserId>[0],
+  courseId: Id<"courses">,
+  supporterKey: string,
+) {
+  return await ctx.db
+    .query("course_interest_signals")
+    .withIndex("by_course_id_and_supporter_key", (q) =>
+      q.eq("courseId", courseId).eq("supporterKey", supporterKey),
+    )
+    .unique();
+}
+
+async function hasCompletedAllPublishedStories(
+  ctx: MutationCtx,
+  courseId: Id<"courses">,
+  legacyUserId: number | null,
+  publishedStoryCount: number,
+) {
+  if (legacyUserId === null || publishedStoryCount === 0) return false;
+
+  const completionRows = await ctx.db
+    .query("story_done_state")
+    .withIndex("by_user_and_course", (q) =>
+      q.eq("legacyUserId", legacyUserId).eq("courseId", courseId),
+    )
+    .collect();
+  return (
+    new Set(completionRows.map((row) => row.storyId)).size >=
+    publishedStoryCount
+  );
+}
+
+async function getStats(
+  ctx: Parameters<typeof getSessionLegacyUserId>[0],
+  courseId: Id<"courses">,
+) {
+  return await ctx.db
+    .query("course_interest_stats")
+    .withIndex("by_course_id", (q) => q.eq("courseId", courseId))
+    .unique();
+}
+
+async function updateStats(
+  ctx: MutationCtx,
+  courseId: Id<"courses">,
+  changes: { total: number; completedAll: number },
+  lastSignalAt?: number,
+) {
+  const existing = await getStats(ctx, courseId);
+  const now = Date.now();
+  if (!existing) {
+    await ctx.db.insert("course_interest_stats", {
+      courseId,
+      totalCount: Math.max(0, changes.total),
+      completedAllCount: Math.max(0, changes.completedAll),
+      lastSignalAt: lastSignalAt ?? null,
+      updatedAt: now,
+    });
+    return;
+  }
+
+  await ctx.db.patch(existing._id, {
+    totalCount: Math.max(0, existing.totalCount + changes.total),
+    completedAllCount: Math.max(
+      0,
+      existing.completedAllCount + changes.completedAll,
+    ),
+    lastSignalAt: lastSignalAt ?? existing.lastSignalAt,
+    updatedAt: now,
+  });
+}
+
+export const getForLearner = query({
+  args: {
+    courseShort: v.string(),
+    anonymousId: v.string(),
+  },
+  returns: learnerInterestValidator,
+  handler: async (ctx, args) => {
+    const course = await getCourseByShort(ctx, args.courseShort);
+    if (!course?.public) return null;
+
+    const keys = await getSupporterKeys(ctx, args.anonymousId);
+    const primarySignal = await getSignal(ctx, course._id, keys.primaryKey);
+    const anonymousSignal =
+      keys.primaryKey === keys.anonymousKey
+        ? null
+        : await getSignal(ctx, course._id, keys.anonymousKey);
+    const signal = primarySignal ?? anonymousSignal;
+    const stats = await getStats(ctx, course._id);
+
+    return {
+      interested: signal !== null,
+      completedAllAtSignal: signal?.completedAllAtSignal ?? false,
+      totalCount: stats?.totalCount ?? 0,
+    };
+  },
+});
+
+export const setForLearner = mutation({
+  args: {
+    courseShort: v.string(),
+    anonymousId: v.string(),
+    interested: v.boolean(),
+  },
+  returns: v.object({
+    interested: v.boolean(),
+    completedAllAtSignal: v.boolean(),
+    totalCount: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const course = await getCourseByShort(ctx, args.courseShort);
+    if (!course?.public) throw new Error("Course not found.");
+
+    const keys = await getSupporterKeys(ctx, args.anonymousId);
+    const primarySignal = await getSignal(ctx, course._id, keys.primaryKey);
+    const anonymousSignal =
+      keys.primaryKey === keys.anonymousKey
+        ? null
+        : await getSignal(ctx, course._id, keys.anonymousKey);
+    const existingSignals = [primarySignal, anonymousSignal].filter(
+      (signal) => signal !== null,
+    );
+
+    if (!args.interested) {
+      for (const signal of existingSignals) {
+        await ctx.db.delete(signal._id);
+      }
+      if (existingSignals.length > 0) {
+        await updateStats(ctx, course._id, {
+          total: -existingSignals.length,
+          completedAll: -existingSignals.filter(
+            (signal) => signal.completedAllAtSignal,
+          ).length,
+        });
+      }
+      const stats = await getStats(ctx, course._id);
+      return {
+        interested: false,
+        completedAllAtSignal: false,
+        totalCount: stats?.totalCount ?? 0,
+      };
+    }
+
+    const completedAllAtSignal = await hasCompletedAllPublishedStories(
+      ctx,
+      course._id,
+      keys.legacyUserId,
+      course.count ?? 0,
+    );
+    const now = Date.now();
+
+    if (primarySignal) {
+      if (completedAllAtSignal && !primarySignal.completedAllAtSignal) {
+        await ctx.db.patch(primarySignal._id, { completedAllAtSignal: true });
+        await updateStats(ctx, course._id, { total: 0, completedAll: 1 }, now);
+      }
+      if (anonymousSignal) {
+        await ctx.db.delete(anonymousSignal._id);
+        await updateStats(ctx, course._id, {
+          total: -1,
+          completedAll: anonymousSignal.completedAllAtSignal ? -1 : 0,
+        });
+      }
+    } else if (anonymousSignal) {
+      const wasCompleted = anonymousSignal.completedAllAtSignal;
+      await ctx.db.patch(anonymousSignal._id, {
+        supporterKey: keys.primaryKey,
+        legacyUserId: keys.legacyUserId ?? undefined,
+        completedAllAtSignal: wasCompleted || completedAllAtSignal,
+      });
+      if (completedAllAtSignal && !wasCompleted) {
+        await updateStats(ctx, course._id, { total: 0, completedAll: 1 }, now);
+      }
+    } else {
+      await ctx.db.insert("course_interest_signals", {
+        courseId: course._id,
+        supporterKey: keys.primaryKey,
+        legacyUserId: keys.legacyUserId ?? undefined,
+        completedAllAtSignal,
+        createdAt: now,
+      });
+      await updateStats(
+        ctx,
+        course._id,
+        { total: 1, completedAll: completedAllAtSignal ? 1 : 0 },
+        now,
+      );
+    }
+
+    const stats = await getStats(ctx, course._id);
+    return {
+      interested: true,
+      completedAllAtSignal:
+        completedAllAtSignal ||
+        primarySignal?.completedAllAtSignal === true ||
+        anonymousSignal?.completedAllAtSignal === true,
+      totalCount: stats?.totalCount ?? 0,
+    };
+  },
+});
+
+export const getForEditor = query({
+  args: {
+    courseIdentifier: v.string(),
+  },
+  returns: editorInterestValidator,
+  handler: async (ctx, args) => {
+    await requireContributorOrAdmin(ctx);
+    const course = await getCourseByShort(ctx, args.courseIdentifier);
+    if (!course) return null;
+    const stats = await getStats(ctx, course._id);
+    return {
+      totalCount: stats?.totalCount ?? 0,
+      completedAllCount: stats?.completedAllCount ?? 0,
+      lastSignalAt: stats?.lastSignalAt ?? null,
+    };
+  },
+});

--- a/convex/lib/publicCourseStories.ts
+++ b/convex/lib/publicCourseStories.ts
@@ -21,7 +21,7 @@ export type PublicCourseStory = {
  * they can never drift apart and start linking to unpublished stories.
  */
 export async function listPublicCourseStories(
-  ctx: QueryCtx,
+  ctx: Pick<QueryCtx, "db">,
   courseId: Id<"courses">,
 ): Promise<PublicCourseStory[]> {
   const stories = await ctx.db

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -223,18 +223,18 @@ export default defineSchema({
   course_interest_signals: defineTable({
     courseId: v.id("courses"),
     supporterKey: v.string(),
-    legacyUserId: v.optional(v.number()),
-    completedAllAtSignal: v.boolean(),
+    supporterKind: v.union(v.literal("browser"), v.literal("account")),
+    completedAllAvailableStoriesAt: v.optional(v.number()),
     createdAt: v.number(),
-  })
-    .index("by_course_id", ["courseId"])
-    .index("by_course_id_and_supporter_key", ["courseId", "supporterKey"]),
+  }).index("by_course_id_and_supporter_key", ["courseId", "supporterKey"]),
 
   course_interest_stats: defineTable({
     courseId: v.id("courses"),
-    totalCount: v.number(),
+    browserCount: v.number(),
+    authenticatedCount: v.number(),
     completedAllCount: v.number(),
-    lastSignalAt: v.union(v.number(), v.null()),
+    browserWindowStartedAt: v.number(),
+    browserAddsInWindow: v.number(),
     updatedAt: v.number(),
   }).index("by_course_id", ["courseId"]),
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -220,6 +220,24 @@ export default defineSchema({
     .index("by_user_and_course", ["legacyUserId", "courseId"])
     .index("by_user_and_last_done_at", ["legacyUserId", "lastDoneAt"]),
 
+  course_interest_signals: defineTable({
+    courseId: v.id("courses"),
+    supporterKey: v.string(),
+    legacyUserId: v.optional(v.number()),
+    completedAllAtSignal: v.boolean(),
+    createdAt: v.number(),
+  })
+    .index("by_course_id", ["courseId"])
+    .index("by_course_id_and_supporter_key", ["courseId", "supporterKey"]),
+
+  course_interest_stats: defineTable({
+    courseId: v.id("courses"),
+    totalCount: v.number(),
+    completedAllCount: v.number(),
+    lastSignalAt: v.union(v.number(), v.null()),
+    updatedAt: v.number(),
+  }).index("by_course_id", ["courseId"]),
+
   user_preferences: defineTable({
     tokenIdentifier: v.string(),
     legacyUserId: v.optional(v.number()),

--- a/convex/storyDone.ts
+++ b/convex/storyDone.ts
@@ -6,6 +6,7 @@ import {
   getSessionLegacyUserId,
   requireSessionLegacyUserId,
 } from "./lib/authorization";
+import { maybeQualifyCourseInterestSignal } from "./courseInterest";
 
 const storyDoneInputValidator = v.object({
   legacyStoryId: v.number(),
@@ -108,6 +109,11 @@ export const recordStoryDone = mutation({
           legacyCourseId: course.legacyId,
           lastDoneAt: doneAt,
         });
+        await maybeQualifyCourseInterestSignal(
+          ctx,
+          story.courseId,
+          legacyUserId,
+        );
       }
     }
 

--- a/src/app/(stories)/(main)/[course_id]/course_interest_card.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_interest_card.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { api } from "@convex/_generated/api";
+import { Heart, Sparkles } from "lucide-react";
+import { useMutation, useQuery } from "convex/react";
+import React from "react";
+
+function getAnonymousId(courseShort: string) {
+  const storageKey = `course_interest_supporter:${courseShort}`;
+  const existing = window.localStorage.getItem(storageKey);
+  if (existing) return existing;
+  const id = crypto.randomUUID();
+  window.localStorage.setItem(storageKey, id);
+  return id;
+}
+
+export default function CourseInterestCard({
+  courseShort,
+  languageName,
+  completedAll,
+}: {
+  courseShort: string;
+  languageName: string;
+  completedAll: boolean;
+}) {
+  const [anonymousId, setAnonymousId] = React.useState<string | null>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const setInterest = useMutation(api.courseInterest.setForLearner);
+  const interest = useQuery(
+    api.courseInterest.getForLearner,
+    anonymousId ? { courseShort, anonymousId } : "skip",
+  );
+
+  React.useEffect(() => {
+    setAnonymousId(getAnonymousId(courseShort));
+  }, [courseShort]);
+
+  const interested = interest?.interested ?? false;
+  const totalCount = interest?.totalCount ?? 0;
+
+  async function toggleInterest() {
+    if (!anonymousId || isSaving) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      await setInterest({
+        courseShort,
+        anonymousId,
+        interested: !interested,
+      });
+    } catch (cause) {
+      console.error("Failed to update course interest", cause);
+      setError("That didn’t work. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <section className="relative mx-auto mt-10 mb-6 max-w-[720px] overflow-hidden rounded-[22px] border-2 border-[#8fd55c] bg-[linear-gradient(145deg,#f4ffe9_0%,#ffffff_58%,#efffe8_100%)] px-5 py-6 text-center shadow-[0_5px_0_#8fd55c] dark:border-[#4f8d35] dark:bg-[linear-gradient(145deg,#20331d_0%,#18231a_58%,#1d2d1b_100%)] dark:shadow-[0_5px_0_#315d24] sm:px-8 sm:py-8">
+      <Sparkles
+        aria-hidden="true"
+        className="absolute top-4 right-5 h-5 w-5 rotate-12 text-[#58a700]"
+      />
+      <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[#d9ffc2] text-[#58a700] dark:bg-[#315d24] dark:text-[#8ee45b]">
+        <Heart className="h-6 w-6" aria-hidden="true" />
+      </div>
+      <h2 className="text-[calc(22/16*1rem)] font-bold leading-tight">
+        {completedAll
+          ? `You finished every ${languageName} story!`
+          : `Want more ${languageName} stories?`}
+      </h2>
+      <p className="mx-auto mt-2 max-w-[500px] text-[var(--text-color-dim)]">
+        {completedAll
+          ? "Let the volunteer contributor team know you’re ready for another one."
+          : "Your signal helps volunteer contributors see that learners are waiting for more."}
+      </p>
+      <button
+        type="button"
+        disabled={!anonymousId || interest === undefined || isSaving}
+        aria-pressed={interested}
+        onClick={toggleInterest}
+        className={`mt-5 inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border-2 px-6 py-3 font-bold transition-[transform,background-color,border-color,box-shadow] active:translate-y-[2px] disabled:cursor-wait disabled:opacity-60 ${
+          interested
+            ? "border-[#77b255] bg-white text-[#3f7d1d] shadow-[0_4px_0_#77b255] dark:bg-[#263625] dark:text-[#a6e582]"
+            : "border-[#58a700] bg-[#58cc02] text-white shadow-[0_4px_0_#58a700] hover:bg-[#61d909]"
+        }`}
+      >
+        <Heart
+          className={`h-5 w-5 ${interested ? "fill-current" : ""}`}
+          aria-hidden="true"
+        />
+        {isSaving
+          ? "Saving…"
+          : interested
+            ? "I’m interested"
+            : "I’d love more stories"}
+      </button>
+      {totalCount > 0 ? (
+        <p className="mt-4 text-[calc(14/16*1rem)] font-bold text-[#4f861f] dark:text-[#9bdc73]">
+          {interested ? "You’re " : ""}
+          {interested ? `one of ${totalCount}` : totalCount}{" "}
+          {totalCount === 1 ? "learner" : "learners"} hoping for more.
+        </p>
+      ) : null}
+      {interested ? (
+        <p className="mt-1 text-[calc(13/16*1rem)] text-[var(--text-color-dim)]">
+          We’ll share this interest with the contributor team.
+        </p>
+      ) : null}
+      {error ? (
+        <p className="mt-3 text-[calc(14/16*1rem)] font-bold text-red-600">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/(stories)/(main)/[course_id]/course_interest_card.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_interest_card.tsx
@@ -37,7 +37,6 @@ export default function CourseInterestCard({
   }, [courseShort]);
 
   const interested = interest?.interested ?? false;
-  const totalCount = interest?.totalCount ?? 0;
 
   async function toggleInterest() {
     if (!anonymousId || isSaving) return;
@@ -97,15 +96,8 @@ export default function CourseInterestCard({
             ? "I’m interested"
             : "I’d love more stories"}
       </button>
-      {totalCount > 0 ? (
-        <p className="mt-4 text-[calc(14/16*1rem)] font-bold text-[#4f861f] dark:text-[#9bdc73]">
-          {interested ? "You’re " : ""}
-          {interested ? `one of ${totalCount}` : totalCount}{" "}
-          {totalCount === 1 ? "learner" : "learners"} hoping for more.
-        </p>
-      ) : null}
       {interested ? (
-        <p className="mt-1 text-[calc(13/16*1rem)] text-[var(--text-color-dim)]">
+        <p className="mt-4 text-[calc(13/16*1rem)] text-[var(--text-color-dim)]">
           We’ll share this interest with the contributor team.
         </p>
       ) : null}

--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -9,6 +9,7 @@ import get_localisation_func from "@/lib/get_localisation_func";
 import ContributorList from "@/components/ContributorList";
 import Switch from "@/components/ui/switch";
 import { hasNoAudioCourseTag } from "@/lib/course-tags";
+import CourseInterestCard from "./course_interest_card";
 
 function SetTitle({ children }: { children: React.ReactNode }) {
   return (
@@ -190,6 +191,10 @@ export default function CoursePageClient({
   const rawTags = course.tags ?? [];
   const normalizedTags = rawTags.map((tag) => tag.trim().toLowerCase());
   const showNoNativeWarning = normalizedTags.includes("no-native");
+  const completedAllStories =
+    course.stories.length > 0 &&
+    course.stories.every((story) => doneMap[story.id] === true);
+  const languageName = course.name || course.learning_language_name;
 
   return (
     <>
@@ -273,6 +278,11 @@ export default function CoursePageClient({
             ))}
           </SetGrid>
         ))}
+        <CourseInterestCard
+          courseShort={course_id}
+          languageName={languageName}
+          completedAll={completedAllStories}
+        />
       </div>
     </>
   );

--- a/src/app/editor/(course)/course_interest_summary.tsx
+++ b/src/app/editor/(course)/course_interest_summary.tsx
@@ -15,6 +15,8 @@ export default function CourseInterestSummary({
   );
 
   if (!courseIdentifier || stats === undefined) return null;
+  const totalCount =
+    (stats?.authenticatedCount ?? 0) + (stats?.browserCount ?? 0);
 
   return (
     <section className="my-6 rounded-2xl border-2 border-[#8fd55c] bg-[#f6ffef] p-5 dark:border-[#416f31] dark:bg-[#20301d]">
@@ -26,12 +28,14 @@ export default function CourseInterestSummary({
           <h2 className="text-[calc(19/16*1rem)] font-bold">
             Learner interest
           </h2>
-          {stats?.totalCount ? (
+          {stats && totalCount > 0 ? (
             <>
               <p className="mt-1 text-[calc(17/16*1rem)]">
-                <strong>{stats.totalCount}</strong>{" "}
-                {stats.totalCount === 1 ? "learner wants" : "learners want"}{" "}
-                more stories in this course.
+                <strong>{stats.authenticatedCount}</strong>{" "}
+                {stats.authenticatedCount === 1
+                  ? "signed-in learner wants"
+                  : "signed-in learners want"}{" "}
+                more stories.
               </p>
               {stats.completedAllCount > 0 ? (
                 <p className="mt-2 flex items-center gap-2 text-[calc(14/16*1rem)] text-[var(--text-color-dim)]">
@@ -40,8 +44,19 @@ export default function CourseInterestSummary({
                     aria-hidden="true"
                   />
                   {stats.completedAllCount}{" "}
-                  {stats.completedAllCount === 1 ? "has" : "have"} completed
-                  every published story.
+                  {stats.completedAllCount === 1
+                    ? "learner finished"
+                    : "learners finished"}{" "}
+                  all available stories before asking for more.
+                </p>
+              ) : null}
+              {stats.browserCount > 0 ? (
+                <p className="mt-2 text-[calc(14/16*1rem)] text-[var(--text-color-dim)]">
+                  Plus {stats.browserCount} additional{" "}
+                  {stats.browserCount === 1
+                    ? "browser signal"
+                    : "browser signals"}
+                  .
                 </p>
               ) : null}
             </>

--- a/src/app/editor/(course)/course_interest_summary.tsx
+++ b/src/app/editor/(course)/course_interest_summary.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { api } from "@convex/_generated/api";
+import { Heart, Trophy } from "lucide-react";
+import { useQuery } from "convex/react";
+
+export default function CourseInterestSummary({
+  courseIdentifier,
+}: {
+  courseIdentifier: string | null;
+}) {
+  const stats = useQuery(
+    api.courseInterest.getForEditor,
+    courseIdentifier ? { courseIdentifier } : "skip",
+  );
+
+  if (!courseIdentifier || stats === undefined) return null;
+
+  return (
+    <section className="my-6 rounded-2xl border-2 border-[#8fd55c] bg-[#f6ffef] p-5 dark:border-[#416f31] dark:bg-[#20301d]">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#d9ffc2] text-[#58a700] dark:bg-[#315d24] dark:text-[#9be66e]">
+          <Heart className="h-5 w-5 fill-current" aria-hidden="true" />
+        </div>
+        <div>
+          <h2 className="text-[calc(19/16*1rem)] font-bold">
+            Learner interest
+          </h2>
+          {stats?.totalCount ? (
+            <>
+              <p className="mt-1 text-[calc(17/16*1rem)]">
+                <strong>{stats.totalCount}</strong>{" "}
+                {stats.totalCount === 1 ? "learner wants" : "learners want"}{" "}
+                more stories in this course.
+              </p>
+              {stats.completedAllCount > 0 ? (
+                <p className="mt-2 flex items-center gap-2 text-[calc(14/16*1rem)] text-[var(--text-color-dim)]">
+                  <Trophy
+                    className="h-4 w-4 shrink-0 text-[#d79b00]"
+                    aria-hidden="true"
+                  />
+                  {stats.completedAllCount}{" "}
+                  {stats.completedAllCount === 1 ? "has" : "have"} completed
+                  every published story.
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className="mt-1 text-[var(--text-color-dim)]">
+              No learner signals yet. A request card is shown below the public
+              story list.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/editor/(course)/edit_list.tsx
+++ b/src/app/editor/(course)/edit_list.tsx
@@ -31,6 +31,7 @@ import type {
   DetailedCourseProps,
   StoryListDataProps,
 } from "@/app/editor/(course)/types";
+import CourseInterestSummary from "./course_interest_summary";
 
 type StoryState = "draft" | "feedback" | "finished" | "published";
 type StoryFilter = "all" | StoryState;
@@ -208,6 +209,7 @@ export default function EditList({
           />
         </div>
       </div>
+      <CourseInterestSummary courseIdentifier={course.short} />
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <div className="w-full min-w-[220px] flex-1 min-[860px]:max-w-[360px]">
           <Input


### PR DESCRIPTION
## What changed

- add an interest CTA below each public course's story list
- allow anonymous learners to signal interest once per browser and signed-in learners once per account
- qualify signed-in signals after the learner completes the exact set of visible stories
- automatically upgrade existing signals when the final available story is completed
- show authenticated, browser, and historically completion-qualified interest separately in the contributor course editor
- limit bursts of new browser signals per course
- maintain denormalized Convex counters and merge anonymous signals into an account after sign-in
- add Convex coverage for toggling, exact completion qualification, automatic upgrades, evidence tiers, throttling, and anonymous/account deduplication

## Why

Courses currently have no feedback loop from learners to volunteer contributor teams. This gives learners a low-friction way to express demand for more translations and gives inactive or uncertain teams concrete evidence that people are waiting for more stories.

The CTA sits below the story list, so it is naturally more prominent on courses with a small catalog. No referral or Reddit-source tracking is collected. Browser signals remain directional evidence, while signed-in and completion-qualified signals are shown separately as stronger indicators.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm test:convex -- convex/courseInterest.test.ts` (66 tests passed)
- deployed Convex schema and functions to the development deployment
- local course-page smoke test
