### PR TITLE
Add pinned courses to the editor

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as authProviderConfig from "../authProviderConfig.js";
 import type * as authProviders from "../authProviders.js";
 import type * as courseContributorBackfill from "../courseContributorBackfill.js";
 import type * as courseInterest from "../courseInterest.js";
+import type * as coursePins from "../coursePins.js";
 import type * as courseReadStats from "../courseReadStats.js";
 import type * as courseWrite from "../courseWrite.js";
 import type * as discordAnnouncements from "../discordAnnouncements.js";
@@ -81,6 +82,7 @@ declare const fullApi: ApiFromModules<{
   authProviders: typeof authProviders;
   courseContributorBackfill: typeof courseContributorBackfill;
   courseInterest: typeof courseInterest;
+  coursePins: typeof coursePins;
   courseReadStats: typeof courseReadStats;
   courseWrite: typeof courseWrite;
   discordAnnouncements: typeof discordAnnouncements;

--- a/convex/coursePins.test.ts
+++ b/convex/coursePins.test.ts
@@ -1,0 +1,88 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+async function insertCourse(
+  t: ReturnType<typeof convexTest>,
+  legacyId: number,
+) {
+  return await t.run(async (ctx) => {
+    const languageId = await ctx.db.insert("languages", {
+      legacyId,
+      name: `Language ${legacyId}`,
+      short: `l${legacyId}`,
+      public: true,
+      rtl: false,
+    });
+    return await ctx.db.insert("courses", {
+      legacyId,
+      learningLanguageId: languageId,
+      fromLanguageId: languageId,
+      learning_language_name: `Language ${legacyId}`,
+      from_language_name: `Language ${legacyId}`,
+      official: false,
+      public: true,
+      contributors: [],
+      contributors_past: [],
+      tags: [],
+    });
+  });
+}
+
+describe("course pins", () => {
+  test("lists no pins for signed-out users", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.query(api.coursePins.listCurrentUserPins, {}),
+    ).resolves.toEqual([]);
+  });
+
+  test("pins and unpins a course for the current user", async () => {
+    const t = convexTest(schema, modules);
+    await insertCourse(t, 42);
+    const asUser = t.withIdentity({ userId: "7" });
+
+    await asUser.mutation(api.coursePins.setCurrentUserCoursePin, {
+      courseLegacyId: 42,
+      pinned: true,
+    });
+    await expect(
+      asUser.query(api.coursePins.listCurrentUserPins, {}),
+    ).resolves.toEqual([42]);
+
+    await asUser.mutation(api.coursePins.setCurrentUserCoursePin, {
+      courseLegacyId: 42,
+      pinned: false,
+    });
+    await expect(
+      asUser.query(api.coursePins.listCurrentUserPins, {}),
+    ).resolves.toEqual([]);
+  });
+
+  test("keeps pins private to each user and makes repeat toggles idempotent", async () => {
+    const t = convexTest(schema, modules);
+    await insertCourse(t, 42);
+    const firstUser = t.withIdentity({ userId: "7" });
+    const secondUser = t.withIdentity({ userId: "8" });
+
+    await firstUser.mutation(api.coursePins.setCurrentUserCoursePin, {
+      courseLegacyId: 42,
+      pinned: true,
+    });
+    await firstUser.mutation(api.coursePins.setCurrentUserCoursePin, {
+      courseLegacyId: 42,
+      pinned: true,
+    });
+
+    await expect(
+      firstUser.query(api.coursePins.listCurrentUserPins, {}),
+    ).resolves.toEqual([42]);
+    await expect(
+      secondUser.query(api.coursePins.listCurrentUserPins, {}),
+    ).resolves.toEqual([]);
+  });
+});

--- a/convex/coursePins.test.ts
+++ b/convex/coursePins.test.ts
@@ -2,6 +2,7 @@
 import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import { api } from "./_generated/api";
+import { MAX_PINNED_COURSES } from "./coursePins";
 import schema from "./schema";
 
 const modules = import.meta.glob("./**/*.ts");
@@ -39,6 +40,16 @@ describe("course pins", () => {
     await expect(
       t.query(api.coursePins.listCurrentUserPins, {}),
     ).resolves.toEqual([]);
+  });
+
+  test("rejects pin changes from signed-out users", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(api.coursePins.setCurrentUserCoursePin, {
+        courseLegacyId: 42,
+        pinned: true,
+      }),
+    ).rejects.toThrow("Unauthorized");
   });
 
   test("pins and unpins a course for the current user", async () => {
@@ -84,5 +95,61 @@ describe("course pins", () => {
     await expect(
       secondUser.query(api.coursePins.listCurrentUserPins, {}),
     ).resolves.toEqual([]);
+  });
+
+  test("allows 20 pins and rejects another without hiding existing pins", async () => {
+    const t = convexTest(schema, modules);
+    for (let legacyId = 1; legacyId <= MAX_PINNED_COURSES + 1; legacyId += 1) {
+      await insertCourse(t, legacyId);
+    }
+    const asUser = t.withIdentity({ userId: "7" });
+
+    for (let legacyId = 1; legacyId <= MAX_PINNED_COURSES; legacyId += 1) {
+      await asUser.mutation(api.coursePins.setCurrentUserCoursePin, {
+        courseLegacyId: legacyId,
+        pinned: true,
+      });
+    }
+
+    await expect(
+      asUser.mutation(api.coursePins.setCurrentUserCoursePin, {
+        courseLegacyId: MAX_PINNED_COURSES + 1,
+        pinned: true,
+      }),
+    ).rejects.toThrow(`You can pin up to ${MAX_PINNED_COURSES} courses`);
+    const visiblePins = await asUser.query(
+      api.coursePins.listCurrentUserPins,
+      {},
+    );
+    expect([...visiblePins].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: MAX_PINNED_COURSES }, (_, index) => index + 1),
+    );
+  });
+
+  test("persists supplied and fallback operation keys on new pins", async () => {
+    const t = convexTest(schema, modules);
+    const firstCourseId = await insertCourse(t, 42);
+    const secondCourseId = await insertCourse(t, 43);
+    const asUser = t.withIdentity({ userId: "7" });
+
+    await asUser.mutation(api.coursePins.setCurrentUserCoursePin, {
+      courseLegacyId: 42,
+      pinned: true,
+      operationKey: "coursePin:42:true:test",
+    });
+    await asUser.mutation(api.coursePins.setCurrentUserCoursePin, {
+      courseLegacyId: 43,
+      pinned: true,
+    });
+
+    const pins = await t.run(async (ctx) =>
+      ctx.db.query("user_pinned_courses").collect(),
+    );
+    expect(pins.find((pin) => pin.courseId === firstCourseId)).toMatchObject({
+      operationKey: "coursePin:42:true:test",
+    });
+    expect(
+      pins.find((pin) => pin.courseId === secondCourseId)?.operationKey,
+    ).toMatch(/^coursePin:43:true:\d+$/);
   });
 });

--- a/convex/coursePins.ts
+++ b/convex/coursePins.ts
@@ -1,0 +1,63 @@
+import { mutation, type MutationCtx, query } from "./_generated/server";
+import { v } from "convex/values";
+
+async function requireTokenIdentifier(ctx: MutationCtx) {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity?.tokenIdentifier) throw new Error("Unauthorized");
+  return identity.tokenIdentifier;
+}
+
+export const listCurrentUserPins = query({
+  args: {},
+  returns: v.array(v.number()),
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity?.tokenIdentifier) return [];
+
+    const pins = await ctx.db
+      .query("user_pinned_courses")
+      .withIndex("by_token_identifier", (q) =>
+        q.eq("tokenIdentifier", identity.tokenIdentifier),
+      )
+      .order("desc")
+      .take(1_000);
+
+    return pins.map((pin) => pin.courseLegacyId);
+  },
+});
+
+export const setCurrentUserCoursePin = mutation({
+  args: {
+    courseLegacyId: v.number(),
+    pinned: v.boolean(),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const tokenIdentifier = await requireTokenIdentifier(ctx);
+    const course = await ctx.db
+      .query("courses")
+      .withIndex("by_id_value", (q) => q.eq("legacyId", args.courseLegacyId))
+      .unique();
+    if (!course) throw new Error("Course not found");
+
+    const existingPin = await ctx.db
+      .query("user_pinned_courses")
+      .withIndex("by_token_identifier_and_course_id", (q) =>
+        q.eq("tokenIdentifier", tokenIdentifier).eq("courseId", course._id),
+      )
+      .unique();
+
+    if (args.pinned && !existingPin) {
+      await ctx.db.insert("user_pinned_courses", {
+        tokenIdentifier,
+        courseId: course._id,
+        courseLegacyId: course.legacyId,
+        pinnedAt: Date.now(),
+      });
+    } else if (!args.pinned && existingPin) {
+      await ctx.db.delete(existingPin._id);
+    }
+
+    return args.pinned;
+  },
+});

--- a/convex/coursePins.ts
+++ b/convex/coursePins.ts
@@ -1,11 +1,8 @@
-import { mutation, type MutationCtx, query } from "./_generated/server";
+import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
+import { requireTokenIdentifier } from "./lib/authorization";
 
-async function requireTokenIdentifier(ctx: MutationCtx) {
-  const identity = await ctx.auth.getUserIdentity();
-  if (!identity?.tokenIdentifier) throw new Error("Unauthorized");
-  return identity.tokenIdentifier;
-}
+export const MAX_PINNED_COURSES = 20;
 
 export const listCurrentUserPins = query({
   args: {},
@@ -20,7 +17,7 @@ export const listCurrentUserPins = query({
         q.eq("tokenIdentifier", identity.tokenIdentifier),
       )
       .order("desc")
-      .take(1_000);
+      .take(MAX_PINNED_COURSES);
 
     return pins.map((pin) => pin.courseLegacyId);
   },
@@ -30,6 +27,7 @@ export const setCurrentUserCoursePin = mutation({
   args: {
     courseLegacyId: v.number(),
     pinned: v.boolean(),
+    operationKey: v.optional(v.string()),
   },
   returns: v.boolean(),
   handler: async (ctx, args) => {
@@ -48,11 +46,25 @@ export const setCurrentUserCoursePin = mutation({
       .unique();
 
     if (args.pinned && !existingPin) {
+      const pinsAtLimit = await ctx.db
+        .query("user_pinned_courses")
+        .withIndex("by_token_identifier", (q) =>
+          q.eq("tokenIdentifier", tokenIdentifier),
+        )
+        .take(MAX_PINNED_COURSES);
+      if (pinsAtLimit.length >= MAX_PINNED_COURSES) {
+        throw new Error(`You can pin up to ${MAX_PINNED_COURSES} courses`);
+      }
+
+      const operationKey =
+        args.operationKey ??
+        `coursePin:${args.courseLegacyId}:${args.pinned}:${Date.now()}`;
       await ctx.db.insert("user_pinned_courses", {
         tokenIdentifier,
         courseId: course._id,
         courseLegacyId: course.legacyId,
         pinnedAt: Date.now(),
+        operationKey,
       });
     } else if (!args.pinned && existingPin) {
       await ctx.db.delete(existingPin._id);

--- a/convex/lib/authorization.ts
+++ b/convex/lib/authorization.ts
@@ -5,6 +5,7 @@ type AuthCtx = MutationCtx | QueryCtx;
 type RoleIdentity = {
   userId?: string | number | null;
   role?: string | null;
+  tokenIdentifier?: string | null;
 } | null;
 
 async function getIdentity(ctx: AuthCtx) {
@@ -28,6 +29,14 @@ export async function requireContributorOrAdmin(ctx: AuthCtx) {
   if (role !== "contributor" && role !== "admin") {
     throw new Error("Unauthorized");
   }
+}
+
+export async function requireTokenIdentifier(ctx: AuthCtx) {
+  const identity = await getIdentity(ctx);
+  if (!identity?.tokenIdentifier) {
+    throw new Error("Unauthorized");
+  }
+  return identity.tokenIdentifier;
 }
 
 export async function isContributorOrAdmin(ctx: AuthCtx) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -257,6 +257,18 @@ export default defineSchema({
     updatedAt: v.number(),
   }).index("by_token_identifier", ["tokenIdentifier"]),
 
+  user_pinned_courses: defineTable({
+    tokenIdentifier: v.string(),
+    courseId: v.id("courses"),
+    courseLegacyId: v.number(),
+    pinnedAt: v.number(),
+  })
+    .index("by_token_identifier", ["tokenIdentifier"])
+    .index("by_token_identifier_and_course_id", [
+      "tokenIdentifier",
+      "courseId",
+    ]),
+
   story_approval: defineTable({
     storyId: v.id("stories"),
     legacyUserId: v.optional(v.number()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -262,6 +262,7 @@ export default defineSchema({
     courseId: v.id("courses"),
     courseLegacyId: v.number(),
     pinnedAt: v.number(),
+    operationKey: v.optional(v.string()),
   })
     .index("by_token_identifier", ["tokenIdentifier"])
     .index("by_token_identifier_and_course_id", [

--- a/src/app/editor/(course)/course_list.tsx
+++ b/src/app/editor/(course)/course_list.tsx
@@ -22,6 +22,7 @@ export default function CourseList({
 }: CourseListProps) {
   const data = useQuery(api.editorRead.getEditorSidebarData, {});
   const courses = data?.courses as CourseProps[] | undefined;
+  const pinnedCourseIds = useQuery(api.coursePins.listCurrentUserPins, {});
 
   const [search, setSearch] = useInput("");
   const router = useRouter();
@@ -41,10 +42,16 @@ export default function CourseList({
     );
   }
 
+  const pinnedCourseIdSet = new Set(pinnedCourseIds ?? []);
+  const sortedCourses = [...courses].sort(
+    (a, b) =>
+      Number(pinnedCourseIdSet.has(b.id)) - Number(pinnedCourseIdSet.has(a.id)),
+  );
+
   let filtered_courses: CourseProps[] = [];
-  if (search === "") filtered_courses = courses;
+  if (search === "") filtered_courses = sortedCourses;
   else {
-    for (let course of courses) {
+    for (let course of sortedCourses) {
       if (
         course.learning_language_name
           .toLowerCase()
@@ -75,8 +82,8 @@ export default function CourseList({
           />
         </div>
         <div>
-          {filtered_courses.map((course, index) => (
-            <div key={index}>
+          {filtered_courses.map((course) => (
+            <div key={course.id}>
               <Link
                 className={
                   "flex items-center border-b border-[var(--header-border)] bg-[var(--body-background)] text-[var(--text-color)] no-underline outline-offset-[-2px] hover:brightness-90 focus:brightness-90 " +

--- a/src/app/editor/(course)/edit_list.tsx
+++ b/src/app/editor/(course)/edit_list.tsx
@@ -33,6 +33,7 @@ import type {
 } from "@/app/editor/(course)/types";
 import CourseInterestSummary from "./course_interest_summary";
 import CourseActivityChart from "./course_activity_chart";
+import { Pin } from "lucide-react";
 
 type StoryState = "draft" | "feedback" | "finished" | "published";
 type StoryFilter = "all" | StoryState;
@@ -63,6 +64,23 @@ export default function EditList({
   const storyPreferences = useQuery(
     api.userPreferences.getCurrentStoryPreferences,
   );
+  const pinnedCourseIds = useQuery(api.coursePins.listCurrentUserPins, {});
+  const setCoursePin = useMutation(api.coursePins.setCurrentUserCoursePin);
+  const [isUpdatingPin, setIsUpdatingPin] = useState(false);
+  const isCoursePinned = pinnedCourseIds?.includes(course.id) ?? false;
+
+  async function toggleCoursePin() {
+    if (isUpdatingPin) return;
+    setIsUpdatingPin(true);
+    try {
+      await setCoursePin({
+        courseLegacyId: course.id,
+        pinned: !isCoursePinned,
+      });
+    } finally {
+      setIsUpdatingPin(false);
+    }
+  }
 
   useEffect(() => {
     setStoryList(stories ?? []);
@@ -196,7 +214,27 @@ export default function EditList({
       )}
       <div className="my-6 space-y-4">
         <div>
-          <h2 className="mb-2 font-bold">Active Contributors</h2>
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <h2 className="font-bold">Active Contributors</h2>
+            <button
+              type="button"
+              className={
+                "inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-semibold transition-colors disabled:cursor-wait disabled:opacity-60 " +
+                (isCoursePinned
+                  ? "border-[var(--button-background)] bg-[var(--button-background)] text-[var(--button-color)]"
+                  : "border-[var(--header-border)] bg-[var(--body-background-faint)] text-[var(--text-color)] hover:bg-[var(--body-background)]")
+              }
+              aria-pressed={isCoursePinned}
+              disabled={pinnedCourseIds === undefined || isUpdatingPin}
+              onClick={() => void toggleCoursePin()}
+            >
+              <Pin
+                className="size-4"
+                fill={isCoursePinned ? "currentColor" : "none"}
+              />
+              {isCoursePinned ? "Unpin course" : "Pin course"}
+            </button>
+          </div>
           <ContributorList
             contributors={course.contributors}
             emptyLabel="No contributors"


### PR DESCRIPTION
## Summary

- add a per-user **Pin course** toggle beside Active Contributors
- keep pinned courses at the top of the editor sidebar, including filtered results
- persist course pins in Convex with isolated per-user rows
- cover pinning, unpinning, user isolation, and idempotency with backend tests

## Why

Contributors who regularly work on or review particular courses need a quick way to keep those courses visible and follow their feedback activity.

## Validation

- pnpm typecheck
- pnpm run lint
- pnpm test
- pnpm test:convex
- deployed with pnpm convex dev --once to the configured development deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to pin and unpin courses from the editor.
  * Pinned courses appear first in course lists.
  * Pin selections are private to each signed-in user.
  * Added loading and pressed states for pin controls.

* **Bug Fixes**
  * Prevented duplicate pin actions and ensured pin operations remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->