### PR TITLE
Announce published courses and story sets on Discord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ SITE_URL=http://localhost:3000
 # RESEND_API_KEY      (optional: email flows)
 # SITE_URL            (must match auth setup)
 # BETTER_AUTH_SECRET  (must match auth setup)
+# DISCORD_TOKEN or DISCORD_BOT_TOKEN (bot token used for publication posts)
+# DISCORD_ANNOUNCEMENTS_CHANNEL_ID (#general-everyone channel ID)

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as courseContributorBackfill from "../courseContributorBackfill.js
 import type * as courseInterest from "../courseInterest.js";
 import type * as courseReadStats from "../courseReadStats.js";
 import type * as courseWrite from "../courseWrite.js";
+import type * as discordAnnouncements from "../discordAnnouncements.js";
 import type * as discordAvatarSync from "../discordAvatarSync.js";
 import type * as discordBot from "../discordBot.js";
 import type * as discordData from "../discordData.js";
@@ -36,6 +37,7 @@ import type * as lib_avatarRows from "../lib/avatarRows.js";
 import type * as lib_courseContributors from "../lib/courseContributors.js";
 import type * as lib_courseCounts from "../lib/courseCounts.js";
 import type * as lib_courseTags from "../lib/courseTags.js";
+import type * as lib_discordAnnouncements from "../lib/discordAnnouncements.js";
 import type * as lib_discordAvatarSync from "../lib/discordAvatarSync.js";
 import type * as lib_phpbb from "../lib/phpbb.js";
 import type * as lib_publicCourseStories from "../lib/publicCourseStories.js";
@@ -79,6 +81,7 @@ declare const fullApi: ApiFromModules<{
   courseInterest: typeof courseInterest;
   courseReadStats: typeof courseReadStats;
   courseWrite: typeof courseWrite;
+  discordAnnouncements: typeof discordAnnouncements;
   discordAvatarSync: typeof discordAvatarSync;
   discordBot: typeof discordBot;
   discordData: typeof discordData;
@@ -93,6 +96,7 @@ declare const fullApi: ApiFromModules<{
   "lib/courseContributors": typeof lib_courseContributors;
   "lib/courseCounts": typeof lib_courseCounts;
   "lib/courseTags": typeof lib_courseTags;
+  "lib/discordAnnouncements": typeof lib_discordAnnouncements;
   "lib/discordAvatarSync": typeof lib_discordAvatarSync;
   "lib/phpbb": typeof lib_phpbb;
   "lib/publicCourseStories": typeof lib_publicCourseStories;

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -22,6 +22,15 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly DISCORD_ANNOUNCEMENTS_CHANNEL_ID: string | undefined;
+  readonly DISCORD_BOT_TOKEN: string | undefined;
+  readonly DISCORD_TOKEN: string | undefined;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +103,11 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -91,3 +91,8 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/convex/adminWrite.ts
+++ b/convex/adminWrite.ts
@@ -4,6 +4,7 @@ import { internalMutation, type MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { requireAdmin } from "./lib/authorization";
 import { hasNoAudioCourseTag } from "./lib/courseTags";
+import { schedulePublicationAnnouncement } from "./lib/discordAnnouncements";
 
 const CLEAR_NO_AUDIO_STORY_AUDIO_PROBLEM_BATCH_SIZE = 100;
 
@@ -269,6 +270,15 @@ export const updateAdminCourse = mutation({
     if (nextPublic && !course.public) patchData.publicSince = Date.now();
 
     await ctx.db.patch(course._id, patchData);
+    if (nextPublic && !course.public) {
+      await schedulePublicationAnnouncement(ctx, {
+        eventKey: `course:${course.legacyId}:published:${patchData.publicSince}`,
+        kind: "course_published",
+        learningLanguage: learningLanguage.name,
+        fromLanguage: fromLanguage.name,
+        courseShort: short,
+      });
+    }
     if (hasNoAudioCourseTag(nextTags)) {
       if ((course.audio_problem_count ?? 0) !== 0) {
         await ctx.db.patch(course._id, {
@@ -407,6 +417,15 @@ export const createAdminCourse = mutation({
       mirrorUpdatedAt: Date.now(),
       lastOperationKey: operationKey,
     });
+    if (nextPublic) {
+      await schedulePublicationAnnouncement(ctx, {
+        eventKey: `course:${legacyId}:published:${publicSince}`,
+        kind: "course_published",
+        learningLanguage: learningLanguage.name,
+        fromLanguage: fromLanguage.name,
+        courseShort: short,
+      });
+    }
 
     return {
       id: legacyId,

--- a/convex/adminWrite.ts
+++ b/convex/adminWrite.ts
@@ -5,6 +5,7 @@ import { v } from "convex/values";
 import { requireAdmin } from "./lib/authorization";
 import { hasNoAudioCourseTag } from "./lib/courseTags";
 import { schedulePublicationAnnouncement } from "./lib/discordAnnouncements";
+import { recomputeCoursePublishedCount } from "./lib/courseCounts";
 
 const CLEAR_NO_AUDIO_STORY_AUDIO_PROBLEM_BATCH_SIZE = 100;
 
@@ -271,12 +272,17 @@ export const updateAdminCourse = mutation({
 
     await ctx.db.patch(course._id, patchData);
     if (nextPublic && !course.public) {
+      const totalStoryCount = await recomputeCoursePublishedCount(
+        ctx,
+        course._id,
+      );
       await schedulePublicationAnnouncement(ctx, {
         eventKey: `course:${course.legacyId}:published:${patchData.publicSince}`,
         kind: "course_published",
         learningLanguage: learningLanguage.name,
         fromLanguage: fromLanguage.name,
         courseShort: short,
+        totalStoryCount,
       });
     }
     if (hasNoAudioCourseTag(nextTags)) {
@@ -424,6 +430,7 @@ export const createAdminCourse = mutation({
         learningLanguage: learningLanguage.name,
         fromLanguage: fromLanguage.name,
         courseShort: short,
+        totalStoryCount: 0,
       });
     }
 

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,8 +1,15 @@
 import { defineApp } from "convex/server";
+import { v } from "convex/values";
 import aggregate from "@convex-dev/aggregate/convex.config";
 import betterAuth from "./betterAuth/convex.config";
 
-const app = defineApp();
+const app = defineApp({
+  env: {
+    DISCORD_TOKEN: v.optional(v.string()),
+    DISCORD_BOT_TOKEN: v.optional(v.string()),
+    DISCORD_ANNOUNCEMENTS_CHANNEL_ID: v.optional(v.string()),
+  },
+});
 
 app.use(betterAuth);
 app.use(aggregate, { name: "storyReadsByCourse" });

--- a/convex/coursePublicSince.test.ts
+++ b/convex/coursePublicSince.test.ts
@@ -60,6 +60,17 @@ async function getCourse(t: ReturnType<typeof convexTest>, legacyId = 100) {
   });
 }
 
+async function getDiscordAnnouncementCount(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const scheduled = await ctx.db.system
+      .query("_scheduled_functions")
+      .collect();
+    return scheduled.filter(
+      (row) => row.name === "discordAnnouncements:postPublicationAnnouncement",
+    ).length;
+  });
+}
+
 const asAdmin = (t: ReturnType<typeof convexTest>) =>
   t.withIdentity({ role: "admin", userId: "1" });
 
@@ -84,6 +95,7 @@ describe("updateAdminCourse publicSince", () => {
     const course = await getCourse(t);
     expect(course.public).toBe(true);
     expect(course.publicSince).toBeGreaterThanOrEqual(before);
+    expect(await getDiscordAnnouncementCount(t)).toBe(1);
   });
 
   test("keeps publicSince when a public course is edited", async () => {
@@ -104,6 +116,7 @@ describe("updateAdminCourse publicSince", () => {
 
     expect(updated.publicSince).toBe(12345);
     expect((await getCourse(t)).publicSince).toBe(12345);
+    expect(await getDiscordAnnouncementCount(t)).toBe(0);
   });
 
   test("keeps publicSince when unpublishing, restamps on republish", async () => {
@@ -135,6 +148,7 @@ describe("updateAdminCourse publicSince", () => {
     );
     expect(republished.publicSince).toBeGreaterThanOrEqual(before);
     expect((await getCourse(t)).publicSince).toBeGreaterThanOrEqual(before);
+    expect(await getDiscordAnnouncementCount(t)).toBe(1);
   });
 });
 
@@ -155,6 +169,7 @@ describe("createAdminCourse publicSince", () => {
     expect(created.publicSince).toBeGreaterThanOrEqual(before);
     const publicCourse = await getCourse(t, created.id);
     expect(publicCourse.publicSince).toBeGreaterThanOrEqual(before);
+    expect(await getDiscordAnnouncementCount(t)).toBe(1);
 
     const createdPrivate = await asAdmin(t).mutation(
       api.adminWrite.createAdminCourse,
@@ -162,6 +177,7 @@ describe("createAdminCourse publicSince", () => {
     );
     expect(createdPrivate.publicSince).toBeUndefined();
     expect((await getCourse(t, createdPrivate.id)).publicSince).toBeUndefined();
+    expect(await getDiscordAnnouncementCount(t)).toBe(1);
   });
 });
 
@@ -185,6 +201,7 @@ describe("lookupTables.upsertCourse publicSince", () => {
     });
 
     expect((await getCourse(t)).publicSince).toBe(12345);
+    expect(await getDiscordAnnouncementCount(t)).toBe(0);
   });
 
   test("stamps publicSince on a private→public mirror transition", async () => {
@@ -198,6 +215,7 @@ describe("lookupTables.upsertCourse publicSince", () => {
     });
 
     expect((await getCourse(t)).publicSince).toBeGreaterThanOrEqual(before);
+    expect(await getDiscordAnnouncementCount(t)).toBe(1);
   });
 
   test("stamps publicSince when the mirror inserts a new public course", async () => {
@@ -210,6 +228,7 @@ describe("lookupTables.upsertCourse publicSince", () => {
     });
 
     expect((await getCourse(t)).publicSince).toBeGreaterThanOrEqual(before);
+    expect(await getDiscordAnnouncementCount(t)).toBe(0);
   });
 });
 

--- a/convex/discordAnnouncements.test.ts
+++ b/convex/discordAnnouncements.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { formatPublicationAnnouncement } from "./lib/discordAnnouncements";
+
+describe("formatPublicationAnnouncement", () => {
+  test("formats a newly public course", () => {
+    expect(
+      formatPublicationAnnouncement({
+        eventKey: "course:100:published:1",
+        kind: "course_published",
+        learningLanguage: "Spanish",
+        fromLanguage: "English",
+        courseShort: "es-en",
+      }),
+    ).toBe(
+      "🎉 A new Spanish course for English speakers is now available on DuoStories!\nhttps://duostories.org/es-en",
+    );
+  });
+
+  test("formats a newly published story set", () => {
+    expect(
+      formatPublicationAnnouncement({
+        eventKey: "course:100:set:2:published:1",
+        kind: "set_published",
+        learningLanguage: "Spanish",
+        fromLanguage: "English",
+        courseShort: "es-en",
+        storyCount: 4,
+      }),
+    ).toBe(
+      "📚 A new set of 4 Spanish stories for English speakers is now available on DuoStories!\nhttps://duostories.org/es-en",
+    );
+  });
+});

--- a/convex/discordAnnouncements.test.ts
+++ b/convex/discordAnnouncements.test.ts
@@ -1,5 +1,38 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  deriveDiscordNonce,
+  handlePublicationAnnouncement,
+} from "./discordAnnouncements";
 import { formatPublicationAnnouncement } from "./lib/discordAnnouncements";
+
+const announcement = {
+  eventKey: "course:100:set:2:published:1722729600000",
+  kind: "set_published" as const,
+  learningLanguage: "Spanish",
+  fromLanguage: "English",
+  courseShort: "es-en",
+  storyCount: 4,
+  totalStoryCount: 24,
+};
+
+function createContext() {
+  return {
+    scheduler: {
+      runAfter: vi.fn(),
+    },
+  };
+}
+
+function configureDiscord() {
+  vi.stubEnv("DISCORD_TOKEN", "test-token");
+  vi.stubEnv("DISCORD_ANNOUNCEMENTS_CHANNEL_ID", "channel-123");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe("formatPublicationAnnouncement", () => {
   test("formats a newly public course", () => {
@@ -31,5 +64,151 @@ describe("formatPublicationAnnouncement", () => {
     ).toBe(
       "📚 A new set of 4 Spanish stories for English speakers is now available on DuoStories!\nThe course now has 24 published stories.\nhttps://duostories.org/es-en",
     );
+  });
+});
+
+describe("postPublicationAnnouncement", () => {
+  test("returns missing_config without calling Discord", async () => {
+    vi.stubEnv("DISCORD_TOKEN", "");
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+    vi.stubEnv("DISCORD_ANNOUNCEMENTS_CHANNEL_ID", "");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const ctx = createContext();
+
+    await expect(
+      handlePublicationAnnouncement(ctx, {
+        announcement,
+        attempt: 1,
+        operationKey: announcement.eventKey,
+      }),
+    ).resolves.toEqual({ posted: false, reason: "missing_config" });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  test("posts the expected payload with a deterministic short nonce", async () => {
+    configureDiscord();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext();
+
+    await expect(
+      handlePublicationAnnouncement(ctx, {
+        announcement,
+        attempt: 1,
+        operationKey: announcement.eventKey,
+      }),
+    ).resolves.toEqual({ posted: true });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://discord.com/api/v10/channels/channel-123/messages",
+    );
+    expect(init.headers).toEqual({
+      authorization: "Bot test-token",
+      "content-type": "application/json",
+    });
+    const body = JSON.parse(String(init.body));
+    expect(body).toEqual({
+      content: formatPublicationAnnouncement(announcement),
+      nonce: await deriveDiscordNonce(announcement.eventKey),
+      enforce_nonce: true,
+    });
+    expect(body.nonce).toHaveLength(24);
+    expect(await deriveDiscordNonce(announcement.eventKey)).toBe(body.nonce);
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  test("retries transient failures with an incremented attempt", async () => {
+    configureDiscord();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const ctx = createContext();
+
+    await expect(
+      handlePublicationAnnouncement(ctx, {
+        announcement,
+        attempt: 2,
+        operationKey: announcement.eventKey,
+      }),
+    ).resolves.toEqual({ posted: false, reason: "request_failed" });
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      120_000,
+      expect.anything(),
+      {
+        announcement,
+        attempt: 3,
+        operationKey: announcement.eventKey,
+      },
+    );
+  });
+
+  test("uses Retry-After for rate limits", async () => {
+    configureDiscord();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("rate limited", {
+          status: 429,
+          headers: { "retry-after": "2.5" },
+        }),
+      ),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const ctx = createContext();
+
+    await handlePublicationAnnouncement(ctx, {
+      announcement,
+      attempt: 1,
+      operationKey: announcement.eventKey,
+    });
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+      2_500,
+      expect.anything(),
+      expect.objectContaining({
+        attempt: 2,
+        operationKey: announcement.eventKey,
+      }),
+    );
+  });
+
+  test("does not retry permanent client errors", async () => {
+    configureDiscord();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("forbidden", { status: 403 })),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const ctx = createContext();
+
+    await expect(
+      handlePublicationAnnouncement(ctx, {
+        announcement,
+        attempt: 1,
+        operationKey: announcement.eventKey,
+      }),
+    ).resolves.toEqual({ posted: false, reason: "request_failed" });
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  test("does not retry after MAX_ATTEMPTS", async () => {
+    configureDiscord();
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const ctx = createContext();
+
+    await expect(
+      handlePublicationAnnouncement(ctx, {
+        announcement,
+        attempt: 5,
+        operationKey: announcement.eventKey,
+      }),
+    ).resolves.toEqual({ posted: false, reason: "request_failed" });
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
   });
 });

--- a/convex/discordAnnouncements.test.ts
+++ b/convex/discordAnnouncements.test.ts
@@ -10,9 +10,10 @@ describe("formatPublicationAnnouncement", () => {
         learningLanguage: "Spanish",
         fromLanguage: "English",
         courseShort: "es-en",
+        totalStoryCount: 12,
       }),
     ).toBe(
-      "🎉 A new Spanish course for English speakers is now available on DuoStories!\nhttps://duostories.org/es-en",
+      "🎉 A new Spanish course for English speakers is now available on DuoStories!\nThe course now has 12 published stories.\nhttps://duostories.org/es-en",
     );
   });
 
@@ -25,9 +26,10 @@ describe("formatPublicationAnnouncement", () => {
         fromLanguage: "English",
         courseShort: "es-en",
         storyCount: 4,
+        totalStoryCount: 24,
       }),
     ).toBe(
-      "📚 A new set of 4 Spanish stories for English speakers is now available on DuoStories!\nhttps://duostories.org/es-en",
+      "📚 A new set of 4 Spanish stories for English speakers is now available on DuoStories!\nThe course now has 24 published stories.\nhttps://duostories.org/es-en",
     );
   });
 });

--- a/convex/discordAnnouncements.ts
+++ b/convex/discordAnnouncements.ts
@@ -1,0 +1,77 @@
+"use node";
+
+import { internal } from "./_generated/api";
+import { internalAction } from "./_generated/server";
+import { v } from "convex/values";
+import { formatPublicationAnnouncement } from "./lib/discordAnnouncements";
+
+const MAX_ATTEMPTS = 5;
+const DEFAULT_CHANNEL_NAME = "general-everyone";
+
+const announcementArgs = {
+  eventKey: v.string(),
+  kind: v.union(v.literal("course_published"), v.literal("set_published")),
+  learningLanguage: v.string(),
+  fromLanguage: v.string(),
+  courseShort: v.string(),
+  storyCount: v.optional(v.number()),
+  attempt: v.number(),
+};
+
+export const postPublicationAnnouncement = internalAction({
+  args: announcementArgs,
+  returns: v.object({
+    posted: v.boolean(),
+    reason: v.optional(v.string()),
+  }),
+  handler: async (ctx, args) => {
+    const token = process.env.DISCORD_TOKEN ?? process.env.DISCORD_BOT_TOKEN;
+    const channelId = process.env.DISCORD_ANNOUNCEMENTS_CHANNEL_ID;
+    if (!token || !channelId) {
+      console.error(
+        `discord-announcement: missing DISCORD_TOKEN/DISCORD_BOT_TOKEN or DISCORD_ANNOUNCEMENTS_CHANNEL_ID for #${DEFAULT_CHANNEL_NAME}`,
+      );
+      return { posted: false, reason: "missing_config" };
+    }
+
+    try {
+      const response = await fetch(
+        `https://discord.com/api/v10/channels/${encodeURIComponent(channelId)}/messages`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bot ${token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            content: formatPublicationAnnouncement(args),
+            nonce: args.eventKey,
+            enforce_nonce: true,
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const details = (await response.text()).slice(0, 500);
+        throw new Error(`Discord HTTP ${response.status}: ${details}`);
+      }
+
+      return { posted: true };
+    } catch (error) {
+      console.error("discord-announcement: post failed", {
+        eventKey: args.eventKey,
+        attempt: args.attempt,
+        error,
+      });
+      if (args.attempt < MAX_ATTEMPTS) {
+        const delayMs = 2 ** (args.attempt - 1) * 60_000;
+        await ctx.scheduler.runAfter(
+          delayMs,
+          internal.discordAnnouncements.postPublicationAnnouncement,
+          { ...args, attempt: args.attempt + 1 },
+        );
+      }
+      return { posted: false, reason: "request_failed" };
+    }
+  },
+});

--- a/convex/discordAnnouncements.ts
+++ b/convex/discordAnnouncements.ts
@@ -13,6 +13,7 @@ const sharedAnnouncementArgs = {
   learningLanguage: v.string(),
   fromLanguage: v.string(),
   courseShort: v.string(),
+  totalStoryCount: v.number(),
 };
 
 const announcementArgs = v.union(

--- a/convex/discordAnnouncements.ts
+++ b/convex/discordAnnouncements.ts
@@ -1,91 +1,120 @@
 "use node";
 
 import { internal } from "./_generated/api";
-import { env, internalAction } from "./_generated/server";
+import { env, internalAction, type ActionCtx } from "./_generated/server";
 import { v } from "convex/values";
-import { formatPublicationAnnouncement } from "./lib/discordAnnouncements";
+import {
+  announcementArgs,
+  formatPublicationAnnouncement,
+  type PublicationAnnouncement,
+} from "./lib/discordAnnouncements";
 
 const MAX_ATTEMPTS = 5;
 const DEFAULT_CHANNEL_NAME = "general-everyone";
 
-const sharedAnnouncementArgs = {
-  eventKey: v.string(),
-  learningLanguage: v.string(),
-  fromLanguage: v.string(),
-  courseShort: v.string(),
-  totalStoryCount: v.number(),
+type AnnouncementActionArgs = {
+  announcement: PublicationAnnouncement;
+  attempt: number;
+  operationKey: string;
 };
 
-const announcementArgs = v.union(
-  v.object({
-    ...sharedAnnouncementArgs,
-    kind: v.literal("course_published"),
-  }),
-  v.object({
-    ...sharedAnnouncementArgs,
-    kind: v.literal("set_published"),
-    storyCount: v.number(),
-  }),
-);
+export async function deriveDiscordNonce(eventKey: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(eventKey),
+  );
+  return Array.from(new Uint8Array(digest).slice(0, 12), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+function getRetryAfterMs(value: string | null) {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+  const date = Date.parse(value);
+  if (!Number.isFinite(date)) return null;
+  return Math.max(0, date - Date.now());
+}
+
+export async function handlePublicationAnnouncement(
+  ctx: { scheduler: Pick<ActionCtx["scheduler"], "runAfter"> },
+  args: AnnouncementActionArgs,
+) {
+  const { announcement, attempt, operationKey } = args;
+  const token = env.DISCORD_TOKEN ?? env.DISCORD_BOT_TOKEN;
+  const channelId = env.DISCORD_ANNOUNCEMENTS_CHANNEL_ID;
+  if (!token || !channelId) {
+    console.error(
+      `discord-announcement: missing DISCORD_TOKEN/DISCORD_BOT_TOKEN or DISCORD_ANNOUNCEMENTS_CHANNEL_ID for #${DEFAULT_CHANNEL_NAME}`,
+    );
+    return { posted: false, reason: "missing_config" as const };
+  }
+
+  let failedStatus: number | null = null;
+  let retryAfterMs: number | null = null;
+  try {
+    const response = await fetch(
+      `https://discord.com/api/v10/channels/${encodeURIComponent(channelId)}/messages`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bot ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          content: formatPublicationAnnouncement(announcement),
+          nonce: await deriveDiscordNonce(announcement.eventKey),
+          enforce_nonce: true,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      failedStatus = response.status;
+      retryAfterMs = getRetryAfterMs(response.headers.get("retry-after"));
+      const details = (await response.text()).slice(0, 500);
+      throw new Error(`Discord HTTP ${response.status}: ${details}`);
+    }
+
+    return { posted: true };
+  } catch (error) {
+    console.error("discord-announcement: post failed", {
+      eventKey: announcement.eventKey,
+      operationKey,
+      attempt,
+      error,
+    });
+    const isPermanentClientError =
+      failedStatus !== null &&
+      failedStatus >= 400 &&
+      failedStatus < 500 &&
+      failedStatus !== 429;
+    if (attempt < MAX_ATTEMPTS && !isPermanentClientError) {
+      const exponentialDelayMs = 2 ** (attempt - 1) * 60_000;
+      const delayMs =
+        failedStatus === 429 && retryAfterMs !== null
+          ? retryAfterMs
+          : exponentialDelayMs;
+      await ctx.scheduler.runAfter(
+        delayMs,
+        internal.discordAnnouncements.postPublicationAnnouncement,
+        { announcement, attempt: attempt + 1, operationKey },
+      );
+    }
+    return { posted: false, reason: "request_failed" as const };
+  }
+}
 
 export const postPublicationAnnouncement = internalAction({
   args: {
     announcement: announcementArgs,
     attempt: v.number(),
+    operationKey: v.string(),
   },
   returns: v.object({
     posted: v.boolean(),
     reason: v.optional(v.string()),
   }),
-  handler: async (ctx, args) => {
-    const { announcement, attempt } = args;
-    const token = env.DISCORD_TOKEN ?? env.DISCORD_BOT_TOKEN;
-    const channelId = env.DISCORD_ANNOUNCEMENTS_CHANNEL_ID;
-    if (!token || !channelId) {
-      console.error(
-        `discord-announcement: missing DISCORD_TOKEN/DISCORD_BOT_TOKEN or DISCORD_ANNOUNCEMENTS_CHANNEL_ID for #${DEFAULT_CHANNEL_NAME}`,
-      );
-      return { posted: false, reason: "missing_config" };
-    }
-
-    try {
-      const response = await fetch(
-        `https://discord.com/api/v10/channels/${encodeURIComponent(channelId)}/messages`,
-        {
-          method: "POST",
-          headers: {
-            authorization: `Bot ${token}`,
-            "content-type": "application/json",
-          },
-          body: JSON.stringify({
-            content: formatPublicationAnnouncement(announcement),
-            nonce: announcement.eventKey,
-            enforce_nonce: true,
-          }),
-        },
-      );
-
-      if (!response.ok) {
-        const details = (await response.text()).slice(0, 500);
-        throw new Error(`Discord HTTP ${response.status}: ${details}`);
-      }
-
-      return { posted: true };
-    } catch (error) {
-      console.error("discord-announcement: post failed", {
-        eventKey: announcement.eventKey,
-        attempt,
-        error,
-      });
-      if (attempt < MAX_ATTEMPTS) {
-        const delayMs = 2 ** (attempt - 1) * 60_000;
-        await ctx.scheduler.runAfter(
-          delayMs,
-          internal.discordAnnouncements.postPublicationAnnouncement,
-          { announcement, attempt: attempt + 1 },
-        );
-      }
-      return { posted: false, reason: "request_failed" };
-    }
-  },
+  handler: handlePublicationAnnouncement,
 });

--- a/convex/discordAnnouncements.ts
+++ b/convex/discordAnnouncements.ts
@@ -1,32 +1,45 @@
 "use node";
 
 import { internal } from "./_generated/api";
-import { internalAction } from "./_generated/server";
+import { env, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { formatPublicationAnnouncement } from "./lib/discordAnnouncements";
 
 const MAX_ATTEMPTS = 5;
 const DEFAULT_CHANNEL_NAME = "general-everyone";
 
-const announcementArgs = {
+const sharedAnnouncementArgs = {
   eventKey: v.string(),
-  kind: v.union(v.literal("course_published"), v.literal("set_published")),
   learningLanguage: v.string(),
   fromLanguage: v.string(),
   courseShort: v.string(),
-  storyCount: v.optional(v.number()),
-  attempt: v.number(),
 };
 
+const announcementArgs = v.union(
+  v.object({
+    ...sharedAnnouncementArgs,
+    kind: v.literal("course_published"),
+  }),
+  v.object({
+    ...sharedAnnouncementArgs,
+    kind: v.literal("set_published"),
+    storyCount: v.number(),
+  }),
+);
+
 export const postPublicationAnnouncement = internalAction({
-  args: announcementArgs,
+  args: {
+    announcement: announcementArgs,
+    attempt: v.number(),
+  },
   returns: v.object({
     posted: v.boolean(),
     reason: v.optional(v.string()),
   }),
   handler: async (ctx, args) => {
-    const token = process.env.DISCORD_TOKEN ?? process.env.DISCORD_BOT_TOKEN;
-    const channelId = process.env.DISCORD_ANNOUNCEMENTS_CHANNEL_ID;
+    const { announcement, attempt } = args;
+    const token = env.DISCORD_TOKEN ?? env.DISCORD_BOT_TOKEN;
+    const channelId = env.DISCORD_ANNOUNCEMENTS_CHANNEL_ID;
     if (!token || !channelId) {
       console.error(
         `discord-announcement: missing DISCORD_TOKEN/DISCORD_BOT_TOKEN or DISCORD_ANNOUNCEMENTS_CHANNEL_ID for #${DEFAULT_CHANNEL_NAME}`,
@@ -44,8 +57,8 @@ export const postPublicationAnnouncement = internalAction({
             "content-type": "application/json",
           },
           body: JSON.stringify({
-            content: formatPublicationAnnouncement(args),
-            nonce: args.eventKey,
+            content: formatPublicationAnnouncement(announcement),
+            nonce: announcement.eventKey,
             enforce_nonce: true,
           }),
         },
@@ -59,16 +72,16 @@ export const postPublicationAnnouncement = internalAction({
       return { posted: true };
     } catch (error) {
       console.error("discord-announcement: post failed", {
-        eventKey: args.eventKey,
-        attempt: args.attempt,
+        eventKey: announcement.eventKey,
+        attempt,
         error,
       });
-      if (args.attempt < MAX_ATTEMPTS) {
-        const delayMs = 2 ** (args.attempt - 1) * 60_000;
+      if (attempt < MAX_ATTEMPTS) {
+        const delayMs = 2 ** (attempt - 1) * 60_000;
         await ctx.scheduler.runAfter(
           delayMs,
           internal.discordAnnouncements.postPublicationAnnouncement,
-          { ...args, attempt: args.attempt + 1 },
+          { announcement, attempt: attempt + 1 },
         );
       }
       return { posted: false, reason: "request_failed" };

--- a/convex/lib/discordAnnouncements.ts
+++ b/convex/lib/discordAnnouncements.ts
@@ -1,14 +1,18 @@
 import { internal } from "../_generated/api";
 import type { MutationCtx } from "../_generated/server";
 
-export type PublicationAnnouncement = {
+type SharedPublicationAnnouncement = {
   eventKey: string;
-  kind: "course_published" | "set_published";
   learningLanguage: string;
   fromLanguage: string;
   courseShort: string;
-  storyCount?: number;
 };
+
+export type PublicationAnnouncement = SharedPublicationAnnouncement &
+  (
+    | { kind: "course_published" }
+    | { kind: "set_published"; storyCount: number }
+  );
 
 export function formatPublicationAnnouncement(args: PublicationAnnouncement) {
   const courseUrl = `https://duostories.org/${encodeURIComponent(args.courseShort)}`;
@@ -21,7 +25,7 @@ export function formatPublicationAnnouncement(args: PublicationAnnouncement) {
 
   const storyLabel = args.storyCount === 1 ? "story" : "stories";
   return [
-    `📚 A new set of ${args.storyCount ?? 0} ${args.learningLanguage} ${storyLabel} for ${args.fromLanguage} speakers is now available on DuoStories!`,
+    `📚 A new set of ${args.storyCount} ${args.learningLanguage} ${storyLabel} for ${args.fromLanguage} speakers is now available on DuoStories!`,
     courseUrl,
   ].join("\n");
 }
@@ -33,6 +37,6 @@ export async function schedulePublicationAnnouncement(
   await ctx.scheduler.runAfter(
     0,
     internal.discordAnnouncements.postPublicationAnnouncement,
-    { ...args, attempt: 1 },
+    { announcement: args, attempt: 1 },
   );
 }

--- a/convex/lib/discordAnnouncements.ts
+++ b/convex/lib/discordAnnouncements.ts
@@ -1,19 +1,28 @@
 import { internal } from "../_generated/api";
 import type { MutationCtx } from "../_generated/server";
+import { type Infer, v } from "convex/values";
 
-type SharedPublicationAnnouncement = {
-  eventKey: string;
-  learningLanguage: string;
-  fromLanguage: string;
-  courseShort: string;
-  totalStoryCount: number;
+const sharedAnnouncementArgs = {
+  eventKey: v.string(),
+  learningLanguage: v.string(),
+  fromLanguage: v.string(),
+  courseShort: v.string(),
+  totalStoryCount: v.number(),
 };
 
-export type PublicationAnnouncement = SharedPublicationAnnouncement &
-  (
-    | { kind: "course_published" }
-    | { kind: "set_published"; storyCount: number }
-  );
+export const announcementArgs = v.union(
+  v.object({
+    ...sharedAnnouncementArgs,
+    kind: v.literal("course_published"),
+  }),
+  v.object({
+    ...sharedAnnouncementArgs,
+    kind: v.literal("set_published"),
+    storyCount: v.number(),
+  }),
+);
+
+export type PublicationAnnouncement = Infer<typeof announcementArgs>;
 
 export function formatPublicationAnnouncement(args: PublicationAnnouncement) {
   const courseUrl = `https://duostories.org/${encodeURIComponent(args.courseShort)}`;
@@ -40,6 +49,6 @@ export async function schedulePublicationAnnouncement(
   await ctx.scheduler.runAfter(
     0,
     internal.discordAnnouncements.postPublicationAnnouncement,
-    { announcement: args, attempt: 1 },
+    { announcement: args, attempt: 1, operationKey: args.eventKey },
   );
 }

--- a/convex/lib/discordAnnouncements.ts
+++ b/convex/lib/discordAnnouncements.ts
@@ -1,0 +1,38 @@
+import { internal } from "../_generated/api";
+import type { MutationCtx } from "../_generated/server";
+
+export type PublicationAnnouncement = {
+  eventKey: string;
+  kind: "course_published" | "set_published";
+  learningLanguage: string;
+  fromLanguage: string;
+  courseShort: string;
+  storyCount?: number;
+};
+
+export function formatPublicationAnnouncement(args: PublicationAnnouncement) {
+  const courseUrl = `https://duostories.org/${encodeURIComponent(args.courseShort)}`;
+  if (args.kind === "course_published") {
+    return [
+      `🎉 A new ${args.learningLanguage} course for ${args.fromLanguage} speakers is now available on DuoStories!`,
+      courseUrl,
+    ].join("\n");
+  }
+
+  const storyLabel = args.storyCount === 1 ? "story" : "stories";
+  return [
+    `📚 A new set of ${args.storyCount ?? 0} ${args.learningLanguage} ${storyLabel} for ${args.fromLanguage} speakers is now available on DuoStories!`,
+    courseUrl,
+  ].join("\n");
+}
+
+export async function schedulePublicationAnnouncement(
+  ctx: MutationCtx,
+  args: PublicationAnnouncement,
+) {
+  await ctx.scheduler.runAfter(
+    0,
+    internal.discordAnnouncements.postPublicationAnnouncement,
+    { ...args, attempt: 1 },
+  );
+}

--- a/convex/lib/discordAnnouncements.ts
+++ b/convex/lib/discordAnnouncements.ts
@@ -6,6 +6,7 @@ type SharedPublicationAnnouncement = {
   learningLanguage: string;
   fromLanguage: string;
   courseShort: string;
+  totalStoryCount: number;
 };
 
 export type PublicationAnnouncement = SharedPublicationAnnouncement &
@@ -19,6 +20,7 @@ export function formatPublicationAnnouncement(args: PublicationAnnouncement) {
   if (args.kind === "course_published") {
     return [
       `🎉 A new ${args.learningLanguage} course for ${args.fromLanguage} speakers is now available on DuoStories!`,
+      `The course now has ${args.totalStoryCount} published ${args.totalStoryCount === 1 ? "story" : "stories"}.`,
       courseUrl,
     ].join("\n");
   }
@@ -26,6 +28,7 @@ export function formatPublicationAnnouncement(args: PublicationAnnouncement) {
   const storyLabel = args.storyCount === 1 ? "story" : "stories";
   return [
     `📚 A new set of ${args.storyCount} ${args.learningLanguage} ${storyLabel} for ${args.fromLanguage} speakers is now available on DuoStories!`,
+    `The course now has ${args.totalStoryCount} published ${args.totalStoryCount === 1 ? "story" : "stories"}.`,
     courseUrl,
   ].join("\n");
 }

--- a/convex/lookupTables.ts
+++ b/convex/lookupTables.ts
@@ -1,6 +1,7 @@
 import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { requireContributorOrAdmin } from "./lib/authorization";
+import { schedulePublicationAnnouncement } from "./lib/discordAnnouncements";
 
 const languageValidator = {
   legacyId: v.number(),
@@ -338,10 +339,28 @@ export const upsertCourse = mutation({
 
     if (existing) {
       await ctx.db.replace(existing._id, doc);
+      if (args.course.public && !existing.public && doc.short) {
+        await schedulePublicationAnnouncement(ctx, {
+          eventKey: `course:${doc.legacyId}:published:${doc.publicSince}`,
+          kind: "course_published",
+          learningLanguage: learningLanguage.name,
+          fromLanguage: fromLanguage.name,
+          courseShort: doc.short,
+        });
+      }
       return { inserted: false, docId: existing._id };
     }
 
     const docId = await ctx.db.insert("courses", doc);
+    if (doc.public && doc.short) {
+      await schedulePublicationAnnouncement(ctx, {
+        eventKey: `course:${doc.legacyId}:published:${doc.publicSince}`,
+        kind: "course_published",
+        learningLanguage: learningLanguage.name,
+        fromLanguage: fromLanguage.name,
+        courseShort: doc.short,
+      });
+    }
     return { inserted: true, docId };
   },
 });

--- a/convex/lookupTables.ts
+++ b/convex/lookupTables.ts
@@ -2,6 +2,7 @@ import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { requireContributorOrAdmin } from "./lib/authorization";
 import { schedulePublicationAnnouncement } from "./lib/discordAnnouncements";
+import { recomputeCoursePublishedCount } from "./lib/courseCounts";
 
 const languageValidator = {
   legacyId: v.number(),
@@ -340,12 +341,17 @@ export const upsertCourse = mutation({
     if (existing) {
       await ctx.db.replace(existing._id, doc);
       if (args.course.public && !existing.public && doc.short) {
+        const totalStoryCount = await recomputeCoursePublishedCount(
+          ctx,
+          existing._id,
+        );
         await schedulePublicationAnnouncement(ctx, {
           eventKey: `course:${doc.legacyId}:published:${doc.publicSince}`,
           kind: "course_published",
           learningLanguage: learningLanguage.name,
           fromLanguage: fromLanguage.name,
           courseShort: doc.short,
+          totalStoryCount,
         });
       }
       return { inserted: false, docId: existing._id };

--- a/convex/lookupTables.ts
+++ b/convex/lookupTables.ts
@@ -352,15 +352,6 @@ export const upsertCourse = mutation({
     }
 
     const docId = await ctx.db.insert("courses", doc);
-    if (doc.public && doc.short) {
-      await schedulePublicationAnnouncement(ctx, {
-        eventKey: `course:${doc.legacyId}:published:${doc.publicSince}`,
-        kind: "course_published",
-        learningLanguage: learningLanguage.name,
-        fromLanguage: fromLanguage.name,
-        courseShort: doc.short,
-      });
-    }
     return { inserted: true, docId };
   },
 });

--- a/convex/storyApproval.test.ts
+++ b/convex/storyApproval.test.ts
@@ -126,4 +126,63 @@ describe("toggleStoryApproval", () => {
       expect(story?.approvalCount).toBe(1);
     });
   });
+
+  test.each([
+    { coursePublic: true, expectedAnnouncements: 1 },
+    { coursePublic: false, expectedAnnouncements: 0 },
+  ])(
+    "schedules a set announcement only when course public is $coursePublic",
+    async ({ coursePublic, expectedAnnouncements }) => {
+      const t = convexTest(schema, modules);
+      t.registerComponent("betterAuth", betterAuthSchema, betterAuthModules);
+      const { courseId, storyId } = await seedCourseWithStory(t);
+
+      await t.run(async (ctx) => {
+        await ctx.db.patch(courseId as Id<"courses">, {
+          public: coursePublic,
+        });
+        await ctx.db.patch(storyId as Id<"stories">, {
+          status: "feedback",
+          approvalCount: 1,
+        });
+        await ctx.db.insert("story_approval", {
+          storyId: storyId as Id<"stories">,
+          legacyUserId: 6,
+          date: Date.now(),
+        });
+        for (let index = 2; index <= 4; index += 1) {
+          await ctx.db.insert("stories", {
+            legacyId: 9 + index,
+            name: `Story ${index}`,
+            set_id: 1,
+            set_index: index,
+            public: false,
+            courseId: courseId as Id<"courses">,
+            status: "finished",
+            deleted: false,
+            approvalCount: 2,
+            todo_count: 0,
+          });
+        }
+      });
+
+      const result = await t
+        .withIdentity(contributor)
+        .mutation(api.storyApproval.toggleStoryApproval, {
+          legacyStoryId: 10,
+        });
+      expect(result.published).toHaveLength(4);
+
+      const announcementCount = await t.run(async (ctx) => {
+        const scheduled = await ctx.db.system
+          .query("_scheduled_functions")
+          .collect();
+        return scheduled.filter(
+          (row) =>
+            row.name === "discordAnnouncements:postPublicationAnnouncement",
+        ).length;
+      });
+      expect(announcementCount).toBe(expectedAnnouncements);
+    },
+  );
 });

--- a/convex/storyApproval.ts
+++ b/convex/storyApproval.ts
@@ -242,6 +242,7 @@ export const toggleStoryApproval = mutation({
             fromLanguage: fromLanguage.name,
             courseShort: course.short,
             storyCount: published.length,
+            totalStoryCount: courseCount,
           });
         }
       }

--- a/convex/storyApproval.ts
+++ b/convex/storyApproval.ts
@@ -11,6 +11,7 @@ import {
   getRankedCourseContributors,
   partitionCourseContributors,
 } from "./lib/courseContributors";
+import { schedulePublicationAnnouncement } from "./lib/discordAnnouncements";
 
 const storyApprovalInputValidator = {
   legacyStoryId: v.number(),
@@ -202,6 +203,9 @@ export const toggleStoryApproval = mutation({
         row.status === "finished" &&
         !row.deleted,
     );
+    const setWasAlreadyPublic = storiesInCourse.some(
+      (row) => row.set_id === story.set_id && row.public && !row.deleted,
+    );
     const finished_in_set = finishedStoriesInSet.length;
 
     const published: number[] = [];
@@ -223,6 +227,24 @@ export const toggleStoryApproval = mutation({
     let courseCount: number | null = null;
     if (published.length > 0) {
       courseCount = await recomputeCoursePublishedCount(ctx, story.courseId);
+
+      const course = await ctx.db.get(story.courseId);
+      if (course?.public && course.short && !setWasAlreadyPublic) {
+        const [learningLanguage, fromLanguage] = await Promise.all([
+          ctx.db.get(course.learningLanguageId),
+          ctx.db.get(course.fromLanguageId),
+        ]);
+        if (learningLanguage && fromLanguage) {
+          await schedulePublicationAnnouncement(ctx, {
+            eventKey: `course:${course.legacyId}:set:${story.set_id ?? "unknown"}:published:${datePublishedMs}`,
+            kind: "set_published",
+            learningLanguage: learningLanguage.name,
+            fromLanguage: fromLanguage.name,
+            courseShort: course.short,
+            storyCount: published.length,
+          });
+        }
+      }
     }
 
     const {


### PR DESCRIPTION
## What changed

- post a DuoStories bot announcement when a course becomes public
- post an announcement when a complete story set is published, while suppressing sets in private courses
- include the affected course's current published-story total in both messages
- retry temporary Discord delivery failures and use an enforced nonce to prevent duplicate posts
- add typed Convex configuration and behavioral coverage for publication gating

## Why

This creates a live progress feed in `#general-everyone` so community members can see new courses and story sets as they become available.

## Deployment note

Set `DISCORD_ANNOUNCEMENTS_CHANNEL_ID` to the numeric ID of `#general-everyone` in each Convex deployment. The existing `DISCORD_TOKEN` or `DISCORD_BOT_TOKEN` is used for delivery.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm run test:convex` (85 tests)
- `pnpm test` (193 tests)
- deployed successfully with `pnpm exec convex dev --once`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Discord announcements when courses are newly published or republished.
  - Added Discord announcements when story sets are published in public courses.
  - Publication announcements include relevant course, language, story set, and story-count details.
  - Announcements use direct links and avoid duplicate notifications for unchanged public content.
  - Failed delivery attempts are retried automatically.

- **Documentation**
  - Documented the Discord configuration variables required for publication announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->