### PR TITLE
Refine Discord publication announcements

### DIFF
--- a/convex/discordAnnouncements.test.ts
+++ b/convex/discordAnnouncements.test.ts
@@ -5,6 +5,8 @@ import {
 } from "./discordAnnouncements";
 import { formatPublicationAnnouncement } from "./lib/discordAnnouncements";
 
+const EXPECTED_DISCORD_MESSAGE_FLAG_SUPPRESS_EMBEDS = 1 << 2;
+
 const announcement = {
   eventKey: "course:100:set:2:published:1722729600000",
   kind: "set_published" as const,
@@ -46,7 +48,7 @@ describe("formatPublicationAnnouncement", () => {
         totalStoryCount: 12,
       }),
     ).toBe(
-      "🎉 A new Spanish course for English speakers is now available on DuoStories!\nThe course now has 12 published stories.\nhttps://duostories.org/es-en",
+      "🎉 A new [Spanish course](https://duostories.org/es-en) for English speakers has just been published!\nThe course now has 12 stories.",
     );
   });
 
@@ -62,7 +64,7 @@ describe("formatPublicationAnnouncement", () => {
         totalStoryCount: 24,
       }),
     ).toBe(
-      "📚 A new set of 4 Spanish stories for English speakers is now available on DuoStories!\nThe course now has 24 published stories.\nhttps://duostories.org/es-en",
+      "📚 A new set of 4 [Spanish stories](https://duostories.org/es-en) for English speakers has just been published!\nThe course now has 24 stories.",
     );
   });
 });
@@ -118,6 +120,7 @@ describe("postPublicationAnnouncement", () => {
       content: formatPublicationAnnouncement(announcement),
       nonce: await deriveDiscordNonce(announcement.eventKey),
       enforce_nonce: true,
+      flags: EXPECTED_DISCORD_MESSAGE_FLAG_SUPPRESS_EMBEDS,
     });
     expect(body.nonce).toHaveLength(24);
     expect(await deriveDiscordNonce(announcement.eventKey)).toBe(body.nonce);

--- a/convex/discordAnnouncements.ts
+++ b/convex/discordAnnouncements.ts
@@ -11,6 +11,7 @@ import {
 
 const MAX_ATTEMPTS = 5;
 const DEFAULT_CHANNEL_NAME = "general-everyone";
+const DISCORD_MESSAGE_FLAG_SUPPRESS_EMBEDS = 1 << 2;
 
 type AnnouncementActionArgs = {
   announcement: PublicationAnnouncement;
@@ -66,6 +67,7 @@ export async function handlePublicationAnnouncement(
           content: formatPublicationAnnouncement(announcement),
           nonce: await deriveDiscordNonce(announcement.eventKey),
           enforce_nonce: true,
+          flags: DISCORD_MESSAGE_FLAG_SUPPRESS_EMBEDS,
         }),
       },
     );

--- a/convex/lib/discordAnnouncements.ts
+++ b/convex/lib/discordAnnouncements.ts
@@ -28,17 +28,15 @@ export function formatPublicationAnnouncement(args: PublicationAnnouncement) {
   const courseUrl = `https://duostories.org/${encodeURIComponent(args.courseShort)}`;
   if (args.kind === "course_published") {
     return [
-      `🎉 A new ${args.learningLanguage} course for ${args.fromLanguage} speakers is now available on DuoStories!`,
-      `The course now has ${args.totalStoryCount} published ${args.totalStoryCount === 1 ? "story" : "stories"}.`,
-      courseUrl,
+      `🎉 A new [${args.learningLanguage} course](${courseUrl}) for ${args.fromLanguage} speakers has just been published!`,
+      `The course now has ${args.totalStoryCount} ${args.totalStoryCount === 1 ? "story" : "stories"}.`,
     ].join("\n");
   }
 
   const storyLabel = args.storyCount === 1 ? "story" : "stories";
   return [
-    `📚 A new set of ${args.storyCount} ${args.learningLanguage} ${storyLabel} for ${args.fromLanguage} speakers is now available on DuoStories!`,
-    `The course now has ${args.totalStoryCount} published ${args.totalStoryCount === 1 ? "story" : "stories"}.`,
-    courseUrl,
+    `📚 A new set of ${args.storyCount} [${args.learningLanguage} ${storyLabel}](${courseUrl}) for ${args.fromLanguage} speakers has just been published!`,
+    `The course now has ${args.totalStoryCount} ${args.totalStoryCount === 1 ? "story" : "stories"}.`,
   ].join("\n");
 }
 


### PR DESCRIPTION
## What changed

- shorten publication announcements to two lines
- link the course directly from the language/course phrase in the first line
- remove redundant DuoStories and `published stories` wording
- suppress Discord link preview embeds

## Example

> 📚 A new set of 4 [Romansh stories](https://duostories.org/roh-en) for English speakers has just been published!  
> The course now has 32 stories.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm run test:convex` (93 tests)
- `pnpm test` (198 tests)
- deployed successfully with `pnpm exec convex dev --once`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated Discord publication announcements with cleaner Markdown links and more concise wording.
  - Removed the separate trailing course URL from announcements.
  - Simplified story-count language for easier reading.
  - Suppressed link previews in Discord messages for a cleaner presentation.
  - Improved announcement formatting for both course and story set publications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->