### PR TITLE
Fix audio cutter inserting audio lines above hint lines

### DIFF
--- a/src/app/editor/(course)/course/[course_id]/story/[story]/audio-cutter/page_client.tsx
+++ b/src/app/editor/(course)/course/[course_id]/story/[story]/audio-cutter/page_client.tsx
@@ -38,7 +38,11 @@ import type {
   StoryElementHeader,
   StoryElementLine,
 } from "@/components/editor/story/syntax_parser_types";
-import { timings_to_text } from "@/lib/editor/audio/audio_edit_tools";
+import {
+  get_audio_insert_line,
+  timings_to_text,
+} from "@/lib/editor/audio/audio_edit_tools";
+import { fix_audio_line_order } from "@/lib/editor/audio/fix_audio_line_order";
 
 export default function AudioCutterPageClient({
   storyId,
@@ -418,16 +422,18 @@ export default function AudioCutterPageClient({
               learningLanguage.tts_replace ?? "",
             );
 
-            const storyText = applyAudioUpdatesToText(
-              data.story_data.text,
-              uploadedSegments.map((segment) => ({
-                ssml: segment.ssml,
-                serializedText: timings_to_text({
-                  filename: segment.uploadedFilename,
-                  keypoints: segment.keypoints,
-                }),
-              })),
-              audioInsertLines,
+            const storyText = fix_audio_line_order(
+              applyAudioUpdatesToText(
+                data.story_data.text,
+                uploadedSegments.map((segment) => ({
+                  ssml: segment.ssml,
+                  serializedText: timings_to_text({
+                    filename: segment.uploadedFilename,
+                    keypoints: segment.keypoints,
+                  }),
+                })),
+                audioInsertLines,
+              ),
             );
 
             const [nextParsedStoryBase, nextParsedMeta] = processStoryFile(
@@ -642,11 +648,7 @@ function applyAudioUpdatesToText(
         };
       }
 
-      const lineInsertNumber = Math.min(
-        Math.max(1, lineInsert - 1),
-        state.doc.lines,
-      );
-      const lineState = state.doc.line(lineInsertNumber);
+      const lineState = get_audio_insert_line(state.doc, lineInsert);
       return {
         from: lineState.from,
         to: lineState.from,

--- a/src/app/editor/story/[story]/v2/editor_v2.tsx
+++ b/src/app/editor/story/[story]/v2/editor_v2.tsx
@@ -32,6 +32,7 @@ import {
   timings_to_text,
   type AudioInsertAnchor,
 } from "@/lib/editor/audio/audio_edit_tools";
+import { fix_audio_line_order } from "@/lib/editor/audio/fix_audio_line_order";
 import type {
   Audio,
   StoryElement,
@@ -76,7 +77,9 @@ function getMax<T>(list: T[], callback: (obj: T) => number) {
 }
 
 function normalizeDocText(text: string): string {
-  return text.replace(/\r\n/g, "\n");
+  // Repair audio lines that older imports placed above the hint lines, so the
+  // loaded document parses cleanly; saving then persists the corrected order.
+  return fix_audio_line_order(text.replace(/\r\n/g, "\n"));
 }
 
 function scrollEditorLineIntoView(view: EditorView, lineNumber: number) {

--- a/src/lib/editor/audio/fix_audio_line_order.test.ts
+++ b/src/lib/editor/audio/fix_audio_line_order.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fix_audio_line_order } from "@/lib/editor/audio/fix_audio_line_order";
+
+test("fix_audio_line_order moves a misplaced audio line below the hint line", () => {
+  const text = [
+    "[SELECT_PHRASE]",
+    "> Selecciona la frase que falta",
+    "Speaker790: Imaynalla, Zari. ¿[Kayqa~diarioykichu]?",
+    "$9873/_35b47c16.mp3;9,0;6,978;8,435;13,543",
+    "~ hola Zari este~es~tu~diario",
+    "- Kay killa diariochu",
+    "+ Kayqa diarioykichu",
+  ].join("\n");
+
+  assert.equal(
+    fix_audio_line_order(text),
+    [
+      "[SELECT_PHRASE]",
+      "> Selecciona la frase que falta",
+      "Speaker790: Imaynalla, Zari. ¿[Kayqa~diarioykichu]?",
+      "~ hola Zari este~es~tu~diario",
+      "$9873/_35b47c16.mp3;9,0;6,978;8,435;13,543",
+      "- Kay killa diariochu",
+      "+ Kayqa diarioykichu",
+    ].join("\n"),
+  );
+});
+
+test("fix_audio_line_order moves the audio line below translation and pronunciation lines", () => {
+  const text = [
+    "Speaker790: Imaynalla",
+    "$9873/_35b47c16.mp3;9,0",
+    "~ hola",
+    "^ ee-mine-ah-lah",
+    "",
+  ].join("\n");
+
+  assert.equal(
+    fix_audio_line_order(text),
+    [
+      "Speaker790: Imaynalla",
+      "~ hola",
+      "^ ee-mine-ah-lah",
+      "$9873/_35b47c16.mp3;9,0",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("fix_audio_line_order fixes multiple misplaced audio lines", () => {
+  const text = [
+    "[LINE]",
+    "Speaker1: Uno",
+    "$1.mp3;1,0",
+    "~ one",
+    "",
+    "[LINE]",
+    "Speaker2: Dos",
+    "$2.mp3;1,0",
+    "~ two",
+  ].join("\n");
+
+  assert.equal(
+    fix_audio_line_order(text),
+    [
+      "[LINE]",
+      "Speaker1: Uno",
+      "~ one",
+      "$1.mp3;1,0",
+      "",
+      "[LINE]",
+      "Speaker2: Dos",
+      "~ two",
+      "$2.mp3;1,0",
+    ].join("\n"),
+  );
+});
+
+test("fix_audio_line_order leaves correctly ordered text unchanged", () => {
+  const text = [
+    "[LINE]",
+    "Speaker790: Imaynalla",
+    "~ hola",
+    "$9873/_35b47c16.mp3;9,0",
+    "",
+    "[LINE]",
+    "> Narrator line without hints",
+    "$1.mp3;1,0",
+    "",
+    "+ answer",
+    "~ answer hint",
+  ].join("\n");
+
+  assert.equal(fix_audio_line_order(text), text);
+});
+
+test("fix_audio_line_order does not reorder across blank lines", () => {
+  const text = ["Speaker1: Uno", "$1.mp3;1,0", "", "~ stray hint"].join("\n");
+
+  assert.equal(fix_audio_line_order(text), text);
+});

--- a/src/lib/editor/audio/fix_audio_line_order.ts
+++ b/src/lib/editor/audio/fix_audio_line_order.ts
@@ -1,0 +1,26 @@
+// The story grammar expects hint lines (~ translation, ^ pronunciation) to
+// come before the $ audio line. Audio imports have historically inserted the
+// audio line one line too high, leaving it above the hints and breaking the
+// parse. This repairs that ordering at the text level.
+
+function strippedLine(line: string) {
+  return line.trim().replace(/\u2067/, "");
+}
+
+export function fix_audio_line_order(text: string): string {
+  const lines = text.split("\n");
+  let changed = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (!strippedLine(lines[i]).startsWith("$")) continue;
+    let end = i + 1;
+    while (end < lines.length && /^[~^]/.test(strippedLine(lines[end]))) {
+      end += 1;
+    }
+    if (end === i + 1) continue;
+    const [audioLine] = lines.splice(i, 1);
+    lines.splice(end - 1, 0, audioLine);
+    changed = true;
+    i = end - 1;
+  }
+  return changed ? lines.join("\n") : text;
+}


### PR DESCRIPTION
## Problem

Importing audio from the audio splitter (cutter) sometimes places the `$` audio line **above** the `~` hint line instead of below it. On drills where answers directly follow the hints (e.g. `[SELECT_PHRASE]`), this breaks the block parse: the hint line and all answer lines are rejected as "Unexpected line outside a recognized block", leaving the drill with zero answers.

## Root cause

`applyAudioUpdatesToText` on the cutter page inserted new audio lines at `lineInsert - 1` — one line above the parser-computed insert point (introduced in #487). When the hints are immediately followed by answers, that off-by-one lands exactly on the hint line. The in-editor insert path (`get_audio_insert_line`) never subtracted.

## Changes

- **Root cause:** the cutter now reuses the shared `get_audio_insert_line` helper, matching the in-editor insert path, so new audio lines land below the hints.
- **Symptom fix:** new `fix_audio_line_order()` moves a `$` audio line below the `~`/`^` hint lines that immediately follow it (a pattern that is invalid in every position of the story grammar). Applied:
  - when the editor loads a story — already-broken stories are repaired in the document, parse cleanly, and show as unsaved changes so one save persists the fix;
  - to the cutter's saved text, so re-running the cutter on a broken story repairs it.
- Conservative by design: only reorders directly adjacent lines (never across blank lines), preserves the original line content/whitespace, and handles multiple hint lines and multiple broken blocks.

## Testing

- New unit tests for `fix_audio_line_order`, including the exact broken `[SELECT_PHRASE]` block from the bug report (verified end-to-end through `processStoryFile`: 4 parse errors before, clean parse with all 3 answers and attached audio after).
- Full suite: 205 tests pass; `pnpm run typecheck` and `pnpm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio placement in story text so audio lines appear beneath related hints, translations, and pronunciation lines.
  * Corrected audio ordering after edits and when stories are saved.
  * Preserved existing text structure, including content separated by blank lines.
  * Improved handling of multiple audio lines to ensure each is positioned consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->