### PR TITLE
Fix dark mode text contrast

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,7 +3,7 @@
 @import "shadcn/tailwind.css";
 /*
 ---break---*/
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is([data-theme="dark"], [data-theme="dark"] *));
 
 @layer base {
   html {

--- a/src/styles/global.test.ts
+++ b/src/styles/global.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("dark utilities follow the app theme attribute", () => {
+  const globalCss = readFileSync(
+    new URL("./global.css", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    globalCss,
+    /@custom-variant dark \(&:is\(\[data-theme="dark"\], \[data-theme="dark"\] \*\)\);/,
+  );
+});


### PR DESCRIPTION
## Summary

- align Tailwind's `dark:` variant with the app's existing `body[data-theme="dark"]` theme marker
- restore the intended dark backgrounds, borders, and foreground colors across the public course card and editor course panels
- add a regression test that protects the theme-selector contract

## Root cause

The app activates dark mode with `data-theme="dark"` on the body, while Tailwind's custom dark variant was configured to require a `.dark` ancestor. The body-level CSS variables switched to light foreground colors, but component-level dark backgrounds never activated, producing pale text on pale cards.

## Screenshots

Public course card:

- [Mobile dark mode](http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260802T134523Z-dark-mode-course-interest-card.png)
- [Desktop dark mode](http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260802T134523Z-dark-mode-course-interest-card-desktop.png)

Editor course page:

- [Mobile dark mode](http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260802T140115Z-editor-course-dark-mobile.png)
- [Desktop dark mode](http://richard-aspire-a515-55g.tailed9e74.ts.net:8787/ac58d26c2a25c7c437ab7980/20260802T140115Z-editor-course-dark-desktop.png)

## Validation

- `pnpm test` — 193 tests passed
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm build`
- generated CSS selector checks confirm both editor dark backgrounds now match `data-theme="dark"`
