### PR TITLE
Link feedback reporters to admin profiles

### DIFF
--- a/convex/storyFeedback.ts
+++ b/convex/storyFeedback.ts
@@ -3,9 +3,14 @@ import {
   paginationResultValidator,
 } from "convex/server";
 import { ConvexError, v } from "convex/values";
+import { components } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { mutation, query, type MutationCtx } from "./_generated/server";
-import { requireAdmin, requireContributorOrAdmin } from "./lib/authorization";
+import {
+  getRole,
+  requireAdmin,
+  requireContributorOrAdmin,
+} from "./lib/authorization";
 import {
   type FeedbackStatus,
   feedbackStatuses,
@@ -43,6 +48,10 @@ const feedbackReportValidator = v.object({
   userEmail: v.union(v.string(), v.null()),
   status: feedbackStatusValidator,
   createdAt: v.number(),
+});
+
+const feedbackReportForReviewValidator = feedbackReportValidator.extend({
+  legacyUserId: v.optional(v.number()),
 });
 
 type CourseDoc = Doc<"courses">;
@@ -88,6 +97,15 @@ function normalizeDerivedLineText(value: string | undefined) {
 
 function getCourseShort(course: CourseDoc) {
   return course.short?.trim() || `${course.legacyId}`;
+}
+
+function getAuthUserId(tokenIdentifier: string | null) {
+  if (!tokenIdentifier) return null;
+  const separatorIndex = tokenIdentifier.lastIndexOf("|");
+  if (separatorIndex < 0 || separatorIndex === tokenIdentifier.length - 1) {
+    return null;
+  }
+  return tokenIdentifier.slice(separatorIndex + 1);
 }
 
 function parseStoryJson(storyContent: StoryContentDoc | null) {
@@ -403,26 +421,69 @@ export const listStoryFeedbackReports = query({
     courseShort: v.optional(v.string()),
     paginationOpts: paginationOptsValidator,
   },
-  returns: paginationResultValidator(feedbackReportValidator),
+  returns: paginationResultValidator(feedbackReportForReviewValidator),
   handler: async (ctx, args) => {
     await requireContributorOrAdmin(ctx);
 
     const courseShort = args.courseShort;
-    if (courseShort !== undefined) {
-      return await ctx.db
-        .query("story_feedback_reports")
-        .withIndex("by_course_short_status_created_at", (q) =>
-          q.eq("courseShort", courseShort).eq("status", args.status),
-        )
-        .order("desc")
-        .paginate(args.paginationOpts);
+    const reports =
+      courseShort !== undefined
+        ? await ctx.db
+            .query("story_feedback_reports")
+            .withIndex("by_course_short_status_created_at", (q) =>
+              q.eq("courseShort", courseShort).eq("status", args.status),
+            )
+            .order("desc")
+            .paginate(args.paginationOpts)
+        : await ctx.db
+            .query("story_feedback_reports")
+            .withIndex("by_status_and_created_at", (q) =>
+              q.eq("status", args.status),
+            )
+            .order("desc")
+            .paginate(args.paginationOpts);
+
+    if ((await getRole(ctx)) !== "admin") return reports;
+
+    const authUserIds = Array.from(
+      new Set(
+        reports.page
+          .map((report) => getAuthUserId(report.userId))
+          .filter((userId): userId is string => userId !== null),
+      ),
+    );
+    if (authUserIds.length === 0) return reports;
+
+    const authUsers = await ctx.runQuery(
+      components.betterAuth.adapter.findMany,
+      {
+        model: "user",
+        where: [{ field: "_id", operator: "in", value: authUserIds }],
+        paginationOpts: { cursor: null, numItems: authUserIds.length + 10 },
+      },
+    );
+    const legacyUserIdByAuthUserId = new Map<string, number>();
+    for (const user of authUsers.page as Array<{
+      _id?: string;
+      userId?: string | null;
+    }>) {
+      const legacyUserId = Number.parseInt(user.userId ?? "", 10);
+      if (!user._id || !Number.isFinite(legacyUserId)) continue;
+      legacyUserIdByAuthUserId.set(user._id, legacyUserId);
     }
 
-    return await ctx.db
-      .query("story_feedback_reports")
-      .withIndex("by_status_and_created_at", (q) => q.eq("status", args.status))
-      .order("desc")
-      .paginate(args.paginationOpts);
+    return {
+      ...reports,
+      page: reports.page.map((report) => {
+        const authUserId = getAuthUserId(report.userId);
+        const legacyUserId = authUserId
+          ? legacyUserIdByAuthUserId.get(authUserId)
+          : undefined;
+        return legacyUserId === undefined
+          ? report
+          : { ...report, legacyUserId };
+      }),
+    };
   },
 });
 

--- a/src/app/editor/feedback/feedback_review_view.tsx
+++ b/src/app/editor/feedback/feedback_review_view.tsx
@@ -35,6 +35,7 @@ export type FeedbackReport = {
   comment: string;
   userName: string | null;
   userEmail: string | null;
+  legacyUserId?: number;
   status: FeedbackStatus;
   createdAt: number;
 };
@@ -287,7 +288,17 @@ function FeedbackReportRow({
           <span>Story {report.storyId}</span>
           {report.line !== undefined ? <span>Line {report.line}</span> : null}
           <span>{getFeedbackSourceLabel(report)}</span>
-          <span>{report.userName || report.userEmail || "Anonymous"}</span>
+          {report.legacyUserId === undefined ? (
+            <span>{report.userName || report.userEmail || "Anonymous"}</span>
+          ) : (
+            <Link
+              href={`/admin/users/${report.legacyUserId}`}
+              className="font-bold text-[var(--link-color)] underline underline-offset-2"
+              title={report.userEmail ?? undefined}
+            >
+              {report.userName || report.userEmail || "View user"}
+            </Link>
+          )}
         </div>
 
         {isStoryElementLine(report.lineElement) ? (


### PR DESCRIPTION
## Summary

- resolve feedback reporters from their stable authentication identifier
- expose the numeric profile ID only to admin reviewers
- link reporter names on the feedback page to the corresponding admin user profile
- preserve the existing plain-text display for contributors and anonymous or unresolved reports

## Why

Admins reviewing story feedback need a quick way to open the reporter profile and find their contact information.

## Validation

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm test` (200 tests)
- `pnpm test:convex` (96 tests)
- deployed Convex functions to the development deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can now see legacy user IDs on story feedback reports.
  * Legacy user IDs link directly to the corresponding user’s admin profile.
  * Feedback reports continue displaying anonymous, name, or email details when no legacy ID is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->