### PR TITLE
Fix Polly speech mark offsets

### DIFF
--- a/src/lib/editor/audio/audio_edit_tools.test.ts
+++ b/src/lib/editor/audio/audio_edit_tools.test.ts
@@ -148,6 +148,59 @@ test("generate_audio_line reports Azure marks that move backward in the source t
   }
 });
 
+test("generate_audio_line maps Polly UTF-8 byte speech marks to source text", async () => {
+  const originalRequest = globalThis.Request;
+  const originalFetch = globalThis.fetch;
+  const source = "Но,  я   обожаю      овощи      и   особенно   помидоры!";
+  const hiddenStart = source.indexOf("помидоры");
+  const ssml = generate_ssml_line(
+    { speaker: "Tatyana", text: source },
+    undefined as never,
+    [{ start: hiddenStart, end: hiddenStart + "помидоры".length }],
+    [],
+  );
+
+  globalThis.Request = class {} as unknown as typeof Request;
+  globalThis.fetch = (async () => ({
+    json: async () => ({
+      output_file: "900/16a0effa.mp3",
+      engine: "polly",
+      marks: [
+        { time: 6, type: "word", start: 7, end: 11, value: "Но" },
+        { time: 562, type: "word", start: 14, end: 16, value: "я" },
+        { time: 807, type: "word", start: 19, end: 31, value: "обожаю" },
+        { time: 1395, type: "word", start: 37, end: 47, value: "овощи" },
+        { time: 1786, type: "word", start: 53, end: 55, value: "и" },
+        {
+          time: 1811,
+          type: "word",
+          start: 58,
+          end: 74,
+          value: "особенно",
+        },
+        {
+          time: 2240,
+          type: "word",
+          start: 102,
+          end: 118,
+          value: "помидоры",
+        },
+      ],
+    }),
+  })) as unknown as typeof fetch;
+
+  try {
+    const result = await generate_audio_line({ ...ssml, id: 900 });
+    assert.deepEqual(result.keypoints.at(-1), {
+      rangeEnd: hiddenStart + "помидоры".length,
+      audioStart: 2240,
+    });
+  } finally {
+    globalThis.Request = originalRequest;
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("generate_audio_line rejects null numeric values from JSON speech marks", async () => {
   const originalRequest = globalThis.Request;
   const originalFetch = globalThis.fetch;

--- a/src/lib/editor/audio/audio_edit_tools.ts
+++ b/src/lib/editor/audio/audio_edit_tools.ts
@@ -9,6 +9,24 @@ export {
   timings_to_text,
 } from "./audio_timing";
 
+function utf8ByteOffsetToStringIndex(text: string, byteOffset: number) {
+  if (!Number.isSafeInteger(byteOffset) || byteOffset < 0) return undefined;
+  let currentByteOffset = 0;
+  if (byteOffset === 0) return 0;
+
+  for (let index = 0; index < text.length; ) {
+    const codePoint = text.codePointAt(index);
+    if (codePoint === undefined) return undefined;
+    const char = String.fromCodePoint(codePoint);
+    currentByteOffset += new TextEncoder().encode(char).length;
+    index += char.length;
+    if (currentByteOffset === byteOffset) return index;
+    if (currentByteOffset > byteOffset) return undefined;
+  }
+
+  return currentByteOffset === byteOffset ? text.length : undefined;
+}
+
 export async function generate_audio_line(ssml: {
   text: string;
   speaker: string;
@@ -60,6 +78,10 @@ export async function generate_audio_line(ssml: {
     text: speak_text,
   });
   let ssml_response = await response2.json();
+  const markOffsetToTextIndex = (offset: number) =>
+    ssml_response.engine === "polly"
+      ? utf8ByteOffsetToStringIndex(speak_text, offset)
+      : offset;
   let keypoints = [];
   if (ssml_response.timepoints) {
     for (let mark of ssml_response.timepoints) {
@@ -96,9 +118,11 @@ export async function generate_audio_line(ssml: {
           `Invalid speech mark at index ${index}: end=${mark.end}, time=${mark.time}`,
         );
       }
-      const rangeEnd = mapping[Math.round(mark.end)];
+      const textIndex = markOffsetToTextIndex(Math.round(mark.end));
+      const rangeEnd = textIndex === undefined ? undefined : mapping[textIndex];
       const audioStart = Math.round(mark.time);
       if (
+        typeof rangeEnd !== "number" ||
         !Number.isFinite(rangeEnd) ||
         !Number.isFinite(audioStart) ||
         rangeEnd < last_end ||


### PR DESCRIPTION
## What changed

- Convert Amazon Polly speech-mark UTF-8 byte offsets back to JavaScript string indexes before using the SSML mapping table.
- Add a regression test using the Russian story 900 line that failed with `rangeEnd=undefined` for the final `помидоры` mark.

## Why

Polly reports speech mark offsets as UTF-8 byte positions. The editor remapper treated those offsets as JavaScript string indexes, which breaks for non-ASCII text once SSML tags and Cyrillic characters are involved. In the failing case, Polly returned `end: 118`, but the JS string mapping length was 106, so regeneration threw `Invalid speech mark ... rangeEnd=undefined`.

## Validation

- `pnpm -s exec tsx --test src/lib/editor/audio/audio_edit_tools.test.ts`
- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
