### PR TITLE
Limit approval preference to contributors

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -253,6 +253,7 @@ export default defineSchema({
     tokenIdentifier: v.string(),
     legacyUserId: v.optional(v.number()),
     hideStoryQuestions: v.boolean(),
+    confirmStoryApprovals: v.optional(v.boolean()),
     updatedAt: v.number(),
   }).index("by_token_identifier", ["tokenIdentifier"]),
 

--- a/convex/userPreferences.test.ts
+++ b/convex/userPreferences.test.ts
@@ -1,0 +1,40 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+describe("user preferences", () => {
+  test("asks for story approval confirmation by default", async () => {
+    const t = convexTest(schema, modules);
+    const asUser = t.withIdentity({ userId: "7" });
+
+    await expect(
+      asUser.query(api.userPreferences.getCurrentStoryPreferences, {}),
+    ).resolves.toMatchObject({
+      confirmStoryApprovals: true,
+      hideStoryQuestions: false,
+    });
+  });
+
+  test("updates one preference without overwriting the other", async () => {
+    const t = convexTest(schema, modules);
+    const asUser = t.withIdentity({ userId: "7" });
+
+    await asUser.mutation(api.userPreferences.setCurrentStoryPreferences, {
+      hideStoryQuestions: true,
+    });
+    await asUser.mutation(api.userPreferences.setCurrentStoryPreferences, {
+      confirmStoryApprovals: false,
+    });
+
+    await expect(
+      asUser.query(api.userPreferences.getCurrentStoryPreferences, {}),
+    ).resolves.toMatchObject({
+      confirmStoryApprovals: false,
+      hideStoryQuestions: true,
+    });
+  });
+});

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -5,6 +5,7 @@ import { getSessionLegacyUserId } from "./lib/authorization";
 const storyPreferencesValidator = v.object({
   hasSavedPreference: v.boolean(),
   hideStoryQuestions: v.boolean(),
+  confirmStoryApprovals: v.boolean(),
 });
 
 export const getCurrentStoryPreferences = query({
@@ -19,6 +20,7 @@ export const getCurrentStoryPreferences = query({
       return {
         hasSavedPreference: false,
         hideStoryQuestions: false,
+        confirmStoryApprovals: true,
       };
     }
 
@@ -32,13 +34,15 @@ export const getCurrentStoryPreferences = query({
     return {
       hasSavedPreference: preference !== null,
       hideStoryQuestions: preference?.hideStoryQuestions ?? false,
+      confirmStoryApprovals: preference?.confirmStoryApprovals ?? true,
     };
   },
 });
 
 export const setCurrentStoryPreferences = mutation({
   args: {
-    hideStoryQuestions: v.boolean(),
+    hideStoryQuestions: v.optional(v.boolean()),
+    confirmStoryApprovals: v.optional(v.boolean()),
   },
   returns: storyPreferencesValidator,
   handler: async (ctx, args) => {
@@ -59,25 +63,36 @@ export const setCurrentStoryPreferences = mutation({
       .unique();
 
     const updatedAt = Date.now();
+    const hideStoryQuestions =
+      args.hideStoryQuestions ??
+      existingPreference?.hideStoryQuestions ??
+      false;
+    const confirmStoryApprovals =
+      args.confirmStoryApprovals ??
+      existingPreference?.confirmStoryApprovals ??
+      true;
 
     if (existingPreference) {
       await ctx.db.patch(existingPreference._id, {
         legacyUserId: legacyUserId ?? undefined,
-        hideStoryQuestions: args.hideStoryQuestions,
+        hideStoryQuestions,
+        confirmStoryApprovals,
         updatedAt,
       });
     } else {
       await ctx.db.insert("user_preferences", {
         tokenIdentifier,
         legacyUserId: legacyUserId ?? undefined,
-        hideStoryQuestions: args.hideStoryQuestions,
+        hideStoryQuestions,
+        confirmStoryApprovals,
         updatedAt,
       });
     }
 
     return {
       hasSavedPreference: true,
-      hideStoryQuestions: args.hideStoryQuestions,
+      hideStoryQuestions,
+      confirmStoryApprovals,
     };
   },
 });

--- a/src/app/(stories)/(main)/profile/actions.ts
+++ b/src/app/(stories)/(main)/profile/actions.ts
@@ -22,6 +22,14 @@ export async function setHideStoryQuestionsPreference(hideQuestions: boolean) {
   });
 }
 
+export async function setConfirmStoryApprovalsPreference(
+  confirmStoryApprovals: boolean,
+) {
+  await fetchAuthMutation(api.userPreferences.setCurrentStoryPreferences, {
+    confirmStoryApprovals,
+  });
+}
+
 export async function deleteCurrentUserAccount() {
   await fetchAuthMutation(api.account.deleteCurrentUser, {});
 }

--- a/src/app/(stories)/(main)/profile/data.ts
+++ b/src/app/(stories)/(main)/profile/data.ts
@@ -15,6 +15,7 @@ export interface ProfileData {
   role: string[];
   provider_linked: Record<string, boolean>;
   hide_story_questions: boolean;
+  confirm_story_approvals: boolean;
 }
 
 export async function getProfileData() {
@@ -34,6 +35,7 @@ export async function getProfileData() {
     ) as Promise<{
       hasSavedPreference: boolean;
       hideStoryQuestions: boolean;
+      confirmStoryApprovals: boolean;
     }>,
   ]);
 
@@ -66,5 +68,6 @@ export async function getProfileData() {
       : isStoryQuestionsDisabled(
           cookieStore.get(HIDE_STORY_QUESTIONS_COOKIE)?.value,
         ),
+    confirm_story_approvals: storyPreferences.confirmStoryApprovals,
   } satisfies ProfileData;
 }

--- a/src/app/(stories)/(main)/profile/data.ts
+++ b/src/app/(stories)/(main)/profile/data.ts
@@ -16,6 +16,7 @@ export interface ProfileData {
   provider_linked: Record<string, boolean>;
   hide_story_questions: boolean;
   confirm_story_approvals: boolean;
+  can_approve_stories: boolean;
 }
 
 export async function getProfileData() {
@@ -69,5 +70,6 @@ export async function getProfileData() {
           cookieStore.get(HIDE_STORY_QUESTIONS_COOKIE)?.value,
         ),
     confirm_story_approvals: storyPreferences.confirmStoryApprovals,
+    can_approve_stories: isContributor(user),
   } satisfies ProfileData;
 }

--- a/src/app/(stories)/(main)/profile/profile.tsx
+++ b/src/app/(stories)/(main)/profile/profile.tsx
@@ -12,6 +12,7 @@ import { resetPostHogUser } from "@/lib/posthog-user";
 import type { ProfileData } from "./data";
 import {
   deleteCurrentUserAccount,
+  setConfirmStoryApprovalsPreference,
   setHideStoryQuestionsPreference,
 } from "./actions";
 
@@ -307,10 +308,17 @@ export default function Profile({ providers }: { providers: ProfileData }) {
   const [hideStoryQuestions, setHideStoryQuestions] = React.useState(
     providers.hide_story_questions,
   );
+  const [confirmStoryApprovals, setConfirmStoryApprovals] = React.useState(
+    providers.confirm_story_approvals,
+  );
   const [storyQuestionsState, setStoryQuestionsState] = React.useState<
     "idle" | "pending" | "success" | "error"
   >("idle");
   const [storyQuestionsError, setStoryQuestionsError] = React.useState("");
+  const [storyApprovalsState, setStoryApprovalsState] = React.useState<
+    "idle" | "pending" | "success" | "error"
+  >("idle");
+  const [storyApprovalsError, setStoryApprovalsError] = React.useState("");
   const [isShowingDeleteAccount, setIsShowingDeleteAccount] =
     React.useState(false);
   const [deleteConfirmation, setDeleteConfirmation] = React.useState("");
@@ -497,6 +505,27 @@ export default function Profile({ providers }: { providers: ProfileData }) {
     }
   }
 
+  async function toggleConfirmStoryApprovals() {
+    if (storyApprovalsState === "pending") return;
+
+    const nextConfirmStoryApprovals = !confirmStoryApprovals;
+    setConfirmStoryApprovals(nextConfirmStoryApprovals);
+    setStoryApprovalsState("pending");
+    setStoryApprovalsError("");
+
+    try {
+      await setConfirmStoryApprovalsPreference(nextConfirmStoryApprovals);
+      setStoryApprovalsState("success");
+    } catch (error) {
+      setConfirmStoryApprovals(!nextConfirmStoryApprovals);
+      setStoryApprovalsState("error");
+      setStoryApprovalsError(
+        (error as Error)?.message ||
+          "Could not update your story approval preference.",
+      );
+    }
+  }
+
   async function removeAccount() {
     if (deleteState === "pending") return;
 
@@ -630,7 +659,6 @@ export default function Profile({ providers }: { providers: ProfileData }) {
                 </div>
               ) : null}
             </SettingRow>
-
             <SettingRow
               label="Email"
               value={providers.email}
@@ -778,6 +806,29 @@ export default function Profile({ providers }: { providers: ProfileData }) {
                 state={storyQuestionsState}
                 error={storyQuestionsError}
                 success="Story preference saved."
+              />
+            </SettingRow>
+            <SettingRow
+              label="Confirm Story Approvals"
+              value={
+                confirmStoryApprovals
+                  ? "Enabled, ask before approving"
+                  : "Disabled, approve immediately"
+              }
+              helper="Show a reminder that approval means you checked the story and think it is ready to publish."
+              action={
+                <Switch
+                  checked={confirmStoryApprovals}
+                  onClick={toggleConfirmStoryApprovals}
+                  disabled={storyApprovalsState === "pending"}
+                  ariaLabel="Confirm before approving stories"
+                />
+              }
+            >
+              <StatusText
+                state={storyApprovalsState}
+                error={storyApprovalsError}
+                success="Approval preference saved."
               />
             </SettingRow>
           </div>

--- a/src/app/(stories)/(main)/profile/profile.tsx
+++ b/src/app/(stories)/(main)/profile/profile.tsx
@@ -803,29 +803,31 @@ export default function Profile({ providers }: { providers: ProfileData }) {
                 success="Story preference saved."
               />
             </SettingRow>
-            <SettingRow
-              label="Confirm Story Approvals"
-              value={
-                confirmStoryApprovals
-                  ? "Enabled, ask before approving"
-                  : "Disabled, approve immediately"
-              }
-              helper="Show a reminder that approval means you checked the story and think it is ready to publish."
-              action={
-                <Switch
-                  checked={confirmStoryApprovals}
-                  onClick={toggleConfirmStoryApprovals}
-                  disabled={storyApprovalsState === "pending"}
-                  ariaLabel="Confirm before approving stories"
+            {providers.can_approve_stories ? (
+              <SettingRow
+                label="Confirm Story Approvals"
+                value={
+                  confirmStoryApprovals
+                    ? "Enabled, ask before approving"
+                    : "Disabled, approve immediately"
+                }
+                helper="Show a reminder that approval means you checked the story and think it is ready to publish."
+                action={
+                  <Switch
+                    checked={confirmStoryApprovals}
+                    onClick={toggleConfirmStoryApprovals}
+                    disabled={storyApprovalsState === "pending"}
+                    ariaLabel="Confirm before approving stories"
+                  />
+                }
+              >
+                <StatusText
+                  state={storyApprovalsState}
+                  error={storyApprovalsError}
+                  success="Approval preference saved."
                 />
-              }
-            >
-              <StatusText
-                state={storyApprovalsState}
-                error={storyApprovalsError}
-                success="Approval preference saved."
-              />
-            </SettingRow>
+              </SettingRow>
+            ) : null}
           </div>
         </section>
 

--- a/src/app/(stories)/(main)/profile/profile.tsx
+++ b/src/app/(stories)/(main)/profile/profile.tsx
@@ -28,6 +28,37 @@ const labelClass =
   "mb-1 block text-[0.82rem] font-bold uppercase tracking-[0.08em] text-[var(--title-color-dim)]";
 const successMessageClass = "mt-2 block text-[var(--button-border)]";
 const errorMessageClass = "mt-2 block text-[var(--error-red)]";
+type PreferenceState = "idle" | "pending" | "success" | "error";
+
+function useBooleanPreference(
+  initialValue: boolean,
+  savePreference: (value: boolean) => Promise<void>,
+  fallbackError: string,
+) {
+  const [value, setValue] = React.useState(initialValue);
+  const [state, setState] = React.useState<PreferenceState>("idle");
+  const [error, setError] = React.useState("");
+
+  const toggle = React.useCallback(async () => {
+    if (state === "pending") return;
+
+    const nextValue = !value;
+    setValue(nextValue);
+    setState("pending");
+    setError("");
+
+    try {
+      await savePreference(nextValue);
+      setState("success");
+    } catch (saveError) {
+      setValue(value);
+      setState("error");
+      setError((saveError as Error)?.message || fallbackError);
+    }
+  }, [fallbackError, savePreference, state, value]);
+
+  return { error, state, toggle, value };
+}
 
 function roleBadgeTone(role: string) {
   if (role === "Admin") {
@@ -305,20 +336,26 @@ export default function Profile({ providers }: { providers: ProfileData }) {
   const [isEditingEmail, setIsEditingEmail] = React.useState(false);
   const [isShowingPasswordReset, setIsShowingPasswordReset] =
     React.useState(false);
-  const [hideStoryQuestions, setHideStoryQuestions] = React.useState(
+  const {
+    value: hideStoryQuestions,
+    state: storyQuestionsState,
+    error: storyQuestionsError,
+    toggle: toggleHideStoryQuestions,
+  } = useBooleanPreference(
     providers.hide_story_questions,
+    setHideStoryQuestionsPreference,
+    "Could not update your story question preference.",
   );
-  const [confirmStoryApprovals, setConfirmStoryApprovals] = React.useState(
+  const {
+    value: confirmStoryApprovals,
+    state: storyApprovalsState,
+    error: storyApprovalsError,
+    toggle: toggleConfirmStoryApprovals,
+  } = useBooleanPreference(
     providers.confirm_story_approvals,
+    setConfirmStoryApprovalsPreference,
+    "Could not update your story approval preference.",
   );
-  const [storyQuestionsState, setStoryQuestionsState] = React.useState<
-    "idle" | "pending" | "success" | "error"
-  >("idle");
-  const [storyQuestionsError, setStoryQuestionsError] = React.useState("");
-  const [storyApprovalsState, setStoryApprovalsState] = React.useState<
-    "idle" | "pending" | "success" | "error"
-  >("idle");
-  const [storyApprovalsError, setStoryApprovalsError] = React.useState("");
   const [isShowingDeleteAccount, setIsShowingDeleteAccount] =
     React.useState(false);
   const [deleteConfirmation, setDeleteConfirmation] = React.useState("");
@@ -482,48 +519,6 @@ export default function Profile({ providers }: { providers: ProfileData }) {
     setSavedUsername(normalizedUsername);
     setUsernameState("success");
     setUsernameError("");
-  }
-
-  async function toggleHideStoryQuestions() {
-    if (storyQuestionsState === "pending") return;
-
-    const nextHideStoryQuestions = !hideStoryQuestions;
-    setHideStoryQuestions(nextHideStoryQuestions);
-    setStoryQuestionsState("pending");
-    setStoryQuestionsError("");
-
-    try {
-      await setHideStoryQuestionsPreference(nextHideStoryQuestions);
-      setStoryQuestionsState("success");
-    } catch (error) {
-      setHideStoryQuestions(!nextHideStoryQuestions);
-      setStoryQuestionsState("error");
-      setStoryQuestionsError(
-        (error as Error)?.message ||
-          "Could not update your story question preference.",
-      );
-    }
-  }
-
-  async function toggleConfirmStoryApprovals() {
-    if (storyApprovalsState === "pending") return;
-
-    const nextConfirmStoryApprovals = !confirmStoryApprovals;
-    setConfirmStoryApprovals(nextConfirmStoryApprovals);
-    setStoryApprovalsState("pending");
-    setStoryApprovalsError("");
-
-    try {
-      await setConfirmStoryApprovalsPreference(nextConfirmStoryApprovals);
-      setStoryApprovalsState("success");
-    } catch (error) {
-      setConfirmStoryApprovals(!nextConfirmStoryApprovals);
-      setStoryApprovalsState("error");
-      setStoryApprovalsError(
-        (error as Error)?.message ||
-          "Could not update your story approval preference.",
-      );
-    }
   }
 
   async function removeAccount() {

--- a/src/app/editor/(course)/edit_list.tsx
+++ b/src/app/editor/(course)/edit_list.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
-import { useMutation } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "@convex/_generated/api";
 import ContributorList from "@/components/ContributorList";
 import {
@@ -60,6 +60,9 @@ export default function EditList({
   const [isStoredFilterApplied, setIsStoredFilterApplied] = useState(false);
   const restoredViewKeyRef = useRef<string | null>(null);
   const deferredStorySearch = useDeferredValue(storySearch);
+  const storyPreferences = useQuery(
+    api.userPreferences.getCurrentStoryPreferences,
+  );
 
   useEffect(() => {
     setStoryList(stories ?? []);
@@ -351,6 +354,9 @@ export default function EditList({
                     status={story.status}
                     public={story.public}
                     official={course.official}
+                    confirmStoryApprovals={
+                      storyPreferences?.confirmStoryApprovals ?? true
+                    }
                     onStoryStateChange={(nextStoryState) => {
                       setStoryList((currentStories) =>
                         currentStories.map((currentStory) =>
@@ -508,6 +514,7 @@ function DropDownStatus(props: {
   status: string;
   public: boolean;
   official: boolean;
+  confirmStoryApprovals: boolean;
   onStoryStateChange: (
     nextStoryState: Pick<
       StoryListDataProps,
@@ -523,8 +530,14 @@ function DropDownStatus(props: {
     props.approvedByCurrentUser,
   );
   let [isConfirmingApproval, setIsConfirmingApproval] = useState(false);
+  let [skipFutureApprovalConfirmations, setSkipFutureApprovalConfirmations] =
+    useState(false);
+  const approveButtonRef = useRef<HTMLButtonElement>(null);
   const toggleApprovalMutation = useMutation(
     api.storyApproval.toggleStoryApproval,
+  );
+  const setStoryPreferencesMutation = useMutation(
+    api.userPreferences.setCurrentStoryPreferences,
   );
   const router = useRouter();
 
@@ -552,13 +565,23 @@ function DropDownStatus(props: {
       void toggleApproval();
       return;
     }
-    setIsConfirmingApproval(true);
+    if (props.confirmStoryApprovals) {
+      setSkipFutureApprovalConfirmations(false);
+      setIsConfirmingApproval(true);
+      return;
+    }
+    void toggleApproval();
   }
 
   async function toggleApproval() {
     setIsConfirmingApproval(false);
     setLoading(1);
     try {
+      if (skipFutureApprovalConfirmations) {
+        await setStoryPreferencesMutation({
+          confirmStoryApprovals: false,
+        });
+      }
       const response = await toggleApprovalMutation({
         legacyStoryId: props.id,
         operationKey: `story_approval:${props.id}:toggle:client`,
@@ -663,7 +686,13 @@ function DropDownStatus(props: {
         open={isConfirmingApproval}
         onOpenChange={setIsConfirmingApproval}
       >
-        <DialogContent className="max-w-[420px] rounded-[8px] bg-[var(--body-background)] text-left whitespace-normal">
+        <DialogContent
+          className="max-w-[420px] rounded-[8px] bg-[var(--body-background)] text-left whitespace-normal"
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            approveButtonRef.current?.focus();
+          }}
+        >
           <DialogTitle className="text-lg font-bold text-[var(--text-color)]">
             Approve story?
           </DialogTitle>
@@ -673,6 +702,16 @@ function DropDownStatus(props: {
               ready to be published?
             </p>
           </DialogDescription>
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-[var(--text-color)]">
+            <input
+              type="checkbox"
+              checked={skipFutureApprovalConfirmations}
+              onChange={(event) =>
+                setSkipFutureApprovalConfirmations(event.target.checked)
+              }
+            />
+            Do not ask again
+          </label>
           <div className="flex justify-end gap-2">
             <button
               type="button"
@@ -683,6 +722,7 @@ function DropDownStatus(props: {
             </button>
             <button
               type="button"
+              ref={approveButtonRef}
               className="rounded-[8px] bg-[#0089e5] px-3 py-2 font-bold text-white hover:brightness-90"
               onClick={() => void toggleApproval()}
             >


### PR DESCRIPTION
## Summary

- show the story approval confirmation preference only to contributors and admins
- derive visibility from the canonical server-side contributor capability instead of profile badge labels

## Why

Ordinary users cannot approve stories, so an approval-specific profile setting is confusing and irrelevant to them.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm test` (200 tests)
- `pnpm run test:convex` (96 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a profile setting to enable or disable confirmation prompts when approving stories.
  * Story approval prompts now include a “Do not ask again” option.
  * Approval dialogs autofocus the Approve button for faster workflows.
  * Preference updates display pending, success, and error states.

* **Bug Fixes**
  * Story preference updates now preserve existing settings when only one preference changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->