### PR TITLE
Play isolated word audio on click

### DIFF
--- a/src/components/StoryHeader/StoryHeader.tsx
+++ b/src/components/StoryHeader/StoryHeader.tsx
@@ -43,12 +43,11 @@ function StoryHeader({
     editorBlock: element.editor,
   };
   const { onClick } = getEditorHandlers(editorProps);
-  const [audioRange, playAudio, ref, url] = useAudio(
-    element,
-    active,
-    settings.show_audio,
-  );
+  const [audioRange, playAudio, ref, url, playWordAudio, playingWordRange] =
+    useAudio(element, active, settings.show_audio);
   const effectiveAudioRange = audioRangeOverride ?? audioRange;
+  const onWordClick =
+    !hideAudioButton && settings.show_audio ? playWordAudio : undefined;
   const isRtl = settings.rtl || element.lang === "rtl";
   const showEditorAudioDetails =
     editorShowAudioDetailsOverride ?? settings.show_audio;
@@ -100,6 +99,8 @@ function StoryHeader({
           hideRangesForChallenge={hideRangesForChallenge}
           content={element.learningLanguageTitleContent}
           editorState={editorState}
+          onWordClick={onWordClick}
+          playingWordRange={playingWordRange}
         />
         {showEditorAudioDetails &&
           element.audio &&

--- a/src/components/StoryLineHints/StoryLineHints.tsx
+++ b/src/components/StoryLineHints/StoryLineHints.tsx
@@ -2,7 +2,10 @@ import React, { CSSProperties } from "react";
 import { ContentWithHints } from "@/components/editor/story/syntax_parser_types";
 import type { EditorStateType } from "@/app/editor/story/[story]/editor_state";
 import { splitDisplayText } from "@/lib/text/tokenization";
+import type { PlayingWordRange } from "@/components/StoryTextLine/use-audio.hook";
 import { cn } from "@/lib/utils";
+
+const WORD_CHARACTER = /[\p{L}\p{N}]/u;
 
 const underlineBaseStyle: CSSProperties = {
   backgroundPosition: "0 100%",
@@ -144,6 +147,8 @@ function StoryLineHints({
   hideRangesForChallenge,
   unhide,
   editorState,
+  onWordClick,
+  playingWordRange,
 }: {
   content: ContentWithHints;
   showHints?: boolean;
@@ -152,6 +157,8 @@ function StoryLineHints({
   hideRangesForChallenge?: { start: number; end: number }[];
   unhide?: number;
   editorState?: EditorStateType;
+  onWordClick?: (start: number, end: number) => void;
+  playingWordRange?: PlayingWordRange | null;
 }) {
   if (!content) return <>Empty</>;
   const visibleContent = showHints
@@ -191,6 +198,7 @@ function StoryLineHints({
   }
 
   function addWord2(start: number, end: number) {
+    const word_text = visibleContent.text.substring(start, end);
     const was_hidden_for_challenge = hideRangesForChallenge?.some((range) =>
       getOverlap(start, end, range.start, range.end),
     );
@@ -217,10 +225,21 @@ function StoryLineHints({
       Object.assign(style, hiddenUnderlineStyle);
     }
 
+    const is_clickable =
+      onWordClick !== undefined && !is_hidden && WORD_CHARACTER.test(word_text);
+    if (
+      playingWordRange &&
+      !is_hidden &&
+      getOverlap(start, end, playingWordRange.start, playingWordRange.end)
+    ) {
+      style.color = "var(--link-blue)";
+    }
+
     const returns = [
       <span
         className={cn(
           "select-text",
+          is_clickable && "cursor-pointer",
           is_hidden === true && "select-none text-[var(--body-background)]",
           is_hidden === "editor" && "opacity-70",
         )}
@@ -234,11 +253,12 @@ function StoryLineHints({
         data-revealed={
           was_hidden_for_challenge && !is_hidden ? true : undefined
         }
+        onClick={is_clickable ? () => onWordClick(start, end) : undefined}
       >
-        {visibleContent.text.substring(start, end)}
+        {word_text}
       </span>,
     ];
-    if (visibleContent.text.substring(start, end).indexOf("\n") !== -1)
+    if (word_text.indexOf("\n") !== -1)
       returns.push(<br key={start + " " + end + " br"} />);
     // add the span and optionally add a line break
     return returns;

--- a/src/components/StoryTextLine/StoryTextLine.tsx
+++ b/src/components/StoryTextLine/StoryTextLine.tsx
@@ -49,12 +49,11 @@ function StoryTextLine({
     editorBlock: element.editor,
   };
   const { onClick } = getEditorHandlers(editorProps);
-  const [audioRange, playAudio, ref, url] = useAudio(
-    element,
-    active,
-    settings.show_audio,
-  );
+  const [audioRange, playAudio, ref, url, playWordAudio, playingWordRange] =
+    useAudio(element, active, settings.show_audio);
   const effectiveAudioRange = audioRangeOverride ?? audioRange;
+  const onWordClick =
+    !hideAudioButton && settings.show_audio ? playWordAudio : undefined;
   const isRtl = getStoryLineDirection({
     storyRtl: settings.rtl,
     lineLang: element.lang,
@@ -121,6 +120,8 @@ function StoryTextLine({
             hideRangesForChallenge={hideRangesForChallenge}
             content={element.line.content}
             editorState={editorState}
+            onWordClick={onWordClick}
+            playingWordRange={playingWordRange}
           />
         </span>
       </div>
@@ -162,6 +163,8 @@ function StoryTextLine({
             unhide={unhide}
             content={element.line.content}
             editorState={editorState}
+            onWordClick={onWordClick}
+            playingWordRange={playingWordRange}
           />
           {showEditorAudioDetails &&
             element.line.content.audio &&
@@ -201,6 +204,8 @@ function StoryTextLine({
             unhide={unhide}
             content={element.line.content}
             editorState={editorState}
+            onWordClick={onWordClick}
+            playingWordRange={playingWordRange}
           />
           {showEditorAudioDetails &&
             element.line.content.audio &&

--- a/src/components/StoryTextLine/use-audio.hook.ts
+++ b/src/components/StoryTextLine/use-audio.hook.ts
@@ -15,6 +15,16 @@ type UseAudioElement = StoryElementLine | StoryElementHeader;
 
 export type PlayingWordRange = { start: number; end: number };
 
+// Timing keypoints sit earlier than the actual speech in the encoded audio
+// (MP3 encoder delay + TTS speech-mark skew). Measured against energy onsets
+// across several courses, speech runs ~25-200ms (median ~75ms) behind its
+// mark depending on the voice. Shift the playback window right: a small
+// start shift trims the previous word's tail, and a larger end pad keeps
+// word endings from being clipped (bleeding a soft next-word onset is less
+// jarring than a cut-off ending).
+const WORD_AUDIO_START_SHIFT_MS = 30;
+const WORD_AUDIO_END_PAD_MS = 150;
+
 export function getPlayableKeypoints(
   keypoints: Audio["keypoints"],
   durationSeconds: number,
@@ -183,8 +193,12 @@ export default function useAudio(
           (keypoint) => keypoint.rangeEnd > start,
         );
         if (index === -1) index = keypoints.length - 1;
-        segmentStart = keypoints[index].audioStart;
-        segmentEnd = keypoints[index + 1]?.audioStart;
+        segmentStart = keypoints[index].audioStart + WORD_AUDIO_START_SHIFT_MS;
+        const nextStart = keypoints[index + 1]?.audioStart;
+        segmentEnd =
+          nextStart !== undefined
+            ? nextStart + WORD_AUDIO_END_PAD_MS
+            : undefined;
         wordRange = {
           start: keypoints[index - 1]?.rangeEnd ?? 0,
           end: keypoints[index].rangeEnd,
@@ -207,9 +221,11 @@ export default function useAudio(
       setPlayingWordRange(wordRange);
 
       if (segmentEnd !== undefined) {
+        // Base the stop timer on the actual position after seeking, since
+        // MP3 seeks are not sample-exact.
         stopTimeout = window.setTimeout(
           cancel,
-          Math.max(0, segmentEnd - segmentStart),
+          Math.max(0, segmentEnd - audioObject.currentTime * 1000),
         );
       }
       audioObject.addEventListener("ended", cancel, { once: true });

--- a/src/components/StoryTextLine/use-audio.hook.ts
+++ b/src/components/StoryTextLine/use-audio.hook.ts
@@ -13,6 +13,8 @@ declare global {
 
 type UseAudioElement = StoryElementLine | StoryElementHeader;
 
+export type PlayingWordRange = { start: number; end: number };
+
 export function getPlayableKeypoints(
   keypoints: Audio["keypoints"],
   durationSeconds: number,
@@ -37,6 +39,8 @@ export default function useAudio(
   enabled = true,
 ) {
   const [audioRange, setAudioRange] = React.useState(99999);
+  const [playingWordRange, setPlayingWordRange] =
+    React.useState<PlayingWordRange | null>(null);
   const audio: Audio | undefined =
     element.type === "LINE"
       ? element.line?.content?.audio
@@ -118,6 +122,101 @@ export default function useAudio(
     return cancel;
   }, [audio, enabled]);
 
+  // Play only the audio segment of the word at character offset `start`,
+  // using the keypoint timestamps: a word's segment runs from its keypoint's
+  // audioStart to the next keypoint's audioStart (or the end of the clip).
+  const playWordAudio = React.useCallback(
+    async (start: number) => {
+      if (!enabled || !audio?.url || !ref.current) return;
+      if (!audio.keypoints?.length) return;
+
+      const audioObject = ref.current;
+
+      // Stop any currently playing audio
+      if (window.playing_audio?.length) {
+        window.playing_audio.forEach((cancel) => cancel());
+      }
+      window.playing_audio = [];
+
+      // Register the cancel handler before awaiting metadata so a newer
+      // click (or full-line play) invalidates this pending request.
+      let cancelled = false;
+      let stopTimeout: number | undefined;
+      const cancel = () => {
+        cancelled = true;
+        if (stopTimeout !== undefined) {
+          clearTimeout(stopTimeout);
+          stopTimeout = undefined;
+        }
+        audioObject.removeEventListener("ended", cancel);
+        audioObject.pause();
+        setPlayingWordRange(null);
+      };
+      window.playing_audio.push(cancel);
+
+      let segmentStart: number;
+      let segmentEnd: number | undefined;
+      let wordRange: PlayingWordRange;
+      try {
+        audioObject.pause();
+        if (audioObject.readyState < HTMLMediaElement.HAVE_METADATA) {
+          audioObject.load();
+          await new Promise<void>((resolve, reject) => {
+            audioObject.addEventListener("loadedmetadata", () => resolve(), {
+              once: true,
+            });
+            audioObject.addEventListener(
+              "error",
+              () => reject(new Error("Audio failed to load")),
+              { once: true },
+            );
+          });
+        }
+        if (cancelled) return;
+
+        const keypoints = getPlayableKeypoints(
+          audio.keypoints,
+          audioObject.duration,
+        );
+        if (!keypoints.length) return;
+        let index = keypoints.findIndex(
+          (keypoint) => keypoint.rangeEnd > start,
+        );
+        if (index === -1) index = keypoints.length - 1;
+        segmentStart = keypoints[index].audioStart;
+        segmentEnd = keypoints[index + 1]?.audioStart;
+        wordRange = {
+          start: keypoints[index - 1]?.rangeEnd ?? 0,
+          end: keypoints[index].rangeEnd,
+        };
+
+        audioObject.currentTime = segmentStart / 1000;
+        await audioObject.play();
+      } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") {
+          return;
+        }
+        console.error("Failed to play audio:", e);
+        return;
+      }
+      if (cancelled) {
+        audioObject.pause();
+        return;
+      }
+
+      setPlayingWordRange(wordRange);
+
+      if (segmentEnd !== undefined) {
+        stopTimeout = window.setTimeout(
+          cancel,
+          Math.max(0, segmentEnd - segmentStart),
+        );
+      }
+      audioObject.addEventListener("ended", cancel, { once: true });
+    },
+    [audio, enabled],
+  );
+
   React.useEffect(() => {
     if (!enabled) return;
     if (!active) return;
@@ -143,7 +242,7 @@ export default function useAudio(
   }, [active, element.type, enabled, playAudio]);
 
   if (!audio?.url) {
-    return [audioRange, undefined, ref, undefined] as const;
+    return [audioRange, undefined, ref, undefined, undefined, null] as const;
   }
 
   const audioUrl =
@@ -151,5 +250,14 @@ export default function useAudio(
       ? audio.url
       : `https://ptoqrnbx8ghuucmt.public.blob.vercel-storage.com/${audio.url}`;
 
-  return [audioRange, playAudio, ref, audioUrl] as const;
+  const hasWordTimings = (audio.keypoints?.length ?? 0) > 0;
+
+  return [
+    audioRange,
+    playAudio,
+    ref,
+    audioUrl,
+    hasWordTimings ? playWordAudio : undefined,
+    playingWordRange,
+  ] as const;
 }


### PR DESCRIPTION
## Summary

Implements a feature request from the Russian course feedback ("I wish I could listen to the isolated word pronunciation by clicking on it"): clicking a word in a story line — or the story title — now plays just that word's slice of the existing line audio.

No new audio files or backend changes: the reader already ships per-word timing keypoints (`{rangeEnd, audioStart}`) for karaoke highlighting, so a clicked word's segment is simply `[keypoint.audioStart, nextKeypoint.audioStart)` on the line's existing `<audio>` element.

- `use-audio.hook.ts`: new `playWordAudio(start)` — validates keypoints via the existing `getPlayableKeypoints`, seeks to the covering keypoint, stops at the next one (or on `ended` for the last word). Registers in the global `window.playing_audio` registry *before* awaiting metadata, so word clicks, full-line playback, and rapid re-clicks cancel each other cleanly.
- `StoryLineHints.tsx`: word spans get a pointer cursor and click handler (real words only — punctuation and challenge-hidden ranges excluded) and turn `--link-blue` while their segment plays. The highlight always covers exactly the character range being played, so coarse/sparse timings stay honest.
- `StoryTextLine.tsx` / `StoryHeader.tsx`: wiring; disabled when audio is off or the line's audio button is hidden (auto-play view).

## Test plan

- [x] Headless-browser test on story 8642 (the one from the feedback): clicking "ключи" in "Твои ключи?" seeks to 292 ms (not clip start), plays ~740 ms, stops on its own, highlights only that word, clears afterwards
- [x] Rapid clicks on two different words: no overlapping audio, no leftover highlight
- [x] Verified prod story data (`posh-caribou-319`) has keypoints on all audio lines, so this works on deployed data as-is
- [x] `pnpm run typecheck`, `pnpm run lint` pass; `codex review` clean after addressing three findings (keypoint validation, single-keypoint lines, pending-load race)

Follow-ups (not in this PR): same feature for the mobile app reader (`app-mobile/src/story/useLineAudio.ts`); keyboard accessibility for word playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added word-level audio playback for supported story content.
  * Click individual words to play their corresponding audio segment when audio is available.
  * Highlight the word currently being played for clearer playback tracking.
  * Added support across story headers and text lines, including titles and avatars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->