### PR TITLE
Keep course interest schema backward compatible

### DIFF
--- a/convex/courseInterest.test.ts
+++ b/convex/courseInterest.test.ts
@@ -337,4 +337,108 @@ describe("course interest", () => {
       }),
     ).rejects.toThrow("Too many new interest signals");
   });
+
+  test("reads and removes documents created by the first release", async () => {
+    const t = convexTest(schema, modules);
+    const { courseId } = await seedCourse(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("course_interest_signals", {
+        courseId,
+        supporterKey: "anonymous:browser_supporter_123456",
+        completedAllAtSignal: false,
+        createdAt: 1_785_358_460_280,
+      });
+      await ctx.db.insert("course_interest_signals", {
+        courseId,
+        supporterKey: "anonymous:another_browser_123456",
+        completedAllAtSignal: false,
+        createdAt: 1_785_358_460_281,
+      });
+      await ctx.db.insert("course_interest_stats", {
+        courseId,
+        totalCount: 2,
+        completedAllCount: 0,
+        lastSignalAt: 1_785_358_460_280,
+        updatedAt: 1_785_358_460_280,
+      });
+    });
+
+    const learnerArgs = {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+    };
+    expect(
+      await t.query(api.courseInterest.getForLearner, learnerArgs),
+    ).toEqual({
+      interested: true,
+      completedAllAvailableStories: false,
+    });
+
+    const editor = t.withIdentity({ userId: "8", role: "contributor" });
+    expect(
+      await editor.query(api.courseInterest.getForEditor, {
+        courseIdentifier: "cy-en",
+      }),
+    ).toEqual({
+      authenticatedCount: 0,
+      browserCount: 2,
+      completedAllCount: 0,
+    });
+
+    await t.mutation(api.courseInterest.setForLearner, {
+      ...learnerArgs,
+      interested: false,
+    });
+    expect(
+      await editor.query(api.courseInterest.getForEditor, {
+        courseIdentifier: "cy-en",
+      }),
+    ).toEqual({
+      authenticatedCount: 0,
+      browserCount: 1,
+      completedAllCount: 0,
+    });
+  });
+
+  test("preserves legacy signed-in and completion-qualified evidence", async () => {
+    const t = convexTest(schema, modules);
+    const { courseId } = await seedCourse(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("course_interest_signals", {
+        courseId,
+        supporterKey: "user:7",
+        completedAllAtSignal: true,
+        createdAt: 1_785_358_460_280,
+      });
+      await ctx.db.insert("course_interest_stats", {
+        courseId,
+        totalCount: 1,
+        completedAllCount: 1,
+        lastSignalAt: 1_785_358_460_280,
+        updatedAt: 1_785_358_460_280,
+      });
+    });
+
+    const learner = t.withIdentity({ userId: "7", role: "user" });
+    expect(
+      await learner.query(api.courseInterest.getForLearner, {
+        courseShort: "cy-en",
+        anonymousId: "another_browser_123456",
+      }),
+    ).toEqual({
+      interested: true,
+      completedAllAvailableStories: true,
+    });
+
+    const editor = t.withIdentity({ userId: "8", role: "contributor" });
+    expect(
+      await editor.query(api.courseInterest.getForEditor, {
+        courseIdentifier: "cy-en",
+      }),
+    ).toEqual({
+      authenticatedCount: 1,
+      browserCount: 0,
+      completedAllCount: 1,
+    });
+  });
 });

--- a/convex/courseInterest.ts
+++ b/convex/courseInterest.ts
@@ -16,9 +16,12 @@ const ANONYMOUS_ID_PATTERN = /^[a-zA-Z0-9_-]{16,100}$/;
 const BROWSER_SIGNAL_WINDOW_MS = 60 * 60 * 1000;
 const MAX_BROWSER_SIGNALS_PER_COURSE_PER_WINDOW = 30;
 const MAX_COMPLETION_ROWS_PER_COURSE = 500;
+const MAX_LEGACY_SIGNALS_PER_COURSE = 500;
 
 type ReadCtx = QueryCtx | MutationCtx;
 type InterestSignal = Doc<"course_interest_signals">;
+type InterestStats = Doc<"course_interest_stats">;
+type SupporterKind = "browser" | "account";
 
 const learnerInterestValidator = v.union(
   v.object({
@@ -50,6 +53,15 @@ type StatsDelta = {
   completedAll: number;
 };
 
+type NormalizedStats = {
+  document: InterestStats | null;
+  browserCount: number;
+  authenticatedCount: number;
+  completedAllCount: number;
+  browserWindowStartedAt: number;
+  browserAddsInWindow: number;
+};
+
 function anonymousSupporterKey(anonymousId: string) {
   if (!ANONYMOUS_ID_PATTERN.test(anonymousId)) {
     throw new Error("Invalid anonymous supporter identifier.");
@@ -59,6 +71,20 @@ function anonymousSupporterKey(anonymousId: string) {
 
 function accountSupporterKey(legacyUserId: number) {
   return `user:${legacyUserId}`;
+}
+
+function getSignalKind(signal: InterestSignal): SupporterKind {
+  return (
+    signal.supporterKind ??
+    (signal.supporterKey.startsWith("user:") ? "account" : "browser")
+  );
+}
+
+function getSignalCompletedAllAt(signal: InterestSignal) {
+  return (
+    signal.completedAllAvailableStoriesAt ??
+    (signal.completedAllAtSignal ? signal.createdAt : undefined)
+  );
 }
 
 async function getSupporterKeys(
@@ -140,12 +166,59 @@ async function getStats(ctx: ReadCtx, courseId: Id<"courses">) {
     .unique();
 }
 
-function assertBrowserSignalAllowance(
-  stats: Doc<"course_interest_stats"> | null,
-  now: number,
-) {
+async function getNormalizedStats(
+  ctx: ReadCtx,
+  courseId: Id<"courses">,
+): Promise<NormalizedStats> {
+  const document = await getStats(ctx, courseId);
   if (
-    stats &&
+    document &&
+    document.browserCount !== undefined &&
+    document.authenticatedCount !== undefined &&
+    document.browserWindowStartedAt !== undefined &&
+    document.browserAddsInWindow !== undefined
+  ) {
+    return {
+      document,
+      browserCount: document.browserCount,
+      authenticatedCount: document.authenticatedCount,
+      completedAllCount: document.completedAllCount,
+      browserWindowStartedAt: document.browserWindowStartedAt,
+      browserAddsInWindow: document.browserAddsInWindow,
+    };
+  }
+
+  const signals = await ctx.db
+    .query("course_interest_signals")
+    .withIndex("by_course_id", (q) => q.eq("courseId", courseId))
+    .take(MAX_LEGACY_SIGNALS_PER_COURSE + 1);
+  if (signals.length > MAX_LEGACY_SIGNALS_PER_COURSE) {
+    throw new Error(
+      `Course ${courseId} has too many legacy interest signals to normalize.`,
+    );
+  }
+
+  let browserCount = 0;
+  let authenticatedCount = 0;
+  let completedAllCount = 0;
+  for (const signal of signals) {
+    if (getSignalKind(signal) === "account") authenticatedCount += 1;
+    else browserCount += 1;
+    if (getSignalCompletedAllAt(signal) !== undefined) completedAllCount += 1;
+  }
+
+  return {
+    document,
+    browserCount,
+    authenticatedCount,
+    completedAllCount,
+    browserWindowStartedAt: document?.updatedAt ?? Date.now(),
+    browserAddsInWindow: 0,
+  };
+}
+
+function assertBrowserSignalAllowance(stats: NormalizedStats, now: number) {
+  if (
     now - stats.browserWindowStartedAt < BROWSER_SIGNAL_WINDOW_MS &&
     stats.browserAddsInWindow >= MAX_BROWSER_SIGNALS_PER_COURSE_PER_WINDOW
   ) {
@@ -161,30 +234,36 @@ async function applyStatsDelta(
   delta: StatsDelta,
   options: { consumeBrowserAllowance?: boolean } = {},
 ) {
-  const existing = await getStats(ctx, courseId);
+  const stats = await getNormalizedStats(ctx, courseId);
+  const existing = stats.document;
   const now = Date.now();
   if (options.consumeBrowserAllowance) {
-    assertBrowserSignalAllowance(existing, now);
+    assertBrowserSignalAllowance(stats, now);
   }
 
   const windowExpired =
-    !existing ||
-    now - existing.browserWindowStartedAt >= BROWSER_SIGNAL_WINDOW_MS;
+    now - stats.browserWindowStartedAt >= BROWSER_SIGNAL_WINDOW_MS;
   const browserWindowStartedAt = windowExpired
     ? now
-    : existing.browserWindowStartedAt;
+    : stats.browserWindowStartedAt;
   const browserAddsInWindow = options.consumeBrowserAllowance
     ? windowExpired
       ? 1
-      : (existing?.browserAddsInWindow ?? 0) + 1
-    : (existing?.browserAddsInWindow ?? 0);
+      : stats.browserAddsInWindow + 1
+    : stats.browserAddsInWindow;
 
   if (!existing) {
     await ctx.db.insert("course_interest_stats", {
       courseId,
-      browserCount: Math.max(0, delta.browser),
-      authenticatedCount: Math.max(0, delta.authenticated),
-      completedAllCount: Math.max(0, delta.completedAll),
+      browserCount: Math.max(0, stats.browserCount + delta.browser),
+      authenticatedCount: Math.max(
+        0,
+        stats.authenticatedCount + delta.authenticated,
+      ),
+      completedAllCount: Math.max(
+        0,
+        stats.completedAllCount + delta.completedAll,
+      ),
       browserWindowStartedAt,
       browserAddsInWindow,
       updatedAt: now,
@@ -193,14 +272,14 @@ async function applyStatsDelta(
   }
 
   await ctx.db.patch(existing._id, {
-    browserCount: Math.max(0, existing.browserCount + delta.browser),
+    browserCount: Math.max(0, stats.browserCount + delta.browser),
     authenticatedCount: Math.max(
       0,
-      existing.authenticatedCount + delta.authenticated,
+      stats.authenticatedCount + delta.authenticated,
     ),
     completedAllCount: Math.max(
       0,
-      existing.completedAllCount + delta.completedAll,
+      stats.completedAllCount + delta.completedAll,
     ),
     browserWindowStartedAt,
     browserAddsInWindow,
@@ -210,9 +289,9 @@ async function applyStatsDelta(
 
 function signalStatsDelta(signal: InterestSignal, direction: 1 | -1) {
   return {
-    browser: signal.supporterKind === "browser" ? direction : 0,
-    authenticated: signal.supporterKind === "account" ? direction : 0,
-    completedAll: signal.completedAllAvailableStoriesAt ? direction : 0,
+    browser: getSignalKind(signal) === "browser" ? direction : 0,
+    authenticated: getSignalKind(signal) === "account" ? direction : 0,
+    completedAll: getSignalCompletedAllAt(signal) !== undefined ? direction : 0,
   };
 }
 
@@ -226,18 +305,18 @@ export async function maybeQualifyCourseInterestSignal(
     courseId,
     accountSupporterKey(legacyUserId),
   );
-  if (!signal || signal.completedAllAvailableStoriesAt) return;
+  if (!signal || getSignalCompletedAllAt(signal) !== undefined) return;
   if (!(await hasCompletedAllVisibleStories(ctx, courseId, legacyUserId))) {
     return;
   }
 
-  await ctx.db.patch(signal._id, {
-    completedAllAvailableStoriesAt: Date.now(),
-  });
   await applyStatsDelta(ctx, courseId, {
     browser: 0,
     authenticated: 0,
     completedAll: 1,
+  });
+  await ctx.db.patch(signal._id, {
+    completedAllAvailableStoriesAt: Date.now(),
   });
 }
 
@@ -261,7 +340,7 @@ export const getForLearner = query({
     return {
       interested: signal !== null,
       completedAllAvailableStories:
-        signal?.completedAllAvailableStoriesAt !== undefined,
+        signal !== null && getSignalCompletedAllAt(signal) !== undefined,
     };
   },
 });
@@ -292,8 +371,8 @@ export const setForLearner = mutation({
 
     if (!args.interested) {
       for (const signal of existingSignals) {
-        await ctx.db.delete(signal._id);
         await applyStatsDelta(ctx, course._id, signalStatsDelta(signal, -1));
+        await ctx.db.delete(signal._id);
       }
       return {
         interested: false,
@@ -309,38 +388,39 @@ export const setForLearner = mutation({
     if (primarySignal) {
       if (
         completedAllAvailableStories &&
-        !primarySignal.completedAllAvailableStoriesAt
+        getSignalCompletedAllAt(primarySignal) === undefined
       ) {
-        await ctx.db.patch(primarySignal._id, {
-          completedAllAvailableStoriesAt: now,
-        });
         await applyStatsDelta(ctx, course._id, {
           browser: 0,
           authenticated: 0,
           completedAll: 1,
         });
+        await ctx.db.patch(primarySignal._id, {
+          completedAllAvailableStoriesAt: now,
+        });
       }
       if (anonymousSignal) {
-        await ctx.db.delete(anonymousSignal._id);
         await applyStatsDelta(
           ctx,
           course._id,
           signalStatsDelta(anonymousSignal, -1),
         );
+        await ctx.db.delete(anonymousSignal._id);
       }
     } else if (anonymousSignal) {
       const alreadyQualified =
-        anonymousSignal.completedAllAvailableStoriesAt !== undefined;
-      await ctx.db.patch(anonymousSignal._id, {
-        supporterKey: keys.primaryKey,
-        supporterKind: keys.primaryKind,
-        completedAllAvailableStoriesAt:
-          alreadyQualified || completedAllAvailableStories ? now : undefined,
-      });
+        getSignalCompletedAllAt(anonymousSignal) !== undefined;
       await applyStatsDelta(ctx, course._id, {
         browser: -1,
         authenticated: 1,
         completedAll: completedAllAvailableStories && !alreadyQualified ? 1 : 0,
+      });
+      await ctx.db.patch(anonymousSignal._id, {
+        supporterKey: keys.primaryKey,
+        supporterKind: keys.primaryKind,
+        completedAllAvailableStoriesAt:
+          getSignalCompletedAllAt(anonymousSignal) ??
+          (completedAllAvailableStories ? now : undefined),
       });
     } else {
       await applyStatsDelta(
@@ -368,8 +448,10 @@ export const setForLearner = mutation({
       interested: true,
       completedAllAvailableStories:
         completedAllAvailableStories ||
-        primarySignal?.completedAllAvailableStoriesAt !== undefined ||
-        anonymousSignal?.completedAllAvailableStoriesAt !== undefined,
+        (primarySignal !== null &&
+          getSignalCompletedAllAt(primarySignal) !== undefined) ||
+        (anonymousSignal !== null &&
+          getSignalCompletedAllAt(anonymousSignal) !== undefined),
     };
   },
 });
@@ -383,11 +465,11 @@ export const getForEditor = query({
     await requireContributorOrAdmin(ctx);
     const course = await getCourseByShort(ctx, args.courseIdentifier);
     if (!course) return null;
-    const stats = await getStats(ctx, course._id);
+    const stats = await getNormalizedStats(ctx, course._id);
     return {
-      browserCount: stats?.browserCount ?? 0,
-      authenticatedCount: stats?.authenticatedCount ?? 0,
-      completedAllCount: stats?.completedAllCount ?? 0,
+      browserCount: stats.browserCount,
+      authenticatedCount: stats.authenticatedCount,
+      completedAllCount: stats.completedAllCount,
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -226,18 +226,27 @@ export default defineSchema({
   course_interest_signals: defineTable({
     courseId: v.id("courses"),
     supporterKey: v.string(),
-    supporterKind: v.union(v.literal("browser"), v.literal("account")),
+    supporterKind: v.optional(
+      v.union(v.literal("browser"), v.literal("account")),
+    ),
     completedAllAvailableStoriesAt: v.optional(v.number()),
+    // Temporary compatibility with documents created by the first release.
+    completedAllAtSignal: v.optional(v.boolean()),
     createdAt: v.number(),
-  }).index("by_course_id_and_supporter_key", ["courseId", "supporterKey"]),
+  })
+    .index("by_course_id", ["courseId"])
+    .index("by_course_id_and_supporter_key", ["courseId", "supporterKey"]),
 
   course_interest_stats: defineTable({
     courseId: v.id("courses"),
-    browserCount: v.number(),
-    authenticatedCount: v.number(),
+    browserCount: v.optional(v.number()),
+    authenticatedCount: v.optional(v.number()),
     completedAllCount: v.number(),
-    browserWindowStartedAt: v.number(),
-    browserAddsInWindow: v.number(),
+    browserWindowStartedAt: v.optional(v.number()),
+    browserAddsInWindow: v.optional(v.number()),
+    // Temporary compatibility with documents created by the first release.
+    totalCount: v.optional(v.number()),
+    lastSignalAt: v.optional(v.union(v.number(), v.null())),
     updatedAt: v.number(),
   }).index("by_course_id", ["courseId"]),
 


### PR DESCRIPTION
## What changed

- accept the legacy course-interest signal and aggregate fields created by the first production release
- interpret old `completedAllAtSignal`, missing `supporterKind`, `totalCount`, and `lastSignalAt` records through the current evidence model
- derive accurate browser, authenticated, and completion-qualified counts from legacy signals
- lazily normalize aggregate counters during subsequent writes without losing or double-counting signals
- restore the course-level signal index needed for bounded legacy normalization
- add regression coverage for the exact anonymous production document shape, legacy signed-in qualified signals, and multi-signal deletion

## Root cause

PR #644 deployed the initial course-interest schema and created production documents. A later commit in the same feature replaced required fields before the next successful production schema push. Convex validates all stored documents during deployment, so it rejected the new schema because existing signals did not contain `supporterKind` and still used `completedAllAtSignal`.

The Next.js build itself completed successfully; the deployment failed while pushing the incompatible Convex schema. The sitemap dynamic-render warning in the build log was non-fatal.

## Impact

The compatibility fields are accepted only for existing documents. New writes continue using the current schema. A later one-time migration can rewrite all legacy documents and then remove the compatibility validators.

## Validation

- `pnpm typecheck`
- `pnpm test:convex -- convex/courseInterest.test.ts` (76 tests passed)
- `pnpm build`
- Biome format and lint on all changed files
- deployed schema/functions successfully to the Convex development deployment

Repository-wide `pnpm run format:check` currently reports a pre-existing formatting difference in `convex/storyFeedback.test.ts` on `main`; that unrelated file is intentionally excluded from this hotfix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course interest tracking for learners and editors using legacy data.
  * Corrected browser, authenticated, and completed-course interest counts.
  * Ensured interest updates and completion status remain accurate across older and newer records.

* **Tests**
  * Added integration coverage for legacy browser and signed-in course interest scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->