### PR TITLE
Add recent publishing activity feed

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -44,6 +44,7 @@ import type * as lib_storyCrossLinks from "../lib/storyCrossLinks.js";
 import type * as localization from "../localization.js";
 import type * as localizationWrite from "../localizationWrite.js";
 import type * as lookupTables from "../lookupTables.js";
+import type * as recentStories from "../recentStories.js";
 import type * as roles from "../roles.js";
 import type * as storyApproval from "../storyApproval.js";
 import type * as storyCrossLinks from "../storyCrossLinks.js";
@@ -101,6 +102,7 @@ declare const fullApi: ApiFromModules<{
   localization: typeof localization;
   localizationWrite: typeof localizationWrite;
   lookupTables: typeof lookupTables;
+  recentStories: typeof recentStories;
   roles: typeof roles;
   storyApproval: typeof storyApproval;
   storyCrossLinks: typeof storyCrossLinks;

--- a/convex/recentStories.test.ts
+++ b/convex/recentStories.test.ts
@@ -106,4 +106,106 @@ describe("getRecentPublishedStorySets", () => {
       "Set 1 story 4",
     ]);
   });
+
+  test("caps results at the 20 newest valid public sets", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const learningLanguageId = await ctx.db.insert("languages", {
+        legacyId: 10,
+        name: "Spanish",
+        short: "es",
+        public: true,
+        rtl: false,
+      });
+      const fromLanguageId = await ctx.db.insert("languages", {
+        legacyId: 11,
+        name: "English",
+        short: "en",
+        public: true,
+        rtl: false,
+      });
+      const imageId = await ctx.db.insert("images", {
+        legacyId: "valid-image",
+        active: "active.svg",
+        gilded: "gilded.svg",
+        locked: "locked.svg",
+        active_lip: "aabbcc",
+        gilded_lip: "ddeeff",
+      });
+      const validCourseId = await ctx.db.insert("courses", {
+        legacyId: 20,
+        short: "es-en",
+        learningLanguageId,
+        fromLanguageId,
+        public: true,
+        official: false,
+      });
+      const privateCourseId = await ctx.db.insert("courses", {
+        legacyId: 21,
+        short: "private",
+        learningLanguageId,
+        fromLanguageId,
+        public: false,
+        official: false,
+      });
+      const shortlessCourseId = await ctx.db.insert("courses", {
+        legacyId: 22,
+        learningLanguageId,
+        fromLanguageId,
+        public: true,
+        official: false,
+      });
+
+      for (let setId = 1; setId <= 23; setId += 1) {
+        await ctx.db.insert("stories", {
+          legacyId: 100 + setId,
+          name: `Valid set ${setId}`,
+          set_id: setId,
+          set_index: 1,
+          date_published: setId,
+          public: true,
+          deleted: false,
+          imageId,
+          courseId: validCourseId,
+          status: "finished",
+          todo_count: 0,
+        });
+      }
+
+      const invalidStories = [
+        { legacyId: 201, courseId: privateCourseId, imageId },
+        { legacyId: 202, courseId: shortlessCourseId, imageId },
+        { legacyId: undefined, courseId: validCourseId, imageId },
+        { legacyId: 204, courseId: validCourseId, imageId: undefined },
+      ];
+      for (const [index, story] of invalidStories.entries()) {
+        await ctx.db.insert("stories", {
+          legacyId: story.legacyId,
+          name: `Invalid story ${index}`,
+          set_id: 100 + index,
+          set_index: 1,
+          date_published: 1_000 + index,
+          public: true,
+          deleted: false,
+          imageId: story.imageId,
+          courseId: story.courseId,
+          status: "finished",
+          todo_count: 0,
+        });
+      }
+    });
+
+    const result = await t.query(
+      api.recentStories.getRecentPublishedStorySets,
+      {},
+    );
+
+    expect(result).toHaveLength(20);
+    expect(result.map((set) => set.setId)).toEqual(
+      Array.from({ length: 20 }, (_, index) => 23 - index),
+    );
+    expect(
+      result.flatMap((set) => set.stories).map((story) => story.title),
+    ).not.toContain(expect.stringContaining("Invalid story"));
+  });
 });

--- a/convex/recentStories.test.ts
+++ b/convex/recentStories.test.ts
@@ -1,0 +1,129 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+describe("getRecentPublishedStories", () => {
+  test("returns newest public stories from public courses", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const learningLanguageId = await ctx.db.insert("languages", {
+        legacyId: 1,
+        name: "Spanish",
+        short: "es",
+        public: true,
+        rtl: false,
+      });
+      const fromLanguageId = await ctx.db.insert("languages", {
+        legacyId: 2,
+        name: "English",
+        short: "en",
+        public: true,
+        rtl: false,
+      });
+      const imageId = await ctx.db.insert("images", {
+        legacyId: "image-1",
+        active: "active.svg",
+        gilded: "gilded.svg",
+        locked: "locked.svg",
+        active_lip: "aabbcc",
+        gilded_lip: "ddeeff",
+      });
+      const publicCourseId = await ctx.db.insert("courses", {
+        legacyId: 10,
+        short: "es-en",
+        name: "Español",
+        learningLanguageId,
+        fromLanguageId,
+        public: true,
+        official: false,
+      });
+      const hiddenCourseId = await ctx.db.insert("courses", {
+        legacyId: 11,
+        short: "hidden",
+        learningLanguageId,
+        fromLanguageId,
+        public: false,
+        official: false,
+      });
+
+      const insertStory = async ({
+        legacyId,
+        name,
+        datePublished,
+        courseId = publicCourseId,
+        isPublic = true,
+        deleted = false,
+      }: {
+        legacyId: number;
+        name: string;
+        datePublished?: number;
+        courseId?: typeof publicCourseId;
+        isPublic?: boolean;
+        deleted?: boolean;
+      }) => {
+        await ctx.db.insert("stories", {
+          legacyId,
+          name,
+          date_published: datePublished,
+          public: isPublic,
+          deleted,
+          imageId,
+          courseId,
+          status: "finished",
+          todo_count: 0,
+        });
+      };
+
+      await insertStory({ legacyId: 1, name: "Older", datePublished: 100 });
+      await insertStory({ legacyId: 2, name: "Newest", datePublished: 300 });
+      await insertStory({ legacyId: 3, name: "Middle", datePublished: 200 });
+      await insertStory({
+        legacyId: 4,
+        name: "Draft",
+        datePublished: 400,
+        isPublic: false,
+      });
+      await insertStory({
+        legacyId: 5,
+        name: "Deleted",
+        datePublished: 500,
+        deleted: true,
+      });
+      await insertStory({
+        legacyId: 6,
+        name: "Hidden course",
+        datePublished: 600,
+        courseId: hiddenCourseId,
+      });
+      await insertStory({ legacyId: 7, name: "Missing date" });
+    });
+
+    const result = await t.query(
+      api.recentStories.getRecentPublishedStories,
+      {},
+    );
+
+    expect(result.map((story) => story.name)).toEqual([
+      "Newest",
+      "Middle",
+      "Older",
+    ]);
+    expect(result[0]).toMatchObject({
+      id: 2,
+      datePublished: 300,
+      image: "image-1",
+      active: "active.svg",
+      activeLip: "aabbcc",
+      course: {
+        short: "es-en",
+        name: "Español",
+        learningLanguageName: "Spanish",
+        fromLanguageName: "English",
+      },
+    });
+  });
+});

--- a/convex/recentStories.test.ts
+++ b/convex/recentStories.test.ts
@@ -6,8 +6,8 @@ import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
 
-describe("getRecentPublishedStories", () => {
-  test("returns newest public stories from public courses", async () => {
+describe("getRecentPublishedStorySets", () => {
+  test("groups published stories into newest-first course and set events", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
       const learningLanguageId = await ctx.db.insert("languages", {
@@ -32,98 +32,78 @@ describe("getRecentPublishedStories", () => {
         active_lip: "aabbcc",
         gilded_lip: "ddeeff",
       });
-      const publicCourseId = await ctx.db.insert("courses", {
+      const courseId = await ctx.db.insert("courses", {
         legacyId: 10,
         short: "es-en",
-        name: "Español",
+        name: "Cuentos de la comunidad",
         learningLanguageId,
         fromLanguageId,
         public: true,
         official: false,
       });
-      const hiddenCourseId = await ctx.db.insert("courses", {
-        legacyId: 11,
-        short: "hidden",
-        learningLanguageId,
-        fromLanguageId,
-        public: false,
-        official: false,
-      });
 
-      const insertStory = async ({
-        legacyId,
-        name,
-        datePublished,
-        courseId = publicCourseId,
-        isPublic = true,
-        deleted = false,
-      }: {
-        legacyId: number;
-        name: string;
-        datePublished?: number;
-        courseId?: typeof publicCourseId;
-        isPublic?: boolean;
-        deleted?: boolean;
-      }) => {
+      const publishedStories = Array.from({ length: 8 }, (_, index) => ({
+        legacyId: index + 1,
+        name: `Set ${index < 4 ? 1 : 2} story ${(index % 4) + 1}`,
+        setId: index < 4 ? 1 : 2,
+        published: index < 4 ? 100 : 300,
+      }));
+      for (const story of publishedStories) {
         await ctx.db.insert("stories", {
-          legacyId,
-          name,
-          date_published: datePublished,
-          public: isPublic,
-          deleted,
+          legacyId: story.legacyId,
+          name: story.name,
+          set_id: story.setId,
+          set_index: story.legacyId,
+          date_published: story.published,
+          public: true,
+          deleted: false,
           imageId,
           courseId,
           status: "finished",
           todo_count: 0,
         });
-      };
-
-      await insertStory({ legacyId: 1, name: "Older", datePublished: 100 });
-      await insertStory({ legacyId: 2, name: "Newest", datePublished: 300 });
-      await insertStory({ legacyId: 3, name: "Middle", datePublished: 200 });
-      await insertStory({
-        legacyId: 4,
-        name: "Draft",
-        datePublished: 400,
-        isPublic: false,
+      }
+      await ctx.db.insert("stories", {
+        legacyId: 20,
+        name: "Created but unpublished",
+        set_id: 3,
+        set_index: 1,
+        public: false,
+        deleted: false,
+        imageId,
+        courseId,
+        status: "draft",
+        todo_count: 0,
       });
-      await insertStory({
-        legacyId: 5,
-        name: "Deleted",
-        datePublished: 500,
-        deleted: true,
-      });
-      await insertStory({
-        legacyId: 6,
-        name: "Hidden course",
-        datePublished: 600,
-        courseId: hiddenCourseId,
-      });
-      await insertStory({ legacyId: 7, name: "Missing date" });
     });
 
     const result = await t.query(
-      api.recentStories.getRecentPublishedStories,
+      api.recentStories.getRecentPublishedStorySets,
       {},
     );
 
-    expect(result.map((story) => story.name)).toEqual([
-      "Newest",
-      "Middle",
-      "Older",
-    ]);
+    expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({
-      id: 2,
       datePublished: 300,
-      image: "image-1",
-      active: "active.svg",
-      activeLip: "aabbcc",
+      setId: 2,
       course: {
-        short: "es-en",
-        name: "Español",
+        courseSlug: "es-en",
+        seriesTitle: "Cuentos de la comunidad",
         learningLanguageName: "Spanish",
         fromLanguageName: "English",
       },
+      stories: [
+        { id: 5, title: "Set 2 story 1" },
+        { id: 6, title: "Set 2 story 2" },
+        { id: 7, title: "Set 2 story 3" },
+        { id: 8, title: "Set 2 story 4" },
+      ],
     });
+    expect(result[1]?.stories.map((story) => story.title)).toEqual([
+      "Set 1 story 1",
+      "Set 1 story 2",
+      "Set 1 story 3",
+      "Set 1 story 4",
+    ]);
   });
 });

--- a/convex/recentStories.ts
+++ b/convex/recentStories.ts
@@ -1,0 +1,75 @@
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+const recentStoryValidator = v.object({
+  id: v.number(),
+  name: v.string(),
+  datePublished: v.number(),
+  image: v.string(),
+  active: v.string(),
+  activeLip: v.string(),
+  course: v.object({
+    short: v.string(),
+    name: v.string(),
+    learningLanguageName: v.string(),
+    fromLanguageName: v.string(),
+  }),
+});
+
+export const getRecentPublishedStories = query({
+  args: {},
+  returns: v.array(recentStoryValidator),
+  handler: async (ctx) => {
+    const stories = (
+      await ctx.db
+        .query("stories")
+        .withIndex("by_public", (q) =>
+          q.eq("public", true).eq("deleted", false),
+        )
+        .collect()
+    )
+      .filter(
+        (story): story is typeof story & { date_published: number } =>
+          story.date_published !== undefined && story.date_published > 0,
+      )
+      .sort((a, b) => b.date_published - a.date_published);
+
+    const rows = [];
+    for (const story of stories) {
+      if (rows.length === 50) break;
+      if (story.legacyId === undefined || !story.imageId) continue;
+
+      const [course, image] = await Promise.all([
+        ctx.db.get(story.courseId),
+        ctx.db.get(story.imageId),
+      ]);
+      if (!course?.public || !course.short || !image) continue;
+
+      const [learningLanguage, fromLanguage] = await Promise.all([
+        ctx.db.get(course.learningLanguageId),
+        ctx.db.get(course.fromLanguageId),
+      ]);
+      const learningLanguageName = learningLanguage?.name ?? "";
+
+      rows.push({
+        id: story.legacyId,
+        name: story.name,
+        datePublished: story.date_published,
+        image: image.legacyId,
+        active: image.active,
+        activeLip: image.active_lip,
+        course: {
+          short: course.short,
+          name:
+            course.name && course.name.trim().length > 0
+              ? course.name
+              : learningLanguageName,
+          learningLanguageName,
+          fromLanguageName: fromLanguage?.name ?? "",
+        },
+      });
+    }
+
+    return rows;
+  },
+});

--- a/convex/recentStories.ts
+++ b/convex/recentStories.ts
@@ -24,6 +24,7 @@ const recentStorySetValidator = v.object({
 
 type RecentStory = Infer<typeof recentStoryValidator>;
 type RecentStorySet = Infer<typeof recentStorySetValidator>;
+const MAX_RECENT_SETS = 20;
 
 export const getRecentPublishedStorySets = query({
   args: {},
@@ -59,10 +60,8 @@ export const getRecentPublishedStorySets = query({
     >();
 
     for (const story of stories) {
-      if (
-        sets.size === 20 &&
-        !sets.has(`${story.courseId}:${story.set_id}:${story.date_published}`)
-      ) {
+      const key = `${story.courseId}:${story.set_id}:${story.date_published}`;
+      if (sets.size === MAX_RECENT_SETS && !sets.has(key)) {
         continue;
       }
       if (story.legacyId === undefined || !story.imageId) continue;
@@ -91,7 +90,6 @@ export const getRecentPublishedStorySets = query({
       const image = await ctx.db.get(story.imageId);
       if (!image) continue;
 
-      const key = `${story.courseId}:${story.set_id}:${story.date_published}`;
       const existingSet = sets.get(key);
       const recentStory: RecentStory = {
         id: story.legacyId,
@@ -102,7 +100,7 @@ export const getRecentPublishedStorySets = query({
       };
       if (existingSet) {
         existingSet.stories.push(recentStory);
-      } else if (sets.size < 20) {
+      } else if (sets.size < MAX_RECENT_SETS) {
         sets.set(key, {
           datePublished: story.date_published,
           setId: story.set_id,

--- a/convex/recentStories.ts
+++ b/convex/recentStories.ts
@@ -1,24 +1,33 @@
+import type { Id } from "./_generated/dataModel";
 import { query } from "./_generated/server";
-import { v } from "convex/values";
+import { type Infer, v } from "convex/values";
 
 const recentStoryValidator = v.object({
   id: v.number(),
-  name: v.string(),
-  datePublished: v.number(),
-  image: v.string(),
+  title: v.string(),
+  setIndex: v.number(),
   active: v.string(),
   activeLip: v.string(),
+});
+
+const recentStorySetValidator = v.object({
+  datePublished: v.number(),
+  setId: v.number(),
   course: v.object({
-    short: v.string(),
-    name: v.string(),
+    courseSlug: v.string(),
+    seriesTitle: v.optional(v.string()),
     learningLanguageName: v.string(),
     fromLanguageName: v.string(),
   }),
+  stories: v.array(recentStoryValidator),
 });
 
-export const getRecentPublishedStories = query({
+type RecentStory = Infer<typeof recentStoryValidator>;
+type RecentStorySet = Infer<typeof recentStorySetValidator>;
+
+export const getRecentPublishedStorySets = query({
   args: {},
-  returns: v.array(recentStoryValidator),
+  returns: v.array(recentStorySetValidator),
   handler: async (ctx) => {
     const stories = (
       await ctx.db
@@ -29,47 +38,83 @@ export const getRecentPublishedStories = query({
         .collect()
     )
       .filter(
-        (story): story is typeof story & { date_published: number } =>
-          story.date_published !== undefined && story.date_published > 0,
+        (
+          story,
+        ): story is typeof story & {
+          date_published: number;
+          set_id: number;
+          set_index: number;
+        } =>
+          story.date_published !== undefined &&
+          story.date_published > 0 &&
+          story.set_id !== undefined &&
+          story.set_index !== undefined,
       )
       .sort((a, b) => b.date_published - a.date_published);
 
-    const rows = [];
+    const sets = new Map<string, RecentStorySet>();
+    const courseCache = new Map<
+      Id<"courses">,
+      RecentStorySet["course"] | null
+    >();
+
     for (const story of stories) {
-      if (rows.length === 50) break;
+      if (
+        sets.size === 20 &&
+        !sets.has(`${story.courseId}:${story.set_id}:${story.date_published}`)
+      ) {
+        continue;
+      }
       if (story.legacyId === undefined || !story.imageId) continue;
 
-      const [course, image] = await Promise.all([
-        ctx.db.get(story.courseId),
-        ctx.db.get(story.imageId),
-      ]);
-      if (!course?.public || !course.short || !image) continue;
+      let course = courseCache.get(story.courseId);
+      if (course === undefined) {
+        const courseRow = await ctx.db.get(story.courseId);
+        if (!courseRow?.public || !courseRow.short) {
+          courseCache.set(story.courseId, null);
+          continue;
+        }
+        const [learningLanguage, fromLanguage] = await Promise.all([
+          ctx.db.get(courseRow.learningLanguageId),
+          ctx.db.get(courseRow.fromLanguageId),
+        ]);
+        course = {
+          courseSlug: courseRow.short,
+          seriesTitle: courseRow.name || undefined,
+          learningLanguageName: learningLanguage?.name ?? "",
+          fromLanguageName: fromLanguage?.name ?? "",
+        };
+        courseCache.set(story.courseId, course);
+      }
+      if (!course) continue;
 
-      const [learningLanguage, fromLanguage] = await Promise.all([
-        ctx.db.get(course.learningLanguageId),
-        ctx.db.get(course.fromLanguageId),
-      ]);
-      const learningLanguageName = learningLanguage?.name ?? "";
+      const image = await ctx.db.get(story.imageId);
+      if (!image) continue;
 
-      rows.push({
+      const key = `${story.courseId}:${story.set_id}:${story.date_published}`;
+      const existingSet = sets.get(key);
+      const recentStory: RecentStory = {
         id: story.legacyId,
-        name: story.name,
-        datePublished: story.date_published,
-        image: image.legacyId,
+        title: story.name,
+        setIndex: story.set_index,
         active: image.active,
         activeLip: image.active_lip,
-        course: {
-          short: course.short,
-          name:
-            course.name && course.name.trim().length > 0
-              ? course.name
-              : learningLanguageName,
-          learningLanguageName,
-          fromLanguageName: fromLanguage?.name ?? "",
-        },
-      });
+      };
+      if (existingSet) {
+        existingSet.stories.push(recentStory);
+      } else if (sets.size < 20) {
+        sets.set(key, {
+          datePublished: story.date_published,
+          setId: story.set_id,
+          course,
+          stories: [recentStory],
+        });
+      }
     }
 
-    return rows;
+    return Array.from(sets.values()).map((set) => ({
+      ...set,
+      stories: set.stories.sort((a, b) => a.setIndex - b.setIndex),
+    }));
   },
 });

--- a/src/app/(stories)/(main)/footer_links.tsx
+++ b/src/app/(stories)/(main)/footer_links.tsx
@@ -37,6 +37,16 @@ export default async function FooterLinks({}) {
             </nav>
           </figure>
           <figure>
+            <figcaption>Explore</figcaption>
+            <nav>
+              <ul>
+                <li>
+                  <Link href="/recent">Recently published</Link>
+                </li>
+              </ul>
+            </nav>
+          </figure>
+          <figure>
             <figcaption>Contribute</figcaption>
             <nav>
               <ul>

--- a/src/app/(stories)/(main)/recent/page.tsx
+++ b/src/app/(stories)/(main)/recent/page.tsx
@@ -56,7 +56,9 @@ export default async function RecentStoriesPage() {
                       {dateFormatter.format(publishedSet.datePublished)}
                     </time>
                     <h2 className="my-1 text-[calc(22/16*1rem)] leading-tight">
-                      {publishedSet.stories.length} stories published
+                      {publishedSet.stories.length}{" "}
+                      {publishedSet.stories.length === 1 ? "story" : "stories"}{" "}
+                      published
                     </h2>
                   </div>
                   <Link

--- a/src/app/(stories)/(main)/recent/page.tsx
+++ b/src/app/(stories)/(main)/recent/page.tsx
@@ -1,0 +1,90 @@
+import { api } from "@convex/_generated/api";
+import { fetchQuery } from "convex/nextjs";
+import Image from "next/image";
+import Link from "next/link";
+
+export const metadata = {
+  title: "Recently published stories | Duostories",
+  description:
+    "See the latest community-translated language learning stories published on Duostories.",
+  alternates: { canonical: "https://duostories.org/recent" },
+};
+
+const dateFormatter = new Intl.DateTimeFormat("en", {
+  dateStyle: "long",
+  timeZone: "UTC",
+});
+
+export default async function RecentStoriesPage() {
+  const stories = await fetchQuery(
+    api.recentStories.getRecentPublishedStories,
+    {},
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-[760px] py-8 sm:py-12">
+      <header className="mb-8 text-center">
+        <h1 className="m-0 text-[calc(32/16*1rem)] leading-tight">
+          Recently published stories
+        </h1>
+        <p className="mx-auto mt-3 max-w-[580px] text-[var(--text-color-dim)]">
+          The latest stories translated and published by the Duostories
+          community.
+        </p>
+      </header>
+
+      {stories.length === 0 ? (
+        <p className="rounded-2xl border-2 border-[var(--overview-hr)] p-8 text-center text-[var(--text-color-dim)]">
+          No recently published stories yet.
+        </p>
+      ) : (
+        <ol className="m-0 grid list-none gap-4 p-0">
+          {stories.map((story) => (
+            <li key={story.id}>
+              <Link
+                href={`/story/${story.id}`}
+                className="group flex min-h-[132px] items-center gap-4 rounded-2xl border-2 border-b-4 border-[var(--overview-hr)] bg-[var(--body-background)] p-4 no-underline transition-transform hover:-translate-y-0.5 active:translate-y-0 sm:gap-6 sm:p-5"
+              >
+                <div
+                  className="relative h-[92px] w-[92px] shrink-0 overflow-hidden rounded-2xl sm:h-[104px] sm:w-[104px]"
+                  style={{ backgroundColor: `#${story.activeLip}` }}
+                >
+                  <Image
+                    src={story.active}
+                    alt=""
+                    fill
+                    sizes="(max-width: 640px) 92px, 104px"
+                    className="object-contain transition-transform duration-300 group-hover:-translate-y-0.5"
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <time
+                    dateTime={new Date(story.datePublished).toISOString()}
+                    className="text-[calc(13/16*1rem)] font-bold tracking-[0.08em] text-[var(--text-color-dim)] uppercase"
+                  >
+                    {dateFormatter.format(story.datePublished)}
+                  </time>
+                  <h2 className="my-1 text-[calc(21/16*1rem)] leading-tight text-[var(--text-color)]">
+                    {story.name}
+                  </h2>
+                  <p className="m-0 text-[calc(15/16*1rem)] leading-snug text-[var(--text-color-dim)]">
+                    {story.course.name}
+                    {story.course.fromLanguageName
+                      ? ` · for ${story.course.fromLanguageName} speakers`
+                      : ""}
+                  </p>
+                </div>
+                <span
+                  aria-hidden="true"
+                  className="hidden text-2xl font-bold text-[var(--text-color-dim)] sm:block"
+                >
+                  ›
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/app/(stories)/(main)/recent/page.tsx
+++ b/src/app/(stories)/(main)/recent/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 export const metadata = {
   title: "Recently published stories | Duostories",
   description:
-    "See the latest community-translated language learning stories published on Duostories.",
+    "See the latest community-translated language learning story sets published on Duostories.",
   alternates: { canonical: "https://duostories.org/recent" },
 };
 
@@ -16,8 +16,8 @@ const dateFormatter = new Intl.DateTimeFormat("en", {
 });
 
 export default async function RecentStoriesPage() {
-  const stories = await fetchQuery(
-    api.recentStories.getRecentPublishedStories,
+  const publishedSets = await fetchQuery(
+    api.recentStories.getRecentPublishedStorySets,
     {},
   );
 
@@ -25,64 +25,82 @@ export default async function RecentStoriesPage() {
     <div className="mx-auto w-full max-w-[760px] py-8 sm:py-12">
       <header className="mb-8 text-center">
         <h1 className="m-0 text-[calc(32/16*1rem)] leading-tight">
-          Recently published stories
+          Recent activity
         </h1>
         <p className="mx-auto mt-3 max-w-[580px] text-[var(--text-color-dim)]">
-          The latest stories translated and published by the Duostories
-          community.
+          The latest story sets published by the Duostories community.
         </p>
       </header>
 
-      {stories.length === 0 ? (
+      {publishedSets.length === 0 ? (
         <p className="rounded-2xl border-2 border-[var(--overview-hr)] p-8 text-center text-[var(--text-color-dim)]">
-          No recently published stories yet.
+          No recently published story sets yet.
         </p>
       ) : (
-        <ol className="m-0 grid list-none gap-4 p-0">
-          {stories.map((story) => (
-            <li key={story.id}>
-              <Link
-                href={`/story/${story.id}`}
-                className="group flex min-h-[132px] items-center gap-4 rounded-2xl border-2 border-b-4 border-[var(--overview-hr)] bg-[var(--body-background)] p-4 no-underline transition-transform hover:-translate-y-0.5 active:translate-y-0 sm:gap-6 sm:p-5"
+        <ol className="m-0 grid list-none gap-5 p-0">
+          {publishedSets.map((publishedSet) => {
+            const courseLabel = `${publishedSet.course.learningLanguageName} from ${publishedSet.course.fromLanguageName}`;
+            return (
+              <li
+                key={`${publishedSet.course.courseSlug}-${publishedSet.setId}-${publishedSet.datePublished}`}
+                className="rounded-2xl border-2 border-b-4 border-[var(--overview-hr)] bg-[var(--body-background)] p-4 sm:p-5"
               >
-                <div
-                  className="relative h-[92px] w-[92px] shrink-0 overflow-hidden rounded-2xl sm:h-[104px] sm:w-[104px]"
-                  style={{ backgroundColor: `#${story.activeLip}` }}
-                >
-                  <Image
-                    src={story.active}
-                    alt=""
-                    fill
-                    sizes="(max-width: 640px) 92px, 104px"
-                    className="object-contain transition-transform duration-300 group-hover:-translate-y-0.5"
-                  />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <time
-                    dateTime={new Date(story.datePublished).toISOString()}
-                    className="text-[calc(13/16*1rem)] font-bold tracking-[0.08em] text-[var(--text-color-dim)] uppercase"
+                <div className="mb-4 flex flex-wrap items-start justify-between gap-x-4 gap-y-1">
+                  <div>
+                    <time
+                      dateTime={new Date(
+                        publishedSet.datePublished,
+                      ).toISOString()}
+                      className="text-[calc(13/16*1rem)] font-bold tracking-[0.08em] text-[var(--text-color-dim)] uppercase"
+                    >
+                      {dateFormatter.format(publishedSet.datePublished)}
+                    </time>
+                    <h2 className="my-1 text-[calc(22/16*1rem)] leading-tight">
+                      {publishedSet.stories.length} stories published
+                    </h2>
+                  </div>
+                  <Link
+                    href={`/${publishedSet.course.courseSlug}`}
+                    className="font-bold text-[var(--duostories-title)] underline decoration-2 underline-offset-4"
                   >
-                    {dateFormatter.format(story.datePublished)}
-                  </time>
-                  <h2 className="my-1 text-[calc(21/16*1rem)] leading-tight text-[var(--text-color)]">
-                    {story.name}
-                  </h2>
-                  <p className="m-0 text-[calc(15/16*1rem)] leading-snug text-[var(--text-color-dim)]">
-                    {story.course.name}
-                    {story.course.fromLanguageName
-                      ? ` · for ${story.course.fromLanguageName} speakers`
-                      : ""}
-                  </p>
+                    {courseLabel}
+                  </Link>
+                  {publishedSet.course.seriesTitle && (
+                    <p className="m-0 w-full text-[calc(14/16*1rem)] text-[var(--text-color-dim)] sm:text-right">
+                      {publishedSet.course.seriesTitle}
+                    </p>
+                  )}
                 </div>
-                <span
-                  aria-hidden="true"
-                  className="hidden text-2xl font-bold text-[var(--text-color-dim)] sm:block"
-                >
-                  ›
-                </span>
-              </Link>
-            </li>
-          ))}
+
+                <ul className="m-0 grid list-none gap-2 p-0 sm:grid-cols-2">
+                  {publishedSet.stories.map((story) => (
+                    <li key={story.id}>
+                      <Link
+                        href={`/story/${story.id}`}
+                        className="group flex min-h-[78px] items-center gap-3 rounded-xl p-2 no-underline transition-colors hover:bg-[var(--overview-hr)]"
+                      >
+                        <div
+                          className="relative h-16 w-16 shrink-0 overflow-hidden rounded-xl"
+                          style={{ backgroundColor: `#${story.activeLip}` }}
+                        >
+                          <Image
+                            src={story.active}
+                            alt=""
+                            fill
+                            sizes="64px"
+                            className="object-contain transition-transform duration-300 group-hover:-translate-y-0.5"
+                          />
+                        </div>
+                        <span className="text-[calc(16/16*1rem)] leading-tight font-bold">
+                          {story.title}
+                        </span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            );
+          })}
         </ol>
       )}
     </div>


### PR DESCRIPTION
## Summary

- add a public `/recent` activity page
- group newly published stories by story set and publication timestamp
- show the course language pair and series title for each publication event
- link directly to both courses and individual stories
- add the page to the public footer navigation

## Why

Story publishing usually happens in sets of four. A flat story list made one publishing action look like several unrelated events and showed the course series title without clearly identifying the course. Grouping by publication event makes current project activity easier to understand.

## Implementation

The feed uses `date_published`, not story creation time. It includes only published, non-deleted stories from public courses and limits the result to the 20 newest story-set events.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm test`
- `pnpm test:convex`
- deployed Convex changes to the dev deployment
- inspected the responsive page against real dev data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Recent Stories page showcasing newly published story sets.
  * Stories are grouped by course and series, with publication dates, story counts, images, and links.
  * Added an Explore footer link for quick access to recent content.
  * Added an empty state when no recent stories are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->