### PR TITLE
Add course usage analytics

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as authProviderConfig from "../authProviderConfig.js";
 import type * as authProviders from "../authProviders.js";
 import type * as courseContributorBackfill from "../courseContributorBackfill.js";
 import type * as courseInterest from "../courseInterest.js";
+import type * as courseReadStats from "../courseReadStats.js";
 import type * as courseWrite from "../courseWrite.js";
 import type * as discordAvatarSync from "../discordAvatarSync.js";
 import type * as discordBot from "../discordBot.js";
@@ -76,6 +77,7 @@ declare const fullApi: ApiFromModules<{
   authProviders: typeof authProviders;
   courseContributorBackfill: typeof courseContributorBackfill;
   courseInterest: typeof courseInterest;
+  courseReadStats: typeof courseReadStats;
   courseWrite: typeof courseWrite;
   discordAvatarSync: typeof discordAvatarSync;
   discordBot: typeof discordBot;
@@ -142,4 +144,6 @@ export declare const internal: FilterApi<
 
 export declare const components: {
   betterAuth: import("../betterAuth/_generated/component.js").ComponentApi<"betterAuth">;
+  storyReadsByCourse: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"storyReadsByCourse">;
+  readersByCourse: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"readersByCourse">;
 };

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,8 +1,11 @@
 import { defineApp } from "convex/server";
+import aggregate from "@convex-dev/aggregate/convex.config";
 import betterAuth from "./betterAuth/convex.config";
 
 const app = defineApp();
 
 app.use(betterAuth);
+app.use(aggregate, { name: "storyReadsByCourse" });
+app.use(aggregate, { name: "readersByCourse" });
 
 export default app;

--- a/convex/courseInterest.test.ts
+++ b/convex/courseInterest.test.ts
@@ -1,20 +1,9 @@
 /// <reference types="vite/client" />
-import { register as registerAggregate } from "@convex-dev/aggregate/test";
-import { convexTest as createConvexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
-import schema from "./schema";
+import { createConvexTest } from "../test/convexTestHarness";
 
-const modules = import.meta.glob("./**/*.ts");
-
-function convexTest(testSchema: typeof schema, testModules: typeof modules) {
-  const t = createConvexTest(testSchema, testModules);
-  registerAggregate(t, "storyReadsByCourse");
-  registerAggregate(t, "readersByCourse");
-  return t;
-}
-
-async function seedCourse(t: ReturnType<typeof convexTest>) {
+async function seedCourse(t: ReturnType<typeof createConvexTest>) {
   return await t.run(async (ctx) => {
     const learningLanguageId = await ctx.db.insert("languages", {
       legacyId: 1,
@@ -73,7 +62,7 @@ async function seedCourse(t: ReturnType<typeof convexTest>) {
 
 describe("course interest", () => {
   test("an anonymous learner can add and remove one signal", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourse(t);
     const args = {
       courseShort: "cy-en",
@@ -116,7 +105,7 @@ describe("course interest", () => {
   });
 
   test("marks a signed-in signal when every story is complete", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     const { courseId, firstStoryId, secondStoryId } = await seedCourse(t);
     await t.run(async (ctx) => {
       for (const [storyId, legacyStoryId] of [
@@ -158,7 +147,7 @@ describe("course interest", () => {
   });
 
   test("does not substitute a deleted completion for a visible story", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     const { courseId, firstStoryId, imageId } = await seedCourse(t);
     const deletedStoryId = await t.run(async (ctx) => {
       return await ctx.db.insert("stories", {
@@ -199,7 +188,7 @@ describe("course interest", () => {
   });
 
   test("upgrades an existing signal when the learner finishes the final story", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourse(t);
     const learner = t.withIdentity({ userId: "7", role: "user" });
     await learner.mutation(api.storyDone.recordStoryDone, {
@@ -228,7 +217,7 @@ describe("course interest", () => {
   });
 
   test("keeps qualification as a historical achievement after publication", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     const { courseId, firstStoryId, secondStoryId, imageId } =
       await seedCourse(t);
     await t.run(async (ctx) => {
@@ -275,7 +264,7 @@ describe("course interest", () => {
   });
 
   test("merges a browser signal into the signed-in learner", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourse(t);
     const args = {
       courseShort: "cy-en",
@@ -300,7 +289,7 @@ describe("course interest", () => {
   });
 
   test("separates browser and authenticated evidence", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourse(t);
     await t.mutation(api.courseInterest.setForLearner, {
       courseShort: "cy-en",
@@ -327,7 +316,7 @@ describe("course interest", () => {
   });
 
   test("ranks courses by total learner interest for editors", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourse(t);
     await t.run(async (ctx) => {
       const learningLanguageId = await ctx.db.insert("languages", {
@@ -396,7 +385,7 @@ describe("course interest", () => {
   });
 
   test("hides courses whose signals were all withdrawn", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourse(t);
     const args = {
       courseShort: "cy-en",
@@ -418,7 +407,7 @@ describe("course interest", () => {
   });
 
   test("rejects the interest ranking for non-contributors", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourse(t);
 
     await expect(t.query(api.courseInterest.listForEditor, {})).rejects.toThrow(
@@ -427,7 +416,7 @@ describe("course interest", () => {
   });
 
   test("limits bursts of new browser signals for one course", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourse(t);
     for (let index = 0; index < 30; index += 1) {
       await t.mutation(api.courseInterest.setForLearner, {

--- a/convex/courseInterest.test.ts
+++ b/convex/courseInterest.test.ts
@@ -1,10 +1,18 @@
 /// <reference types="vite/client" />
-import { convexTest } from "convex-test";
+import { register as registerAggregate } from "@convex-dev/aggregate/test";
+import { convexTest as createConvexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
+
+function convexTest(testSchema: typeof schema, testModules: typeof modules) {
+  const t = createConvexTest(testSchema, testModules);
+  registerAggregate(t, "storyReadsByCourse");
+  registerAggregate(t, "readersByCourse");
+  return t;
+}
 
 async function seedCourse(t: ReturnType<typeof convexTest>) {
   return await t.run(async (ctx) => {

--- a/convex/courseReadStats.test.ts
+++ b/convex/courseReadStats.test.ts
@@ -1,20 +1,9 @@
 /// <reference types="vite/client" />
-import { register as registerAggregate } from "@convex-dev/aggregate/test";
-import { convexTest as createConvexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
-import schema from "./schema";
+import { createConvexTest } from "../test/convexTestHarness";
 
-const modules = import.meta.glob("./**/*.ts");
-
-function setupTest() {
-  const t = createConvexTest(schema, modules);
-  registerAggregate(t, "storyReadsByCourse");
-  registerAggregate(t, "readersByCourse");
-  return t;
-}
-
-async function seedCourse(t: ReturnType<typeof setupTest>) {
+async function seedCourse(t: ReturnType<typeof createConvexTest>) {
   return await t.run(async (ctx) => {
     const learningLanguageId = await ctx.db.insert("languages", {
       legacyId: 1,
@@ -54,7 +43,7 @@ async function seedCourse(t: ReturnType<typeof setupTest>) {
 
 describe("course read stats", () => {
   test("counts completions while deduplicating signed-in learners", async () => {
-    const t = setupTest();
+    const t = createConvexTest();
     await seedCourse(t);
     const now = Date.now();
     const learner = t.withIdentity({ userId: "7" });
@@ -86,7 +75,7 @@ describe("course read stats", () => {
   });
 
   test("backfills legacy completions idempotently", async () => {
-    const t = setupTest();
+    const t = createConvexTest();
     const { courseId, storyId } = await seedCourse(t);
     const now = Date.now();
     await t.run(async (ctx) => {
@@ -103,6 +92,7 @@ describe("course read stats", () => {
         paginationOpts: { cursor: null, numItems: 10 },
       });
       expect(result.isDone).toBe(true);
+      expect(result.skipped).toBe(0);
     }
 
     await t.run(async (ctx) => {
@@ -115,5 +105,44 @@ describe("course read stats", () => {
     });
     expect(stats?.totalStoryReads).toBe(1);
     expect(stats?.totalReaders).toBe(1);
+  });
+
+  test("restricts editor stats and clamps the requested period", async () => {
+    const t = createConvexTest();
+    await seedCourse(t);
+
+    expect(
+      await t.query(api.courseReadStats.getForEditor, {
+        courseIdentifier: "es-en",
+      }),
+    ).toBeNull();
+
+    const stats = await t
+      .withIdentity({ role: "contributor" })
+      .query(api.courseReadStats.getForEditor, {
+        courseIdentifier: "es-en",
+        days: 1_000,
+      });
+    expect(stats?.points).toHaveLength(180);
+  });
+
+  test("reports completions whose story no longer exists", async () => {
+    const t = createConvexTest();
+    const { storyId } = await seedCourse(t);
+    await t.run(async (ctx) => {
+      await ctx.db.delete(storyId);
+      await ctx.db.insert("story_done", {
+        storyId,
+        time: Date.now(),
+      });
+    });
+
+    const result = await t
+      .withIdentity({ role: "admin" })
+      .mutation(api.courseReadStats.backfill, {
+        paginationOpts: { cursor: null, numItems: 10 },
+      });
+    expect(result.processed).toBe(1);
+    expect(result.skipped).toBe(1);
   });
 });

--- a/convex/courseReadStats.test.ts
+++ b/convex/courseReadStats.test.ts
@@ -1,0 +1,119 @@
+/// <reference types="vite/client" />
+import { register as registerAggregate } from "@convex-dev/aggregate/test";
+import { convexTest as createConvexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+function setupTest() {
+  const t = createConvexTest(schema, modules);
+  registerAggregate(t, "storyReadsByCourse");
+  registerAggregate(t, "readersByCourse");
+  return t;
+}
+
+async function seedCourse(t: ReturnType<typeof setupTest>) {
+  return await t.run(async (ctx) => {
+    const learningLanguageId = await ctx.db.insert("languages", {
+      legacyId: 1,
+      name: "Spanish",
+      short: "es",
+      public: true,
+      rtl: false,
+    });
+    const fromLanguageId = await ctx.db.insert("languages", {
+      legacyId: 2,
+      name: "English",
+      short: "en",
+      public: true,
+      rtl: false,
+    });
+    const courseId = await ctx.db.insert("courses", {
+      legacyId: 100,
+      short: "es-en",
+      learningLanguageId,
+      fromLanguageId,
+      public: true,
+      official: false,
+    });
+    const storyId = await ctx.db.insert("stories", {
+      legacyId: 10,
+      duo_id: "story-10",
+      name: "A story",
+      public: true,
+      courseId,
+      status: "finished",
+      deleted: false,
+      todo_count: 0,
+    });
+    return { courseId, storyId };
+  });
+}
+
+describe("course read stats", () => {
+  test("counts completions while deduplicating signed-in learners", async () => {
+    const t = setupTest();
+    await seedCourse(t);
+    const now = Date.now();
+    const learner = t.withIdentity({ userId: "7" });
+
+    await learner.mutation(api.storyDone.recordStoryDone, {
+      legacyStoryId: 10,
+      time: now - 1_000,
+    });
+    await learner.mutation(api.storyDone.recordStoryDone, {
+      legacyStoryId: 10,
+      time: now,
+    });
+    await t.mutation(api.storyDone.recordStoryDone, {
+      legacyStoryId: 10,
+      time: now,
+    });
+
+    const stats = await t
+      .withIdentity({ role: "contributor" })
+      .query(api.courseReadStats.getForEditor, {
+        courseIdentifier: "es-en",
+        days: 30,
+      });
+    expect(stats?.totalStoryReads).toBe(3);
+    expect(stats?.totalReaders).toBe(1);
+    expect(
+      stats?.points.reduce((sum, point) => sum + point.storyReads, 0),
+    ).toBe(3);
+  });
+
+  test("backfills legacy completions idempotently", async () => {
+    const t = setupTest();
+    const { courseId, storyId } = await seedCourse(t);
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("story_done", {
+        storyId,
+        legacyUserId: 7,
+        time: now,
+      });
+    });
+
+    const admin = t.withIdentity({ role: "admin" });
+    for (let run = 0; run < 2; run += 1) {
+      const result = await admin.mutation(api.courseReadStats.backfill, {
+        paginationOpts: { cursor: null, numItems: 10 },
+      });
+      expect(result.isDone).toBe(true);
+    }
+
+    await t.run(async (ctx) => {
+      const [completion] = await ctx.db.query("story_done").collect();
+      expect(completion?.courseId).toBe(courseId);
+      expect(await ctx.db.query("course_readers").collect()).toHaveLength(1);
+    });
+    const stats = await admin.query(api.courseReadStats.getForEditor, {
+      courseIdentifier: "es-en",
+    });
+    expect(stats?.totalStoryReads).toBe(1);
+    expect(stats?.totalReaders).toBe(1);
+  });
+});

--- a/convex/courseReadStats.ts
+++ b/convex/courseReadStats.ts
@@ -1,0 +1,190 @@
+import { TableAggregate } from "@convex-dev/aggregate";
+import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+import { components } from "./_generated/api";
+import type { DataModel, Doc, Id } from "./_generated/dataModel";
+import { mutation, query, type MutationCtx } from "./_generated/server";
+import { isContributorOrAdmin, requireAdmin } from "./lib/authorization";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_DAYS = 90;
+const MAX_DAYS = 180;
+
+function storyDoneCourseId(doc: Doc<"story_done">): Id<"courses"> {
+  if (!doc.courseId) throw new Error(`story_done ${doc._id} has no courseId`);
+  return doc.courseId;
+}
+
+const storyReadsByCourse = new TableAggregate<{
+  Namespace: Id<"courses">;
+  Key: number;
+  DataModel: DataModel;
+  TableName: "story_done";
+}>(components.storyReadsByCourse, {
+  namespace: storyDoneCourseId,
+  sortKey: (doc) => doc.time,
+});
+
+const readersByCourse = new TableAggregate<{
+  Namespace: Id<"courses">;
+  Key: number;
+  DataModel: DataModel;
+  TableName: "course_readers";
+}>(components.readersByCourse, {
+  namespace: (doc) => doc.courseId,
+  sortKey: (doc) => doc.firstReadAt,
+});
+
+export async function recordCourseReadStats(
+  ctx: MutationCtx,
+  completion: Doc<"story_done">,
+) {
+  await storyReadsByCourse.insertIfDoesNotExist(ctx, completion);
+  if (completion.legacyUserId === undefined) return;
+
+  const existing = await ctx.db
+    .query("course_readers")
+    .withIndex("by_course_id_and_legacy_user_id", (q) =>
+      q
+        .eq("courseId", storyDoneCourseId(completion))
+        .eq("legacyUserId", completion.legacyUserId!),
+    )
+    .unique();
+
+  if (!existing) {
+    const id = await ctx.db.insert("course_readers", {
+      courseId: storyDoneCourseId(completion),
+      legacyUserId: completion.legacyUserId,
+      firstReadAt: completion.time,
+      lastReadAt: completion.time,
+    });
+    const reader = await ctx.db.get(id);
+    if (!reader) throw new Error("Course reader was not persisted");
+    await readersByCourse.insertIfDoesNotExist(ctx, reader);
+    return;
+  }
+
+  const firstReadAt = Math.min(existing.firstReadAt, completion.time);
+  const lastReadAt = Math.max(existing.lastReadAt, completion.time);
+  if (
+    firstReadAt === existing.firstReadAt &&
+    lastReadAt === existing.lastReadAt
+  ) {
+    await readersByCourse.insertIfDoesNotExist(ctx, existing);
+    return;
+  }
+
+  await ctx.db.patch(existing._id, { firstReadAt, lastReadAt });
+  const updated = await ctx.db.get(existing._id);
+  if (!updated) throw new Error("Course reader disappeared during update");
+  await readersByCourse.replaceOrInsert(ctx, existing, updated);
+}
+
+const chartPointValidator = v.object({
+  date: v.string(),
+  storyReads: v.number(),
+  newReaders: v.number(),
+  totalReaders: v.number(),
+});
+
+export const getForEditor = query({
+  args: {
+    courseIdentifier: v.string(),
+    days: v.optional(v.number()),
+  },
+  returns: v.union(
+    v.object({
+      points: v.array(chartPointValidator),
+      totalStoryReads: v.number(),
+      totalReaders: v.number(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    if (!(await isContributorOrAdmin(ctx))) return null;
+    const course = /^\d+$/.test(args.courseIdentifier)
+      ? await ctx.db
+          .query("courses")
+          .withIndex("by_id_value", (q) =>
+            q.eq("legacyId", Number(args.courseIdentifier)),
+          )
+          .unique()
+      : await ctx.db
+          .query("courses")
+          .withIndex("by_short", (q) => q.eq("short", args.courseIdentifier))
+          .unique();
+    if (!course) return null;
+
+    const days = Math.max(
+      1,
+      Math.min(MAX_DAYS, Math.floor(args.days ?? DEFAULT_DAYS)),
+    );
+    const todayStart = Math.floor(Date.now() / DAY_MS) * DAY_MS;
+    const start = todayStart - (days - 1) * DAY_MS;
+    const buckets = Array.from({ length: days }, (_, index) => {
+      const lower = start + index * DAY_MS;
+      return { lower, upper: lower + DAY_MS };
+    });
+    const bounds = buckets.map(({ lower, upper }) => ({
+      namespace: course._id,
+      bounds: {
+        lower: { key: lower, inclusive: true },
+        upper: { key: upper, inclusive: false },
+      },
+    }));
+
+    const [storyReads, newReaders, readersBeforeStart, totalStoryReads] =
+      await Promise.all([
+        storyReadsByCourse.countBatch(ctx, bounds),
+        readersByCourse.countBatch(ctx, bounds),
+        readersByCourse.count(ctx, {
+          namespace: course._id,
+          bounds: { upper: { key: start, inclusive: false } },
+        }),
+        storyReadsByCourse.count(ctx, { namespace: course._id }),
+      ]);
+
+    let totalReaders = readersBeforeStart;
+    const points = buckets.map(({ lower }, index) => {
+      totalReaders += newReaders[index] ?? 0;
+      return {
+        date: new Date(lower).toISOString().slice(0, 10),
+        storyReads: storyReads[index] ?? 0,
+        newReaders: newReaders[index] ?? 0,
+        totalReaders,
+      };
+    });
+
+    return { points, totalStoryReads, totalReaders };
+  },
+});
+
+export const backfill = mutation({
+  args: { paginationOpts: paginationOptsValidator },
+  returns: v.object({
+    processed: v.number(),
+    continueCursor: v.string(),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+    const page = await ctx.db.query("story_done").paginate(args.paginationOpts);
+
+    for (const completion of page.page) {
+      let current = completion;
+      if (!current.courseId) {
+        const story = await ctx.db.get(current.storyId);
+        if (!story) continue;
+        await ctx.db.patch(current._id, { courseId: story.courseId });
+        current = { ...current, courseId: story.courseId };
+      }
+      await recordCourseReadStats(ctx, current);
+    }
+
+    return {
+      processed: page.page.length,
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+    };
+  },
+});

--- a/convex/courseReadStats.ts
+++ b/convex/courseReadStats.ts
@@ -163,6 +163,7 @@ export const backfill = mutation({
   args: { paginationOpts: paginationOptsValidator },
   returns: v.object({
     processed: v.number(),
+    skipped: v.number(),
     continueCursor: v.string(),
     isDone: v.boolean(),
   }),
@@ -170,11 +171,15 @@ export const backfill = mutation({
     await requireAdmin(ctx);
     const page = await ctx.db.query("story_done").paginate(args.paginationOpts);
 
+    let skipped = 0;
     for (const completion of page.page) {
       let current = completion;
       if (!current.courseId) {
         const story = await ctx.db.get(current.storyId);
-        if (!story) continue;
+        if (!story) {
+          skipped += 1;
+          continue;
+        }
         await ctx.db.patch(current._id, { courseId: story.courseId });
         current = { ...current, courseId: story.courseId };
       }
@@ -183,6 +188,7 @@ export const backfill = mutation({
 
     return {
       processed: page.page.length,
+      skipped,
       continueCursor: page.continueCursor,
       isDone: page.isDone,
     };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -194,6 +194,7 @@ export default defineSchema({
 
   story_done: defineTable({
     storyId: v.id("stories"),
+    courseId: v.optional(v.id("courses")),
     legacyUserId: v.optional(v.number()),
     time: v.number(),
   })
@@ -201,6 +202,13 @@ export default defineSchema({
     .index("by_user", ["legacyUserId"])
     .index("by_user_and_story", ["legacyUserId", "storyId"])
     .index("by_user_time", ["legacyUserId", "time"]),
+
+  course_readers: defineTable({
+    courseId: v.id("courses"),
+    legacyUserId: v.number(),
+    firstReadAt: v.number(),
+    lastReadAt: v.number(),
+  }).index("by_course_id_and_legacy_user_id", ["courseId", "legacyUserId"]),
 
   story_done_state: defineTable({
     storyId: v.id("stories"),

--- a/convex/storyDone.test.ts
+++ b/convex/storyDone.test.ts
@@ -1,11 +1,19 @@
 /// <reference types="vite/client" />
-import { convexTest } from "convex-test";
+import { register as registerAggregate } from "@convex-dev/aggregate/test";
+import { convexTest as createConvexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
+
+function convexTest(testSchema: typeof schema, testModules: typeof modules) {
+  const t = createConvexTest(testSchema, testModules);
+  registerAggregate(t, "storyReadsByCourse");
+  registerAggregate(t, "readersByCourse");
+  return t;
+}
 
 async function seedCourseWithStory(t: ReturnType<typeof convexTest>) {
   return await t.run(async (ctx) => {

--- a/convex/storyDone.test.ts
+++ b/convex/storyDone.test.ts
@@ -1,21 +1,10 @@
 /// <reference types="vite/client" />
-import { register as registerAggregate } from "@convex-dev/aggregate/test";
-import { convexTest as createConvexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
-import schema from "./schema";
+import { createConvexTest } from "../test/convexTestHarness";
 
-const modules = import.meta.glob("./**/*.ts");
-
-function convexTest(testSchema: typeof schema, testModules: typeof modules) {
-  const t = createConvexTest(testSchema, testModules);
-  registerAggregate(t, "storyReadsByCourse");
-  registerAggregate(t, "readersByCourse");
-  return t;
-}
-
-async function seedCourseWithStory(t: ReturnType<typeof convexTest>) {
+async function seedCourseWithStory(t: ReturnType<typeof createConvexTest>) {
   return await t.run(async (ctx) => {
     const learningLanguageId = await ctx.db.insert("languages", {
       legacyId: 1,
@@ -57,7 +46,7 @@ async function seedCourseWithStory(t: ReturnType<typeof convexTest>) {
 
 describe("recordStoryDone", () => {
   test("anonymous completion inserts story_done without a user and no course_activity", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     const { storyId } = await seedCourseWithStory(t);
 
     const result = await t.mutation(api.storyDone.recordStoryDone, {
@@ -83,7 +72,7 @@ describe("recordStoryDone", () => {
   });
 
   test("authenticated completion also creates story_done_state and course_activity", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     const { storyId } = await seedCourseWithStory(t);
     const asUser = t.withIdentity({ userId: "7" });
 
@@ -122,7 +111,7 @@ describe("recordStoryDone", () => {
   });
 
   test("unknown legacyStoryId rejects with Missing story", async () => {
-    const t = convexTest(schema, modules);
+    const t = createConvexTest();
     await seedCourseWithStory(t);
 
     await expect(

--- a/convex/storyDone.ts
+++ b/convex/storyDone.ts
@@ -7,6 +7,7 @@ import {
   requireSessionLegacyUserId,
 } from "./lib/authorization";
 import { maybeQualifyCourseInterestSignal } from "./courseInterest";
+import { recordCourseReadStats } from "./courseReadStats";
 
 const storyDoneInputValidator = v.object({
   legacyStoryId: v.number(),
@@ -74,6 +75,7 @@ export const recordStoryDone = mutation({
       } else {
         docId = await ctx.db.insert("story_done", {
           storyId: story._id,
+          courseId: story.courseId,
           legacyUserId,
           time: doneAt,
         });
@@ -82,10 +84,17 @@ export const recordStoryDone = mutation({
     } else {
       docId = await ctx.db.insert("story_done", {
         storyId: story._id,
+        courseId: story.courseId,
         legacyUserId: undefined,
         time: doneAt,
       });
       inserted = true;
+    }
+
+    if (inserted) {
+      const done = await ctx.db.get(docId);
+      if (!done) throw new Error("Story completion was not persisted");
+      await recordCourseReadStats(ctx, done);
     }
 
     if (typeof legacyUserId === "number") {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@better-auth/expo": "^1.6.25",
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.1",
+    "@convex-dev/aggregate": "^0.2.2",
     "@convex-dev/better-auth": "^0.12.5",
     "@lezer/highlight": "^1.2.3",
     "@mdx-js/mdx": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@codemirror/state':
         specifier: ^6.7.1
         version: 6.7.1
+      '@convex-dev/aggregate':
+        specifier: ^0.2.2
+        version: 0.2.2(convex@1.42.3(bufferutil@4.1.0)(react@19.2.8))
       '@convex-dev/better-auth':
         specifier: ^0.12.5
         version: 0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.25(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.17.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))))(convex@1.42.3(bufferutil@4.1.0)(react@19.2.8))(hono@4.12.32)(react@19.2.8)(typescript@6.0.3)
@@ -593,6 +596,11 @@ packages:
 
   '@codemirror/view@6.43.0':
     resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
+
+  '@convex-dev/aggregate@0.2.2':
+    resolution: {integrity: sha512-9sskfPZdiH0mdc33Obcf2+gQSPDpyHqUDkYmXDsUqhqe5lLwGKYbrxw7LgxHmYm9c1YLbaXqxKiM1CgucfKAAw==}
+    peerDependencies:
+      convex: ^1.24.8
 
   '@convex-dev/better-auth@0.12.5':
     resolution: {integrity: sha512-YFUbGk04OlINno9FpOTNZN67AP+kSQsblfep5zs1f/WTgMWjD5FymU6rSSh3mu52gukmDNnBJTjC/lj4QRpjlQ==}
@@ -5374,6 +5382,10 @@ snapshots:
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
+
+  '@convex-dev/aggregate@0.2.2(convex@1.42.3(bufferutil@4.1.0)(react@19.2.8))':
+    dependencies:
+      convex: 1.42.3(bufferutil@4.1.0)(react@19.2.8)
 
   '@convex-dev/better-auth@0.12.5(@standard-schema/spec@1.1.0)(better-auth@1.6.25(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.17.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))))(convex@1.42.3(bufferutil@4.1.0)(react@19.2.8))(hono@4.12.32)(react@19.2.8)(typescript@6.0.3)':
     dependencies:

--- a/src/app/editor/(course)/course_activity_chart.tsx
+++ b/src/app/editor/(course)/course_activity_chart.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { api } from "@convex/_generated/api";
+import { Activity, BookOpen, Users } from "lucide-react";
+import { useQuery } from "convex/react";
+import { useId, useState } from "react";
+
+const PERIODS = [30, 90, 180] as const;
+const WIDTH = 720;
+const HEIGHT = 116;
+const PAD_X = 8;
+const PAD_Y = 10;
+
+type Point = {
+  date: string;
+  storyReads: number;
+  newReaders: number;
+  totalReaders: number;
+};
+
+export default function CourseActivityChart({
+  courseIdentifier,
+}: {
+  courseIdentifier: string;
+}) {
+  const [days, setDays] = useState<(typeof PERIODS)[number]>(90);
+  const data = useQuery(api.courseReadStats.getForEditor, {
+    courseIdentifier,
+    days,
+  });
+
+  if (data === undefined) {
+    return (
+      <div className="my-6 h-[350px] animate-pulse rounded-2xl bg-black/5" />
+    );
+  }
+  if (!data) return null;
+
+  const readsInPeriod = data.points.reduce(
+    (total, point) => total + point.storyReads,
+    0,
+  );
+  const readersInPeriod = data.points.reduce(
+    (total, point) => total + point.newReaders,
+    0,
+  );
+
+  return (
+    <section className="my-6 overflow-hidden rounded-2xl border-2 border-[#9cc7de] bg-[#f4fbff] dark:border-[#31576d] dark:bg-[#172a35]">
+      <header className="flex flex-wrap items-start justify-between gap-4 border-b border-[#cce2ed] px-5 py-4 dark:border-[#294858]">
+        <div className="flex gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#d8f1ff] text-[#1680b5] dark:bg-[#244b60] dark:text-[#75c9f2]">
+            <Activity className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div>
+            <h2 className="text-[calc(19/16*1rem)] font-bold">
+              Course activity
+            </h2>
+            <p className="mt-0.5 text-sm text-[var(--text-color-dim)]">
+              Completions from all visitors; learner counts include signed-in
+              accounts.
+            </p>
+          </div>
+        </div>
+        <div
+          className="flex rounded-xl bg-[#dceef7] p-1 dark:bg-[#203f50]"
+          aria-label="Chart period"
+          role="group"
+        >
+          {PERIODS.map((period) => (
+            <button
+              key={period}
+              type="button"
+              className={`rounded-lg px-3 py-1.5 text-sm font-bold transition ${
+                days === period
+                  ? "bg-white text-[#126f9c] shadow-sm dark:bg-[#315d72] dark:text-white"
+                  : "text-[var(--text-color-dim)] hover:text-[var(--text-color)]"
+              }`}
+              aria-pressed={days === period}
+              onClick={() => setDays(period)}
+            >
+              {period}d
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid gap-5 p-5 min-[760px]:grid-cols-2">
+        <MetricChart
+          icon={<BookOpen className="h-4 w-4" aria-hidden="true" />}
+          label="Stories read"
+          value={readsInPeriod}
+          detail={`${data.totalStoryReads.toLocaleString()} all time`}
+          points={data.points}
+          valueForPoint={(point) => point.storyReads}
+          color="#1680b5"
+          kind="bars"
+        />
+        <MetricChart
+          icon={<Users className="h-4 w-4" aria-hidden="true" />}
+          label="Signed-in learners"
+          value={data.totalReaders}
+          detail={`+${readersInPeriod.toLocaleString()} in this period`}
+          points={data.points}
+          valueForPoint={(point) => point.totalReaders}
+          color="#58a700"
+          kind="line"
+        />
+      </div>
+    </section>
+  );
+}
+
+function MetricChart({
+  icon,
+  label,
+  value,
+  detail,
+  points,
+  valueForPoint,
+  color,
+  kind,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  detail: string;
+  points: Point[];
+  valueForPoint: (point: Point) => number;
+  color: string;
+  kind: "bars" | "line";
+}) {
+  const gradientId = useId().replaceAll(":", "");
+  const values = points.map(valueForPoint);
+  const max = Math.max(1, ...values);
+  const chartWidth = WIDTH - PAD_X * 2;
+  const chartHeight = HEIGHT - PAD_Y * 2;
+  const coordinates = values.map((value, index) => ({
+    x: PAD_X + (index / Math.max(1, values.length - 1)) * chartWidth,
+    y: PAD_Y + chartHeight - (value / max) * chartHeight,
+  }));
+  const line = coordinates.map(({ x, y }) => `${x},${y}`).join(" ");
+  const area = `${PAD_X},${HEIGHT - PAD_Y} ${line} ${WIDTH - PAD_X},${HEIGHT - PAD_Y}`;
+  const barWidth = Math.max(1.5, chartWidth / Math.max(1, values.length) - 1);
+
+  return (
+    <article className="rounded-xl bg-white/75 p-4 shadow-[0_1px_0_rgba(20,80,110,0.08)] dark:bg-black/10">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <p className="flex items-center gap-1.5 text-sm font-bold text-[var(--text-color-dim)]">
+            <span style={{ color }}>{icon}</span>
+            {label}
+          </p>
+          <p className="mt-1 text-3xl font-black tabular-nums">
+            {value.toLocaleString()}
+          </p>
+        </div>
+        <p className="pb-1 text-right text-xs text-[var(--text-color-dim)]">
+          {detail}
+        </p>
+      </div>
+      <svg
+        className="mt-3 h-[116px] w-full overflow-visible"
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        role="img"
+        aria-label={`${label} over the selected period`}
+        preserveAspectRatio="none"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0" stopColor={color} stopOpacity="0.3" />
+            <stop offset="1" stopColor={color} stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+        <path
+          d={`M ${PAD_X} ${HEIGHT - PAD_Y} H ${WIDTH - PAD_X}`}
+          stroke="currentColor"
+          className="text-black/10 dark:text-white/10"
+        />
+        {kind === "bars" ? (
+          coordinates.map(({ x, y }, index) => (
+            <rect
+              key={points[index]?.date}
+              x={x - barWidth / 2}
+              y={y}
+              width={barWidth}
+              height={HEIGHT - PAD_Y - y}
+              rx={Math.min(2, barWidth / 2)}
+              fill={color}
+              opacity="0.78"
+            >
+              <title>{`${points[index]?.date}: ${values[index]} stories read`}</title>
+            </rect>
+          ))
+        ) : (
+          <>
+            <polygon points={area} fill={`url(#${gradientId})`} />
+            <polyline
+              points={line}
+              fill="none"
+              stroke={color}
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          </>
+        )}
+      </svg>
+      <div className="mt-1 flex justify-between text-[11px] text-[var(--text-color-dim)]">
+        <span>{formatDate(points[0]?.date)}</span>
+        <span>{formatDate(points.at(-1)?.date)}</span>
+      </div>
+    </article>
+  );
+}
+
+function formatDate(date?: string) {
+  if (!date) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${date}T00:00:00Z`));
+}

--- a/src/app/editor/(course)/edit_list.tsx
+++ b/src/app/editor/(course)/edit_list.tsx
@@ -32,6 +32,7 @@ import type {
   StoryListDataProps,
 } from "@/app/editor/(course)/types";
 import CourseInterestSummary from "./course_interest_summary";
+import CourseActivityChart from "./course_activity_chart";
 
 type StoryState = "draft" | "feedback" | "finished" | "published";
 type StoryFilter = "all" | StoryState;
@@ -210,6 +211,9 @@ export default function EditList({
         </div>
       </div>
       <CourseInterestSummary courseIdentifier={course.short} />
+      {course.short ? (
+        <CourseActivityChart courseIdentifier={course.short} />
+      ) : null}
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <div className="w-full min-w-[220px] flex-1 min-[860px]:max-w-[360px]">
           <Input

--- a/test/convexTestHarness.ts
+++ b/test/convexTestHarness.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+import { register as registerAggregate } from "@convex-dev/aggregate/test";
+import { convexTest } from "convex-test";
+import schema from "../convex/schema";
+
+const modules = import.meta.glob("../convex/**/*.ts");
+
+export function createConvexTest() {
+  const t = convexTest(schema, modules);
+  registerAggregate(t, "storyReadsByCourse");
+  registerAggregate(t, "readersByCourse");
+  return t;
+}


### PR DESCRIPTION
## Summary

- track story completions by course with the Convex Aggregate component
- deduplicate signed-in learners in a `course_readers` source table
- add an idempotent, paginated admin backfill for historical completions
- show responsive 30, 90, and 180-day activity charts on editor course pages

## Why

Course contributors currently cannot see whether published courses are being used. These aggregates provide bounded historical queries for story reads and cumulative signed-in learners without scanning the raw completion table or maintaining hot daily counter documents.

Anonymous completions contribute to story-read totals. Unique learner totals intentionally include signed-in accounts only because historical anonymous completions have no stable visitor identifier.

## Validation

- `pnpm run lint`
- `pnpm typecheck`
- `pnpm run test:convex` (79 tests)
- `pnpm test` (187 tests)

## Deployment note

The local `CONVEX_DEPLOY_KEY` resolved to the production deployment when the required `pnpm convex dev --once` command was run. The schema, functions, and Aggregate components were synced there, but the historical backfill was deliberately not started. Confirm the intended deployment before invoking `courseReadStats:backfill`; run it in bounded pages until `isDone` is true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an editor course activity dashboard with 30-, 90-, and 180-day views.
  - Visualize daily story reads, new learners, cumulative learners, and total reads.
  - Added responsive charts with loading, empty, dark-mode, and accessibility support.
  - Read statistics now track course activity and reader history for anonymous and signed-in readers.
- **Bug Fixes**
  - Added administrative backfill support for older reading records with safe repeat processing.
  - Improved handling of incomplete or deleted story records during statistics updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->