### PR TITLE
Limit approval preference to contributors

### DIFF
--- a/src/app/(stories)/(main)/profile/data.ts
+++ b/src/app/(stories)/(main)/profile/data.ts
@@ -16,6 +16,7 @@ export interface ProfileData {
   provider_linked: Record<string, boolean>;
   hide_story_questions: boolean;
   confirm_story_approvals: boolean;
+  can_approve_stories: boolean;
 }
 
 export async function getProfileData() {
@@ -69,5 +70,6 @@ export async function getProfileData() {
           cookieStore.get(HIDE_STORY_QUESTIONS_COOKIE)?.value,
         ),
     confirm_story_approvals: storyPreferences.confirmStoryApprovals,
+    can_approve_stories: isContributor(user),
   } satisfies ProfileData;
 }

--- a/src/app/(stories)/(main)/profile/profile.tsx
+++ b/src/app/(stories)/(main)/profile/profile.tsx
@@ -803,29 +803,31 @@ export default function Profile({ providers }: { providers: ProfileData }) {
                 success="Story preference saved."
               />
             </SettingRow>
-            <SettingRow
-              label="Confirm Story Approvals"
-              value={
-                confirmStoryApprovals
-                  ? "Enabled, ask before approving"
-                  : "Disabled, approve immediately"
-              }
-              helper="Show a reminder that approval means you checked the story and think it is ready to publish."
-              action={
-                <Switch
-                  checked={confirmStoryApprovals}
-                  onClick={toggleConfirmStoryApprovals}
-                  disabled={storyApprovalsState === "pending"}
-                  ariaLabel="Confirm before approving stories"
+            {providers.can_approve_stories ? (
+              <SettingRow
+                label="Confirm Story Approvals"
+                value={
+                  confirmStoryApprovals
+                    ? "Enabled, ask before approving"
+                    : "Disabled, approve immediately"
+                }
+                helper="Show a reminder that approval means you checked the story and think it is ready to publish."
+                action={
+                  <Switch
+                    checked={confirmStoryApprovals}
+                    onClick={toggleConfirmStoryApprovals}
+                    disabled={storyApprovalsState === "pending"}
+                    ariaLabel="Confirm before approving stories"
+                  />
+                }
+              >
+                <StatusText
+                  state={storyApprovalsState}
+                  error={storyApprovalsError}
+                  success="Approval preference saved."
                 />
-              }
-            >
-              <StatusText
-                state={storyApprovalsState}
-                error={storyApprovalsError}
-                success="Approval preference saved."
-              />
-            </SettingRow>
+              </SettingRow>
+            ) : null}
           </div>
         </section>
 


### PR DESCRIPTION
## Summary

- show the story approval confirmation preference only to contributors and admins
- derive visibility from the canonical server-side contributor capability instead of profile badge labels

## Why

Ordinary users cannot approve stories, so an approval-specific profile setting is confusing and irrelevant to them.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm test` (200 tests)
- `pnpm run test:convex` (96 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Confirm Story Approvals” preference now appears only for contributors who can approve stories.
  * Existing approval confirmation settings and feedback remain unchanged when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->