### PR TITLE
Fix stalled ElevenLabs audio generation

### DIFF
--- a/src/app/audio/_lib/audio/elevenlabs.test.ts
+++ b/src/app/audio/_lib/audio/elevenlabs.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseElevenLabsMessage } from "@/app/audio/_lib/audio/elevenlabs";
+
+test("parses current ElevenLabs snake_case completion and alignment fields", () => {
+  assert.deepEqual(
+    parseElevenLabsMessage(
+      JSON.stringify({
+        audio: "YXVkaW8=",
+        is_final: true,
+        alignment: {
+          chars: ["H", "i"],
+          char_start_times_ms: [0, 25],
+        },
+      }),
+    ),
+    {
+      audio: "YXVkaW8=",
+      isFinal: true,
+      alignment: [
+        ["H", 0],
+        ["i", 25],
+      ],
+    },
+  );
+});
+
+test("continues to parse legacy ElevenLabs camelCase fields", () => {
+  assert.deepEqual(
+    parseElevenLabsMessage(
+      JSON.stringify({
+        isFinal: false,
+        alignment: {
+          chars: ["A"],
+          charStartTimesMs: [10],
+        },
+      }),
+    ),
+    {
+      audio: undefined,
+      isFinal: false,
+      alignment: [["A", 10]],
+    },
+  );
+});
+
+test("parses ElevenLabs error frames instead of leaving generation pending", () => {
+  assert.deepEqual(
+    parseElevenLabsMessage(
+      JSON.stringify({ error: "voice_id_does_not_exist" }),
+    ),
+    {
+      audio: undefined,
+      isFinal: false,
+      alignment: [],
+      error: "voice_id_does_not_exist",
+    },
+  );
+});

--- a/src/app/audio/_lib/audio/elevenlabs.ts
+++ b/src/app/audio/_lib/audio/elevenlabs.ts
@@ -16,6 +16,53 @@ interface GenerateResult {
   alignment: [string, number][];
 }
 
+interface ParsedElevenLabsMessage {
+  audio?: string;
+  isFinal: boolean;
+  alignment: [string, number][];
+  error?: string;
+}
+
+const GENERATION_TIMEOUT_MS = 30_000;
+
+export function parseElevenLabsMessage(data: string): ParsedElevenLabsMessage {
+  const response = JSON.parse(data) as {
+    alignment?: {
+      chars?: string[];
+      charStartTimesMs?: number[];
+      char_start_times_ms?: number[];
+    };
+    audio?: string;
+    isFinal?: boolean;
+    is_final?: boolean;
+    error?: string | { message?: string };
+  };
+  const chars = response.alignment?.chars ?? [];
+  const startTimes =
+    response.alignment?.char_start_times_ms ??
+    response.alignment?.charStartTimesMs ??
+    [];
+  const alignment: [string, number][] = [];
+
+  for (let i = 0; i < Math.min(chars.length, startTimes.length); i++) {
+    alignment.push([chars[i], startTimes[i]]);
+  }
+
+  let error: string | undefined;
+  if (typeof response.error === "string") {
+    error = response.error;
+  } else if (response.error?.message) {
+    error = response.error.message;
+  }
+
+  return {
+    audio: response.audio,
+    isFinal: response.is_final ?? response.isFinal ?? false,
+    alignment,
+    ...(error ? { error } : {}),
+  };
+}
+
 async function generate(
   voiceId: string,
   text: string,
@@ -26,6 +73,30 @@ async function generate(
 
     const audioBuffers: Buffer[] = [];
     const alignment: [string, number][] = [];
+    let settled = false;
+    const timeout = setTimeout(() => {
+      fail(
+        new Error(
+          `ElevenLabs generation timed out after ${GENERATION_TIMEOUT_MS}ms`,
+        ),
+      );
+      socket.terminate();
+    }, GENERATION_TIMEOUT_MS);
+
+    function succeed() {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ audioBuffers, alignment });
+      socket.close();
+    }
+
+    function fail(error: Error) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    }
 
     // 2. Initialize the connection by sending the BOS message
     socket.onopen = function (_event: Event) {
@@ -58,21 +129,9 @@ async function generate(
 
     // 5. Handle server responses
     socket.onmessage = function (event: { data: string }) {
-      const response = JSON.parse(event.data) as {
-        alignment?: { chars: string[]; charStartTimesMs: number[] };
-        audio?: string;
-        isFinal?: boolean;
-        normalizedAlignment?: unknown;
-      };
+      const response = parseElevenLabsMessage(event.data.toString());
 
-      if (response.alignment) {
-        for (let i = 0; i < response.alignment.chars.length; i++) {
-          alignment.push([
-            response.alignment.chars[i],
-            response.alignment.charStartTimesMs[i],
-          ]);
-        }
-      }
+      alignment.push(...response.alignment);
 
       if (response.audio) {
         // decode and handle the audio data (e.g., play it)
@@ -80,16 +139,16 @@ async function generate(
         audioBuffers.push(Buffer.from(audioChunk));
       }
 
-      if (response.isFinal) {
-        // the generation is complete
-        resolve({ audioBuffers: audioBuffers, alignment: alignment });
-      }
+      if (response.error)
+        fail(new Error(`ElevenLabs error: ${response.error}`));
+
+      if (response.isFinal) succeed();
     };
 
     // Handle errors
     socket.onerror = function (error: Error) {
       console.error(`WebSocket Error: ${error}`);
-      reject(error);
+      fail(error);
     };
 
     // Handle socket closing
@@ -98,7 +157,13 @@ async function generate(
       code: number;
       reason: string;
     }) {
-      if (event.wasClean) {
+      if (!settled) {
+        fail(
+          new Error(
+            `ElevenLabs connection closed before completion (code=${event.code}, reason=${event.reason || "none"})`,
+          ),
+        );
+      } else if (event.wasClean) {
         console.info(
           `Connection closed cleanly, code=${event.code}, reason=${event.reason}`,
         );

--- a/src/app/audio/_lib/audio/elevenlabs.ts
+++ b/src/app/audio/_lib/audio/elevenlabs.ts
@@ -80,7 +80,6 @@ async function generate(
           `ElevenLabs generation timed out after ${GENERATION_TIMEOUT_MS}ms`,
         ),
       );
-      socket.terminate();
     }, GENERATION_TIMEOUT_MS);
 
     function succeed() {
@@ -95,6 +94,7 @@ async function generate(
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
+      socket.terminate();
       reject(error);
     }
 
@@ -129,7 +129,13 @@ async function generate(
 
     // 5. Handle server responses
     socket.onmessage = function (event: { data: string }) {
-      const response = parseElevenLabsMessage(event.data.toString());
+      let response: ParsedElevenLabsMessage;
+      try {
+        response = parseElevenLabsMessage(event.data.toString());
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
 
       alignment.push(...response.alignment);
 
@@ -139,8 +145,10 @@ async function generate(
         audioBuffers.push(Buffer.from(audioChunk));
       }
 
-      if (response.error)
+      if (response.error) {
         fail(new Error(`ElevenLabs error: ${response.error}`));
+        return;
+      }
 
       if (response.isFinal) succeed();
     };

--- a/src/app/audio/create/route.ts
+++ b/src/app/audio/create/route.ts
@@ -72,7 +72,6 @@ export async function POST(req: NextRequest) {
         console.error(`[Audio] Engine ${engine.name} failed:`, e);
         engineFailure = true;
       }
-      break;
     }
   }
 

--- a/src/app/audio/create/route.ts
+++ b/src/app/audio/create/route.ts
@@ -58,6 +58,7 @@ export async function POST(req: NextRequest) {
   }
 
   let answer: SynthesisResult | undefined;
+  let engineFailure = false;
   for (const engine of audio_engines) {
     if (await engine.isValidVoice(speaker)) {
       try {
@@ -69,14 +70,22 @@ export async function POST(req: NextRequest) {
         break;
       } catch (e) {
         console.error(`[Audio] Engine ${engine.name} failed:`, e);
-        // Continue to next engine instead of returning
+        engineFailure = true;
       }
       break;
     }
   }
 
-  if (answer === undefined)
-    return new Response("Error not found.", { status: 404 });
+  if (answer === undefined) {
+    return NextResponse.json(
+      {
+        error: engineFailure
+          ? "Audio generation failed. Please try again."
+          : "No text-to-speech engine recognizes this voice.",
+      },
+      { status: engineFailure ? 502 : 404 },
+    );
+  }
 
   if (id !== 0) {
     answer.output_file = `${id}/` + file;

--- a/src/lib/editor/audio/audio_edit_tools.test.ts
+++ b/src/lib/editor/audio/audio_edit_tools.test.ts
@@ -10,6 +10,32 @@ import {
   timings_to_text,
 } from "@/lib/editor/audio/audio_edit_tools";
 
+test("generate_audio_line reports a failed synthesis response", async () => {
+  const originalRequest = globalThis.Request;
+  const originalFetch = globalThis.fetch;
+  globalThis.Request = class {} as unknown as typeof Request;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ error: "Audio generation failed." }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+  try {
+    await assert.rejects(
+      () =>
+        generate_audio_line({
+          speaker: "example-voice",
+          text: "Example",
+          id: 0,
+        }),
+      { message: "Audio generation failed." },
+    );
+  } finally {
+    globalThis.Request = originalRequest;
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("timing_text_without_filename keeps only timing deltas", () => {
   assert.equal(
     timing_text_without_filename("$audio/1961/_f34f3b72.mp3;2,132768;7,127"),

--- a/src/lib/editor/audio/audio_edit_tools.ts
+++ b/src/lib/editor/audio/audio_edit_tools.ts
@@ -59,6 +59,15 @@ export async function generate_audio_line(ssml: {
     speaker: speaker,
     text: speak_text,
   });
+  if (response2.ok === false) {
+    const body = await response2.text();
+    let message = body || `Audio generation failed (${response2.status}).`;
+    try {
+      const parsed = JSON.parse(body) as { error?: string };
+      message = parsed.error || message;
+    } catch {}
+    throw new Error(message);
+  }
   let ssml_response = await response2.json();
   let keypoints = [];
   if (ssml_response.timepoints) {


### PR DESCRIPTION
## Summary

- support current ElevenLabs snake_case completion and alignment fields while retaining legacy camelCase compatibility
- reject ElevenLabs error frames and premature WebSocket closures, with a 30-second timeout as a final guard
- return structured API errors and surface them correctly in the editor
- add regression coverage for current, legacy, and error WebSocket payloads

## Root cause

The ElevenLabs WebSocket adapter only recognized `isFinal` and camelCase alignment fields. Current payloads can use `is_final` and `char_start_times_ms`. More importantly, ElevenLabs error frames such as `voice_id_does_not_exist` were ignored, and socket closure did not settle the generation promise. The `/audio/create` request therefore remained pending indefinitely.

## Impact

ElevenLabs generation now completes with current response payloads and fails promptly with an actionable response when a voice is stale or the provider closes/errors. The editor no longer attempts to parse plain-text failures as JSON.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm test` — 191 tests passed
- live provider probe confirmed the previously stalled saved voice returns `voice_id_does_not_exist`, which is now handled immediately


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio generation reliability by handling connection timeouts, premature closures, server errors, and alternate provider response formats.
  * Audio generation now displays clearer, server-provided error messages.
  * Added distinct responses for unsupported voices and temporary synthesis service failures.
* **Tests**
  * Added coverage for current and legacy provider messages, error handling, and failed audio generation responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->