### PR TITLE
Add an admin-only course vocabulary explorer

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -60,6 +60,7 @@ import type * as storyReviewLint from "../storyReviewLint.js";
 import type * as storyTables from "../storyTables.js";
 import type * as storyWrite from "../storyWrite.js";
 import type * as userPreferences from "../userPreferences.js";
+import type * as vocabulary from "../vocabulary.js";
 
 import type {
   ApiFromModules,
@@ -120,6 +121,7 @@ declare const fullApi: ApiFromModules<{
   storyTables: typeof storyTables;
   storyWrite: typeof storyWrite;
   userPreferences: typeof userPreferences;
+  vocabulary: typeof vocabulary;
 }>;
 
 /**

--- a/convex/vocabulary.test.ts
+++ b/convex/vocabulary.test.ts
@@ -1,0 +1,26 @@
+/// <reference types="vite/client" />
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import { createConvexTest } from "../test/convexTestHarness";
+
+describe("course vocabulary", () => {
+  test("is restricted to admins", async () => {
+    const t = createConvexTest();
+    const args = { short: "da-en" };
+
+    await expect(
+      t.query(api.vocabulary.getCourseVocabularySourceForAdmin, args),
+    ).rejects.toThrow("Unauthorized");
+    await expect(
+      t
+        .withIdentity({ role: "contributor" })
+        .query(api.vocabulary.getCourseVocabularySourceForAdmin, args),
+    ).rejects.toThrow("Unauthorized");
+
+    await expect(
+      t
+        .withIdentity({ role: "admin" })
+        .query(api.vocabulary.getCourseVocabularySourceForAdmin, args),
+    ).resolves.toBeNull();
+  });
+});

--- a/convex/vocabulary.ts
+++ b/convex/vocabulary.ts
@@ -1,0 +1,74 @@
+import { v } from "convex/values";
+
+import { query } from "./_generated/server";
+import { getPublicStoryJson } from "./lib/publicStoryContent";
+import { listPublicCourseStories } from "./lib/publicCourseStories";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getStoryLines(json: unknown) {
+  if (!isRecord(json) || !Array.isArray(json.elements)) return [];
+
+  const lines: string[] = [];
+  for (const element of json.elements) {
+    if (!isRecord(element) || element.type !== "LINE") continue;
+    const line = element.line;
+    if (!isRecord(line) || !isRecord(line.content)) continue;
+    const text = line.content.text;
+    if (typeof text === "string" && text.trim().length > 0) lines.push(text);
+  }
+  return lines;
+}
+
+const vocabularyStoryValidator = v.object({
+  id: v.number(),
+  name: v.string(),
+  setId: v.number(),
+  setIndex: v.number(),
+  lines: v.array(v.string()),
+});
+
+export const getPublicCourseVocabularySource = query({
+  args: { short: v.string() },
+  returns: v.union(
+    v.object({
+      short: v.string(),
+      name: v.string(),
+      learningLanguageName: v.string(),
+      stories: v.array(vocabularyStoryValidator),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const course = await ctx.db
+      .query("courses")
+      .withIndex("by_short", (q) => q.eq("short", args.short))
+      .unique();
+    if (!course?.public || !course.short) return null;
+
+    const [learningLanguage, publicStories] = await Promise.all([
+      ctx.db.get(course.learningLanguageId),
+      listPublicCourseStories(ctx, course._id),
+    ]);
+
+    const stories = await Promise.all(
+      publicStories.map(async ({ story, legacyId, set_id, set_index }) => ({
+        id: legacyId,
+        name: story.name,
+        setId: set_id,
+        setIndex: set_index,
+        lines: getStoryLines(await getPublicStoryJson(ctx, story._id)),
+      })),
+    );
+    const learningLanguageName = learningLanguage?.name ?? "";
+
+    return {
+      short: course.short,
+      name: course.name?.trim() || learningLanguageName,
+      learningLanguageName,
+      stories,
+    };
+  },
+});

--- a/convex/vocabulary.ts
+++ b/convex/vocabulary.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { query } from "./_generated/server";
+import { requireAdmin } from "./lib/authorization";
 import { getPublicStoryJson } from "./lib/publicStoryContent";
 import { listPublicCourseStories } from "./lib/publicCourseStories";
 
@@ -30,7 +31,7 @@ const vocabularyStoryValidator = v.object({
   lines: v.array(v.string()),
 });
 
-export const getPublicCourseVocabularySource = query({
+export const getCourseVocabularySourceForAdmin = query({
   args: { short: v.string() },
   returns: v.union(
     v.object({
@@ -42,6 +43,8 @@ export const getPublicCourseVocabularySource = query({
     v.null(),
   ),
   handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
     const course = await ctx.db
       .query("courses")
       .withIndex("by_short", (q) => q.eq("short", args.short))

--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -11,6 +11,7 @@ import Switch from "@/components/ui/switch";
 import { hasNoAudioCourseTag } from "@/lib/course-tags";
 import CourseInterestCard from "./course_interest_card";
 import Link from "next/link";
+import { authClient } from "@/lib/auth-client";
 
 function SetTitle({ children }: { children: React.ReactNode }) {
   return (
@@ -124,6 +125,9 @@ export default function CoursePageClient({
     [course_id],
   );
   const [listeningMode, setListeningMode] = React.useState(false);
+  const { data: session } = authClient.useSession();
+  const isAdmin =
+    (session?.user as { role?: string } | undefined)?.role === "admin";
   const course = usePreloadedQuery(preloadedCourse);
   const noAudioCourse = hasNoAudioCourseTag(course?.tags);
 
@@ -259,7 +263,7 @@ export default function CoursePageClient({
           contributors={course.contributors}
           contributorsPast={course.contributors_past}
         />
-        {course.stories.length > 0 ? (
+        {isAdmin && course.stories.length > 0 ? (
           <div className="mx-auto mb-8 max-w-[720px] rounded-xl border border-[var(--overview-hr)] px-5 py-4">
             <h2 className="text-lg font-bold">Course vocabulary</h2>
             <p className="mt-1 text-[var(--text-color-dim)]">

--- a/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
+++ b/src/app/(stories)/(main)/[course_id]/course_page_client.tsx
@@ -10,6 +10,7 @@ import ContributorList from "@/components/ContributorList";
 import Switch from "@/components/ui/switch";
 import { hasNoAudioCourseTag } from "@/lib/course-tags";
 import CourseInterestCard from "./course_interest_card";
+import Link from "next/link";
 
 function SetTitle({ children }: { children: React.ReactNode }) {
   return (
@@ -258,6 +259,21 @@ export default function CoursePageClient({
           contributors={course.contributors}
           contributorsPast={course.contributors_past}
         />
+        {course.stories.length > 0 ? (
+          <div className="mx-auto mb-8 max-w-[720px] rounded-xl border border-[var(--overview-hr)] px-5 py-4">
+            <h2 className="text-lg font-bold">Course vocabulary</h2>
+            <p className="mt-1 text-[var(--text-color-dim)]">
+              See how the course&apos;s unique word list grows from story to
+              story.
+            </p>
+            <Link
+              className="mt-3 inline-block font-bold text-[var(--link-color)] underline underline-offset-2"
+              href={`/${course_id}/vocabulary`}
+            >
+              Explore vocabulary →
+            </Link>
+          </div>
+        ) : null}
         {storiesBySet.map((set) => (
           <SetGrid
             key={set.setId}

--- a/src/app/(stories)/(main)/[course_id]/vocabulary/page.tsx
+++ b/src/app/(stories)/(main)/[course_id]/vocabulary/page.tsx
@@ -1,0 +1,195 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { api } from "@convex/_generated/api";
+import { fetchQuery } from "convex/nextjs";
+
+import Header from "../../header";
+import { analyzeCourseVocabulary } from "@/lib/course-vocabulary";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ course_id: string }>;
+}): Promise<Metadata> {
+  const { course_id: courseId } = await params;
+  return {
+    title: `Course vocabulary | Duostories`,
+    description: `See how the unique vocabulary grows throughout the ${courseId} Duostories course.`,
+    alternates: { canonical: `https://duostories.org/${courseId}/vocabulary` },
+  };
+}
+
+function Stat({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="rounded-xl border border-[var(--overview-hr)] p-4 text-center">
+      <strong className="block text-3xl">{value.toLocaleString()}</strong>
+      <span className="text-sm text-[var(--text-color-dim)]">{label}</span>
+    </div>
+  );
+}
+
+function GrowthChart({ values }: { values: number[] }) {
+  if (values.length === 0) return null;
+  const width = 700;
+  const height = 240;
+  const padding = 28;
+  const maximum = Math.max(...values, 1);
+  const points = values
+    .map((value, index) => {
+      const x =
+        values.length === 1
+          ? width / 2
+          : padding + (index / (values.length - 1)) * (width - padding * 2);
+      const y = height - padding - (value / maximum) * (height - padding * 2);
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <figure className="m-0 mt-8">
+      <figcaption className="mb-3 font-bold">
+        Unique vocabulary through the course
+      </figcaption>
+      <svg
+        className="h-auto w-full overflow-visible rounded-xl border border-[var(--overview-hr)] bg-[var(--body-background-faint)]"
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label={`Cumulative unique word count rises from ${values[0]?.toLocaleString()} after the first story to ${values.at(-1)?.toLocaleString()} after the last story.`}
+      >
+        <line
+          x1={padding}
+          y1={height - padding}
+          x2={width - padding}
+          y2={height - padding}
+          stroke="var(--overview-hr)"
+          strokeWidth="2"
+        />
+        <polyline
+          points={points}
+          fill="none"
+          stroke="var(--link-blue)"
+          strokeWidth="5"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+      </svg>
+    </figure>
+  );
+}
+
+export default async function VocabularyPage({
+  params,
+}: {
+  params: Promise<{ course_id: string }>;
+}) {
+  const { course_id: courseId } = await params;
+  if (!courseId.includes("-") || courseId.includes(".")) notFound();
+
+  const course = await fetchQuery(
+    api.vocabulary.getPublicCourseVocabularySource,
+    {
+      short: courseId,
+    },
+  );
+  if (!course) notFound();
+
+  const analysis = analyzeCourseVocabulary(course.stories);
+  const languageName = course.name || course.learningLanguageName;
+  const alphabeticalWords = [...analysis.words].sort((a, b) =>
+    a.localeCompare(b, courseId.split("-")[0]),
+  );
+
+  return (
+    <>
+      <Header>
+        <h1>{languageName} course vocabulary</h1>
+        <p>
+          See which words appear in the story dialogue and how the vocabulary
+          grows as you move through the course.
+        </p>
+      </Header>
+      <div className="mx-auto mb-12 w-full max-w-[720px]">
+        <Link
+          href={`/${courseId}`}
+          className="font-bold text-[var(--link-blue)] no-underline"
+        >
+          ← Back to the course
+        </Link>
+
+        <div className="mt-6 grid grid-cols-3 gap-3 max-[560px]:grid-cols-1">
+          <Stat value={analysis.uniqueWordCount} label="unique words" />
+          <Stat value={analysis.totalWordCount} label="words in total" />
+          <Stat value={analysis.stories.length} label="stories analyzed" />
+        </div>
+
+        <p className="mt-4 text-sm text-[var(--text-color-dim)]">
+          Counts use the spoken story lines, ignore capitalization and
+          punctuation, and count different forms of a word separately.
+        </p>
+
+        <GrowthChart
+          values={analysis.stories.map((story) => story.cumulativeUniqueWords)}
+        />
+
+        <section className="mt-9" aria-labelledby="story-growth-heading">
+          <h2 id="story-growth-heading" className="text-2xl font-bold">
+            Growth by story
+          </h2>
+          <div className="mt-3 overflow-x-auto rounded-xl border border-[var(--overview-hr)]">
+            <table className="w-full border-collapse text-left">
+              <thead className="bg-[var(--body-background-faint)] text-sm">
+                <tr>
+                  <th className="p-3">Story</th>
+                  <th className="p-3 text-right">New</th>
+                  <th className="p-3 text-right">Total unique</th>
+                </tr>
+              </thead>
+              <tbody>
+                {analysis.stories.map((story, index) => (
+                  <tr
+                    key={story.id}
+                    className="border-t border-[var(--overview-hr)]"
+                  >
+                    <td className="p-3">
+                      <Link
+                        href={`/story/${story.id}`}
+                        className="font-bold text-[var(--link-blue)]"
+                      >
+                        {index + 1}. {story.name}
+                      </Link>
+                      <details className="mt-1 text-sm">
+                        <summary className="cursor-pointer text-[var(--text-color-dim)]">
+                          Show {story.newWords.length.toLocaleString()} new
+                          words
+                        </summary>
+                        <p className="mt-2 leading-7">
+                          {story.newWords.length > 0
+                            ? story.newWords.join(" · ")
+                            : "No new words in this story."}
+                        </p>
+                      </details>
+                    </td>
+                    <td className="p-3 text-right align-top font-bold">
+                      +{story.newWords.length.toLocaleString()}
+                    </td>
+                    <td className="p-3 text-right align-top">
+                      {story.cumulativeUniqueWords.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <details className="mt-8 rounded-xl border border-[var(--overview-hr)] p-4">
+          <summary className="cursor-pointer text-xl font-bold">
+            Complete word list ({analysis.uniqueWordCount.toLocaleString()})
+          </summary>
+          <p className="mt-4 leading-8">{alphabeticalWords.join(" · ")}</p>
+        </details>
+      </div>
+    </>
+  );
+}

--- a/src/app/(stories)/(main)/[course_id]/vocabulary/page.tsx
+++ b/src/app/(stories)/(main)/[course_id]/vocabulary/page.tsx
@@ -2,10 +2,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { api } from "@convex/_generated/api";
-import { fetchQuery } from "convex/nextjs";
 
 import Header from "../../header";
 import { analyzeCourseVocabulary } from "@/lib/course-vocabulary";
+import { fetchAuthQuery } from "@/lib/auth-server";
+import { requireAdmin } from "@/lib/userInterface";
 
 export async function generateMetadata({
   params,
@@ -17,6 +18,7 @@ export async function generateMetadata({
     title: `Course vocabulary | Duostories`,
     description: `See how the unique vocabulary grows throughout the ${courseId} Duostories course.`,
     alternates: { canonical: `https://duostories.org/${courseId}/vocabulary` },
+    robots: { index: false, follow: false },
   };
 }
 
@@ -86,8 +88,9 @@ export default async function VocabularyPage({
   const { course_id: courseId } = await params;
   if (!courseId.includes("-") || courseId.includes(".")) notFound();
 
-  const course = await fetchQuery(
-    api.vocabulary.getPublicCourseVocabularySource,
+  await requireAdmin();
+  const course = await fetchAuthQuery(
+    api.vocabulary.getCourseVocabularySourceForAdmin,
     {
       short: courseId,
     },

--- a/src/lib/course-vocabulary.test.ts
+++ b/src/lib/course-vocabulary.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { analyzeCourseVocabulary, tokenizeWords } from "./course-vocabulary";
+
+test("tokenizeWords handles Danish letters, apostrophes, and case", () => {
+  assert.deepEqual(tokenizeWords("Æble, æble! blåbær og Mads' cykel."), [
+    "æble",
+    "æble",
+    "blåbær",
+    "og",
+    "mads",
+    "cykel",
+  ]);
+});
+
+test("analyzeCourseVocabulary tracks new and cumulative words by story", () => {
+  const analysis = analyzeCourseVocabulary([
+    { id: 1, name: "One", setId: 1, setIndex: 1, lines: ["Hej verden"] },
+    {
+      id: 2,
+      name: "Two",
+      setId: 1,
+      setIndex: 2,
+      lines: ["Hej igen, verden!"],
+    },
+  ]);
+
+  assert.equal(analysis.totalWordCount, 5);
+  assert.equal(analysis.uniqueWordCount, 3);
+  assert.deepEqual(analysis.stories[0]?.newWords, ["hej", "verden"]);
+  assert.deepEqual(analysis.stories[1]?.newWords, ["igen"]);
+  assert.deepEqual(
+    analysis.stories.map((story) => story.cumulativeUniqueWords),
+    [2, 3],
+  );
+});

--- a/src/lib/course-vocabulary.ts
+++ b/src/lib/course-vocabulary.ts
@@ -1,0 +1,56 @@
+export type VocabularyStoryInput = {
+  id: number;
+  name: string;
+  setId: number;
+  setIndex: number;
+  lines: string[];
+};
+
+export type VocabularyStoryAnalysis = VocabularyStoryInput & {
+  wordCount: number;
+  uniqueWordCount: number;
+  newWords: string[];
+  cumulativeUniqueWords: number;
+};
+
+const WORD_PATTERN = /\p{L}[\p{L}\p{M}'’ʼ-]*/gu;
+const EDGE_PUNCTUATION = /^['’ʼ-]+|['’ʼ-]+$/gu;
+
+export function tokenizeWords(text: string) {
+  return Array.from(text.normalize("NFC").matchAll(WORD_PATTERN), ([match]) =>
+    match.replace(EDGE_PUNCTUATION, "").toLocaleLowerCase(),
+  ).filter(Boolean);
+}
+
+export function analyzeCourseVocabulary(stories: VocabularyStoryInput[]) {
+  const seen = new Set<string>();
+  let totalWordCount = 0;
+
+  const analyzedStories: VocabularyStoryAnalysis[] = stories.map((story) => {
+    const words = story.lines.flatMap(tokenizeWords);
+    const storyWords = new Set(words);
+    const newWords: string[] = [];
+
+    for (const word of words) {
+      if (seen.has(word)) continue;
+      seen.add(word);
+      newWords.push(word);
+    }
+    totalWordCount += words.length;
+
+    return {
+      ...story,
+      wordCount: words.length,
+      uniqueWordCount: storyWords.size,
+      newWords,
+      cumulativeUniqueWords: seen.size,
+    };
+  });
+
+  return {
+    totalWordCount,
+    uniqueWordCount: seen.size,
+    words: Array.from(seen),
+    stories: analyzedStories,
+  };
+}


### PR DESCRIPTION
## Summary

- add a course vocabulary explorer with total and unique dialogue-word counts
- show cumulative vocabulary growth, per-story new words, and a complete alphabetical list
- keep the feature admin-only while its usefulness and production cost are evaluated
- protect both the route and Convex query, hide public navigation, and mark the page `noindex`

## Why

Course contributors want to understand how vocabulary grows across ordered stories. The initial implementation is intentionally restricted to admins because computing the analysis currently reads every published story in the course; a cached public version can be designed after the feature is evaluated.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm test` — 200 passing
- `pnpm run test:convex` — 94 passing
- unauthenticated route check redirects to `/auth/admin`
- Convex development deployment completed with `pnpm convex dev --once`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only course vocabulary page with summary statistics, growth charts, per-story details, and an alphabetical word list.
  * Added a “Course vocabulary” link for administrators on eligible course pages.
  * Added vocabulary analysis supporting Unicode characters, apostrophes, word normalization, and cumulative word tracking.

* **Bug Fixes**
  * Restricted vocabulary data access to administrators and public courses.

* **Tests**
  * Added coverage for access restrictions and vocabulary analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->