### PR TITLE
Add backfillPublicSince internal mutation for pre-tracking courses

### DIFF
--- a/convex/adminWrite.ts
+++ b/convex/adminWrite.ts
@@ -423,3 +423,38 @@ export const createAdminCourse = mutation({
     };
   },
 });
+
+/**
+ * One-time backfill for courses that were public before `publicSince` existed.
+ * Dates are derived offline (Discord release announcements, earliest public
+ * story) and applied via
+ * `npx convex run adminWrite:backfillPublicSince '{"entries": [...]}' --prod`.
+ * Only fills courses that are public AND still missing publicSince — never
+ * overwrites a value the live write paths have already recorded.
+ */
+export const backfillPublicSince = internalMutation({
+  args: {
+    entries: v.array(v.object({ short: v.string(), publicSince: v.number() })),
+  },
+  returns: v.object({
+    updated: v.array(v.string()),
+    skipped: v.array(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const updated: string[] = [];
+    const skipped: string[] = [];
+    for (const entry of args.entries) {
+      const course = await ctx.db
+        .query("courses")
+        .withIndex("by_short", (q) => q.eq("short", entry.short))
+        .unique();
+      if (!course || !course.public || course.publicSince !== undefined) {
+        skipped.push(entry.short);
+        continue;
+      }
+      await ctx.db.patch(course._id, { publicSince: entry.publicSince });
+      updated.push(entry.short);
+    }
+    return { updated, skipped };
+  },
+});

--- a/convex/coursePublicSince.test.ts
+++ b/convex/coursePublicSince.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
@@ -222,5 +222,31 @@ describe("getPublicCourseList publicSince", () => {
     const list = await t.query(api.landing.getPublicCourseList, {});
     expect(list).toHaveLength(1);
     expect(list[0].publicSince).toBe(12345);
+  });
+});
+
+describe("backfillPublicSince", () => {
+  test("fills only public courses missing a value; never overwrites", async () => {
+    const t = convexTest(schema, modules);
+    await seedLanguages(t);
+    await seedCourse(t, { isPublic: true }); // es-en, no publicSince
+
+    const result = await t.mutation(internal.adminWrite.backfillPublicSince, {
+      entries: [
+        { short: "es-en", publicSince: 1_600_000_000_000 },
+        { short: "missing-xx", publicSince: 1 },
+      ],
+    });
+    expect(result.updated).toEqual(["es-en"]);
+    expect(result.skipped).toEqual(["missing-xx"]);
+    expect((await getCourse(t)).publicSince).toBe(1_600_000_000_000);
+
+    // Re-running must not overwrite the now-present value.
+    const again = await t.mutation(internal.adminWrite.backfillPublicSince, {
+      entries: [{ short: "es-en", publicSince: 42 }],
+    });
+    expect(again.updated).toEqual([]);
+    expect(again.skipped).toEqual(["es-en"]);
+    expect((await getCourse(t)).publicSince).toBe(1_600_000_000_000);
   });
 });


### PR DESCRIPTION
Follow-up to #643 (this commit just missed the merge).

Adds an internal, idempotent mutation to backfill `publicSince` for the ~90 courses that were already public before tracking existed:

- Fills **only** courses that are public and still have no `publicSince`.
- Never overwrites values the live write paths have recorded.
- Returns `{updated, skipped}` for auditability.
- Applied post-deploy via `npx convex run adminWrite:backfillPublicSince '{"entries": [...]}' --prod`.

The date table itself is being derived offline from two signals — Discord release announcements (pending bot read access to #announcements) cross-checked against each course's earliest public-story date — and will be reviewed before anything is applied.

Test covers fill, missing-course skip, and the no-overwrite re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)