### PR TITLE
Add learner interest ranking page and simplify interest summary

### DIFF
--- a/convex/courseInterest.test.ts
+++ b/convex/courseInterest.test.ts
@@ -318,6 +318,106 @@ describe("course interest", () => {
     });
   });
 
+  test("ranks courses by total learner interest for editors", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourse(t);
+    await t.run(async (ctx) => {
+      const learningLanguageId = await ctx.db.insert("languages", {
+        legacyId: 3,
+        name: "Gaelic",
+        short: "gd",
+        public: true,
+        rtl: false,
+      });
+      const fromLanguage = await ctx.db
+        .query("languages")
+        .withIndex("by_short", (q) => q.eq("short", "en"))
+        .unique();
+      if (!fromLanguage) throw new Error("Missing seeded English language.");
+      await ctx.db.insert("courses", {
+        legacyId: 101,
+        short: "gd-en",
+        learningLanguageId,
+        fromLanguageId: fromLanguage._id,
+        public: true,
+        official: false,
+        count: 1,
+      });
+    });
+
+    await t.mutation(api.courseInterest.setForLearner, {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+      interested: true,
+    });
+    await t.mutation(api.courseInterest.setForLearner, {
+      courseShort: "gd-en",
+      anonymousId: "another_browser_123456",
+      interested: true,
+    });
+    const learner = t.withIdentity({ userId: "7", role: "user" });
+    await learner.mutation(api.courseInterest.setForLearner, {
+      courseShort: "gd-en",
+      anonymousId: "signed_in_browser_123456",
+      interested: true,
+    });
+
+    const editor = t.withIdentity({ userId: "8", role: "contributor" });
+    expect(await editor.query(api.courseInterest.listForEditor, {})).toEqual([
+      {
+        courseShort: "gd-en",
+        learningLanguageId: expect.anything(),
+        learningLanguageName: "Gaelic",
+        fromLanguageShort: "en",
+        public: true,
+        storyCount: 1,
+        totalCount: 2,
+        completedAllCount: 0,
+      },
+      {
+        courseShort: "cy-en",
+        learningLanguageId: expect.anything(),
+        learningLanguageName: "Welsh",
+        fromLanguageShort: "en",
+        public: true,
+        storyCount: 2,
+        totalCount: 1,
+        completedAllCount: 0,
+      },
+    ]);
+  });
+
+  test("hides courses whose signals were all withdrawn", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourse(t);
+    const args = {
+      courseShort: "cy-en",
+      anonymousId: "browser_supporter_123456",
+    };
+    await t.mutation(api.courseInterest.setForLearner, {
+      ...args,
+      interested: true,
+    });
+    await t.mutation(api.courseInterest.setForLearner, {
+      ...args,
+      interested: false,
+    });
+
+    const editor = t.withIdentity({ userId: "8", role: "contributor" });
+    expect(await editor.query(api.courseInterest.listForEditor, {})).toEqual(
+      [],
+    );
+  });
+
+  test("rejects the interest ranking for non-contributors", async () => {
+    const t = convexTest(schema, modules);
+    await seedCourse(t);
+
+    await expect(t.query(api.courseInterest.listForEditor, {})).rejects.toThrow(
+      "Unauthorized",
+    );
+  });
+
   test("limits bursts of new browser signals for one course", async () => {
     const t = convexTest(schema, modules);
     await seedCourse(t);

--- a/convex/courseInterest.ts
+++ b/convex/courseInterest.ts
@@ -37,6 +37,17 @@ const editorInterestValidator = v.union(
   v.null(),
 );
 
+const editorInterestCourseValidator = v.object({
+  courseShort: v.union(v.string(), v.null()),
+  learningLanguageId: v.id("languages"),
+  learningLanguageName: v.string(),
+  fromLanguageShort: v.string(),
+  public: v.boolean(),
+  storyCount: v.number(),
+  totalCount: v.number(),
+  completedAllCount: v.number(),
+});
+
 type SupporterKeys = {
   anonymousKey: string;
   legacyUserId: number | null;
@@ -371,6 +382,70 @@ export const setForLearner = mutation({
         primarySignal?.completedAllAvailableStoriesAt !== undefined ||
         anonymousSignal?.completedAllAvailableStoriesAt !== undefined,
     };
+  },
+});
+
+export const listForEditor = query({
+  args: {},
+  returns: v.array(editorInterestCourseValidator),
+  handler: async (ctx) => {
+    await requireContributorOrAdmin(ctx);
+
+    // One row per course that ever received a signal, so this stays bounded
+    // by the number of courses.
+    const statsRows = await ctx.db.query("course_interest_stats").collect();
+    const activeStats = statsRows.filter(
+      (stats) => stats.authenticatedCount + stats.browserCount > 0,
+    );
+
+    const courseById = new Map<Id<"courses">, Doc<"courses">>();
+    for (const course of await Promise.all(
+      activeStats.map((stats) => ctx.db.get(stats.courseId)),
+    )) {
+      if (course) courseById.set(course._id, course);
+    }
+
+    const languageIds = Array.from(
+      new Set(
+        Array.from(courseById.values()).flatMap((course) => [
+          course.learningLanguageId,
+          course.fromLanguageId,
+        ]),
+      ),
+    );
+    const languageById = new Map<Id<"languages">, Doc<"languages">>();
+    for (const language of await Promise.all(
+      languageIds.map((languageId) => ctx.db.get(languageId)),
+    )) {
+      if (language) languageById.set(language._id, language);
+    }
+
+    const rows = [];
+    for (const stats of activeStats) {
+      const course = courseById.get(stats.courseId);
+      if (!course) continue;
+      const learningLanguage = languageById.get(course.learningLanguageId);
+      const fromLanguage = languageById.get(course.fromLanguageId);
+      rows.push({
+        courseShort: course.short ?? null,
+        learningLanguageId: course.learningLanguageId,
+        learningLanguageName:
+          learningLanguage?.name ?? course.learning_language_name ?? "",
+        fromLanguageShort: fromLanguage?.short ?? "",
+        public: course.public,
+        storyCount: course.count ?? 0,
+        totalCount: stats.authenticatedCount + stats.browserCount,
+        completedAllCount: stats.completedAllCount,
+      });
+    }
+
+    rows.sort(
+      (a, b) =>
+        b.totalCount - a.totalCount ||
+        b.completedAllCount - a.completedAllCount ||
+        a.learningLanguageName.localeCompare(b.learningLanguageName),
+    );
+    return rows;
   },
 });
 

--- a/src/app/editor/(course)/course_interest_summary.tsx
+++ b/src/app/editor/(course)/course_interest_summary.tsx
@@ -3,6 +3,7 @@
 import { api } from "@convex/_generated/api";
 import { Heart, Trophy } from "lucide-react";
 import { useQuery } from "convex/react";
+import Link from "next/link";
 
 export default function CourseInterestSummary({
   courseIdentifier,
@@ -31,11 +32,9 @@ export default function CourseInterestSummary({
           {stats && totalCount > 0 ? (
             <>
               <p className="mt-1 text-[calc(17/16*1rem)]">
-                <strong>{stats.authenticatedCount}</strong>{" "}
-                {stats.authenticatedCount === 1
-                  ? "signed-in learner wants"
-                  : "signed-in learners want"}{" "}
-                more stories.
+                <strong>{totalCount}</strong>{" "}
+                {totalCount === 1 ? "learner wants" : "learners want"} more
+                stories.
               </p>
               {stats.completedAllCount > 0 ? (
                 <p className="mt-2 flex items-center gap-2 text-[calc(14/16*1rem)] text-[var(--text-color-dim)]">
@@ -50,15 +49,6 @@ export default function CourseInterestSummary({
                   all available stories before asking for more.
                 </p>
               ) : null}
-              {stats.browserCount > 0 ? (
-                <p className="mt-2 text-[calc(14/16*1rem)] text-[var(--text-color-dim)]">
-                  Plus {stats.browserCount} additional{" "}
-                  {stats.browserCount === 1
-                    ? "browser signal"
-                    : "browser signals"}
-                  .
-                </p>
-              ) : null}
             </>
           ) : (
             <p className="mt-1 text-[var(--text-color-dim)]">
@@ -66,6 +56,11 @@ export default function CourseInterestSummary({
               story list.
             </p>
           )}
+          <p className="mt-2 text-[calc(14/16*1rem)]">
+            <Link className="underline" href="/editor/interest">
+              Compare interest across all courses
+            </Link>
+          </p>
         </div>
       </div>
     </section>

--- a/src/app/editor/(course)/interest/interest_list.tsx
+++ b/src/app/editor/(course)/interest/interest_list.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { api } from "@convex/_generated/api";
+import { Heart, Trophy } from "lucide-react";
+import { useQuery } from "convex/react";
+import Link from "next/link";
+import LanguageFlag from "@/components/ui/language-flag";
+import { Spinner } from "@/components/ui/spinner";
+
+export default function InterestList() {
+  const courses = useQuery(api.courseInterest.listForEditor, {});
+
+  if (courses === undefined) return <Spinner />;
+
+  return (
+    <div className="mx-auto max-w-[800px] p-5">
+      <h1 className="flex items-center gap-3 text-[calc(24/16*1rem)] font-bold">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#d9ffc2] text-[#58a700] dark:bg-[#315d24] dark:text-[#9be66e]">
+          <Heart className="h-5 w-5 fill-current" aria-hidden="true" />
+        </span>
+        Learner interest
+      </h1>
+      <p className="mt-2 text-[var(--text-color-dim)]">
+        Courses ranked by how many learners asked for more stories.
+      </p>
+      {courses.length === 0 ? (
+        <p className="mt-6 text-[var(--text-color-dim)]">
+          No learner signals yet.
+        </p>
+      ) : (
+        <ol className="mt-6 list-none p-0">
+          {courses.map((course, index) => {
+            const name = `${course.learningLanguageName} [${course.fromLanguageShort}]`;
+            const content = (
+              <>
+                <span className="w-8 shrink-0 text-right text-[var(--text-color-dim)]">
+                  {index + 1}.
+                </span>
+                <LanguageFlag
+                  className="m-1 ml-3"
+                  languageId={course.learningLanguageId}
+                  width={40}
+                />
+                <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+                  {name}
+                </span>
+                {!course.public ? (
+                  <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[calc(12/16*1rem)] text-amber-900">
+                    not public
+                  </span>
+                ) : null}
+                <span className="ml-auto flex shrink-0 items-center gap-4 pl-3">
+                  {course.completedAllCount > 0 ? (
+                    <span
+                      className="flex items-center gap-1 text-[var(--text-color-dim)]"
+                      title={`${course.completedAllCount} ${
+                        course.completedAllCount === 1 ? "learner" : "learners"
+                      } finished all available stories before asking for more.`}
+                    >
+                      <Trophy
+                        className="h-4 w-4 text-[#d79b00]"
+                        aria-hidden="true"
+                      />
+                      {course.completedAllCount}
+                    </span>
+                  ) : null}
+                  <span
+                    className="flex w-14 items-center justify-end gap-1 font-bold text-[#58a700] dark:text-[#9be66e]"
+                    title={`${course.totalCount} ${
+                      course.totalCount === 1
+                        ? "learner wants"
+                        : "learners want"
+                    } more stories.`}
+                  >
+                    <Heart
+                      className="h-4 w-4 shrink-0 fill-current"
+                      aria-hidden="true"
+                    />
+                    {course.totalCount}
+                  </span>
+                </span>
+              </>
+            );
+            const rowClass =
+              "flex items-center border-b border-[var(--header-border)] py-1 pr-3 text-[var(--text-color)]";
+            return (
+              <li key={course.courseShort ?? name}>
+                {course.courseShort ? (
+                  <Link
+                    className={`${rowClass} no-underline hover:brightness-90 focus:brightness-90`}
+                    href={`/editor/course/${course.courseShort}`}
+                  >
+                    {content}
+                  </Link>
+                ) : (
+                  <div className={rowClass}>{content}</div>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/app/editor/(course)/interest/page.tsx
+++ b/src/app/editor/(course)/interest/page.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from "next";
+import InterestList from "./interest_list";
+
+export async function generateMetadata({}): Promise<Metadata> {
+  return {
+    title: `Learner Interest | Duostories Editor`,
+    alternates: {
+      canonical: `https://duostories.org/editor/interest/`,
+    },
+  } as Metadata;
+}
+
+export default function Page() {
+  return <InterestList />;
+}

--- a/src/app/editor/(course)/page.tsx
+++ b/src/app/editor/(course)/page.tsx
@@ -1,5 +1,6 @@
 import { getUser, isContributor } from "@/lib/userInterface";
 import { Metadata } from "next";
+import Link from "next/link";
 
 export async function generateMetadata({}): Promise<Metadata> {
   return {
@@ -21,6 +22,13 @@ export default async function Page({}) {
   }
 
   return (
-    <p id="no_stories">Click on one of the courses to display its stories.</p>
+    <div>
+      <p id="no_stories">Click on one of the courses to display its stories.</p>
+      <p className="mt-4">
+        <Link className="underline" href="/editor/interest">
+          ❤️ Courses ranked by learner interest
+        </Link>
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- The per-course "Learner interest" card in the editor now shows one combined learner count (signed-in + browser signals) instead of splitting them, which read oddly when the signed-in count was zero ("0 signed-in learners want more stories. Plus 1 additional browser signal."). The stats table still records both kinds of signals separately for future use.
- New `/editor/interest` page that ranks all courses by total story requests, so contributors can see where more stories are wanted most. Each row shows rank, flag, course name, a "not public" badge where relevant, the finished-all-stories trophy count, and total hearts, and links to the course's editor page.
- Linked from the editor landing page and from each course's interest card.
- Backend: new contributor/admin-gated Convex query `courseInterest.listForEditor` that reads the bounded `course_interest_stats` table, joins course + language names, hides courses whose signals were all withdrawn, and sorts by total hearts (tiebreak: completed-all count, then language name).

## Test plan
- [x] `pnpm exec vitest run convex/courseInterest.test.ts` — 11 tests pass, including 3 new cases: ranking order across courses, hiding fully-withdrawn courses, rejecting non-contributors
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [ ] Visit `/editor/interest` as a contributor and check the ranking renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an editor page ranking courses by learner interest.
  * Rankings combine browser and authenticated interest, with completion counts and language details.
  * Added visibility indicators, language flags, completion trophies, and links to available course pages.
  * Added navigation from the editor’s empty state to the interest rankings.

* **Improvements**
  * Updated course interest summaries with combined counts and clearer singular/plural wording.
  * Added loading and no-results states for the rankings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->