### PR TITLE
Add contributor channel review command

### DIFF
--- a/convex/storyReview.test.ts
+++ b/convex/storyReview.test.ts
@@ -1,0 +1,119 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { expect, test } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+test("resolves the earliest set containing an unpublished story", async () => {
+  const t = convexTest(schema, modules);
+  await t.run(async (ctx) => {
+    const learningLanguageId = await ctx.db.insert("languages", {
+      legacyId: 1,
+      name: "Nahuatl",
+      short: "nhe",
+      public: true,
+      rtl: false,
+    });
+    const fromLanguageId = await ctx.db.insert("languages", {
+      legacyId: 2,
+      name: "English",
+      short: "en",
+      public: true,
+      rtl: false,
+    });
+    const courseId = await ctx.db.insert("courses", {
+      legacyId: 10,
+      short: "nhe-en",
+      learningLanguageId,
+      fromLanguageId,
+      public: true,
+      official: false,
+    });
+
+    for (const story of [
+      { legacyId: 11, setId: 1, setIndex: 1, public: true, deleted: false },
+      { legacyId: 21, setId: 2, setIndex: 1, public: true, deleted: false },
+      { legacyId: 22, setId: 2, setIndex: 2, public: false, deleted: false },
+      { legacyId: 23, setId: 2, setIndex: 3, public: false, deleted: true },
+      { legacyId: 31, setId: 3, setIndex: 1, public: false, deleted: false },
+    ]) {
+      await ctx.db.insert("stories", {
+        legacyId: story.legacyId,
+        name: `Story ${story.legacyId}`,
+        set_id: story.setId,
+        set_index: story.setIndex,
+        public: story.public,
+        deleted: story.deleted,
+        courseId,
+        status: "finished",
+        todo_count: 0,
+      });
+    }
+    await ctx.db.insert("stories", {
+      legacyId: 99,
+      name: "Unassigned draft",
+      public: false,
+      deleted: false,
+      courseId,
+      status: "draft",
+      todo_count: 0,
+    });
+  });
+
+  const result = await t.query(internal.storyReview.getNextUnpublishedSet, {
+    courseShort: "nhe-en",
+  });
+
+  expect(result).toEqual({
+    courseShort: "nhe-en",
+    setId: 2,
+    storyIds: [21, 22],
+  });
+});
+
+test("returns null when a course has no unpublished stories", async () => {
+  const t = convexTest(schema, modules);
+  await t.run(async (ctx) => {
+    const learningLanguageId = await ctx.db.insert("languages", {
+      legacyId: 1,
+      name: "Nahuatl",
+      short: "nhe",
+      public: true,
+      rtl: false,
+    });
+    const fromLanguageId = await ctx.db.insert("languages", {
+      legacyId: 2,
+      name: "English",
+      short: "en",
+      public: true,
+      rtl: false,
+    });
+    const courseId = await ctx.db.insert("courses", {
+      legacyId: 10,
+      short: "nhe-en",
+      learningLanguageId,
+      fromLanguageId,
+      public: true,
+      official: false,
+    });
+    await ctx.db.insert("stories", {
+      legacyId: 11,
+      name: "Published story",
+      set_id: 1,
+      set_index: 1,
+      public: true,
+      deleted: false,
+      courseId,
+      status: "finished",
+      todo_count: 0,
+    });
+  });
+
+  const result = await t.query(internal.storyReview.getNextUnpublishedSet, {
+    courseShort: "nhe-en",
+  });
+
+  expect(result).toBeNull();
+});

--- a/convex/storyReview.ts
+++ b/convex/storyReview.ts
@@ -96,11 +96,63 @@ export const getCourseListForReview = internalQuery({
           course.from_language_name ??
           ""
         }`,
+        learningLanguage:
+          languageById.get(course.learningLanguageId)?.name ??
+          course.learning_language_name ??
+          "",
+        learningLanguageShort:
+          languageById.get(course.learningLanguageId)?.short ?? "",
       }));
   },
 });
 
 const MAX_SETS_PER_REQUEST = 8;
+
+export const getNextUnpublishedSet = internalQuery({
+  args: { courseShort: v.string() },
+  returns: v.union(
+    v.object({
+      courseShort: v.string(),
+      setId: v.number(),
+      storyIds: v.array(v.number()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const course = await ctx.db
+      .query("courses")
+      .withIndex("by_short", (q) => q.eq("short", args.courseShort))
+      .unique();
+    if (!course) return null;
+
+    const [nextUnpublished] = await ctx.db
+      .query("stories")
+      .withIndex("by_course_public_deleted_set", (q) =>
+        q
+          .eq("courseId", course._id)
+          .eq("public", false)
+          .eq("deleted", false)
+          .gte("set_id", 0),
+      )
+      .take(1);
+    if (!nextUnpublished) return null;
+
+    const setId = nextUnpublished.set_id ?? 0;
+    const stories = await ctx.db
+      .query("stories")
+      .withIndex("by_set", (q) =>
+        q.eq("courseId", course._id).eq("set_id", setId),
+      )
+      .take(50);
+    return {
+      courseShort: args.courseShort,
+      setId,
+      storyIds: stories
+        .filter((story) => !story.deleted && typeof story.legacyId === "number")
+        .map((story) => story.legacyId as number),
+    };
+  },
+});
 
 // Resolves "course + set numbers" (how contributors actually ask for reviews)
 // to story ids, in set order. An empty sets array means "all sets".
@@ -182,6 +234,7 @@ export const reviewStoriesForDiscord = httpAction(async (ctx, req) => {
     storyIds?: unknown;
     courseShort?: unknown;
     sets?: unknown;
+    nextUnpublished?: unknown;
     listCourses?: unknown;
   };
   if (parsed.secret !== expectedSecret) {
@@ -199,7 +252,25 @@ export const reviewStoriesForDiscord = httpAction(async (ctx, req) => {
 
     let storyIds: number[];
     let setsTruncated = false;
-    if (typeof parsed.courseShort === "string") {
+    let selectedSetId: number | undefined;
+    if (
+      typeof parsed.courseShort === "string" &&
+      parsed.nextUnpublished === true
+    ) {
+      const resolution: {
+        courseShort: string;
+        setId: number;
+        storyIds: number[];
+      } | null = await ctx.runQuery(
+        internal.storyReview.getNextUnpublishedSet,
+        { courseShort: parsed.courseShort },
+      );
+      if (!resolution) {
+        return json({ ok: true, noUnpublished: true, stories: [] });
+      }
+      storyIds = resolution.storyIds;
+      selectedSetId = resolution.setId;
+    } else if (typeof parsed.courseShort === "string") {
       const sets = Array.isArray(parsed.sets)
         ? parsed.sets.filter(
             (setId): setId is number =>
@@ -246,7 +317,13 @@ export const reviewStoriesForDiscord = httpAction(async (ctx, req) => {
     );
     // never drop requested content silently: the bot reports partial coverage
     const truncated = setsTruncated || totalResolved > storyIds.length;
-    return json({ ok: true, stories, truncated, totalResolved });
+    return json({
+      ok: true,
+      stories,
+      truncated,
+      totalResolved,
+      selectedSetId,
+    });
   } catch (error) {
     console.error("review-stories failed", error);
     return json({ ok: false, error: "Internal error" }, 500);

--- a/discord_roles/REVIEW_BOT.md
+++ b/discord_roles/REVIEW_BOT.md
@@ -17,6 +17,14 @@ comments. Optionally an AI review (Codex CLI) follows for the stories of the
 paused set, clearly labeled. Posting `recheck` re-runs everything and
 naturally continues where work is left.
 
+The bot also registers a global `/review` command for language contributor
+channels such as `#nahuatl-contrib`. With no argument it matches the channel's
+language against the course list and reviews the lowest-numbered set containing
+an unpublished story. If that language has courses from multiple base
+languages, the bot replies with a private course picker. An optional target can
+be a set number (`/review target:7`) or one or more Duostories story links; these
+explicit targets take precedence over the next-unpublished default.
+
 It is a separate process from `discord_reacting_bot.py` on purpose: a crash or
 hang here must never affect role syncing.
 
@@ -45,6 +53,10 @@ pnpm exec convex env set DISCORD_REVIEW_SECRET <secret> --prod
 
 The bot reads the review checklists from `../docs/review-checklists/`, so run
 it from an up-to-date checkout of this repository.
+
+The Discord application must be installed with the `applications.commands`
+scope. Global command updates can take a while to appear in every server after
+the service restarts.
 
 For the AI review, the `codex` CLI must be installed and authenticated for the
 user running the bot.

--- a/discord_roles/discord_review_bot.py
+++ b/discord_roles/discord_review_bot.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from urllib import error, request
 
 import discord
+from discord import app_commands
 from env_utils import load_env_file
 
 params = load_env_file(Path(__file__).parent / ".env.local")
@@ -54,6 +55,7 @@ CHECKLIST_DIR = Path(__file__).resolve().parent.parent / "docs" / "review-checkl
 STORY_LINK_RE = re.compile(
     r"duostories\.org/(?:editor/(?:course/[\w-]+/)?story|story)/(\d+)"
 )
+SET_TARGET_RE = re.compile(r"^(?:set\s*)?(\d+)$", re.I)
 
 # Values that must never appear in anything we post publicly: every
 # credential-looking key from .env.local (public values like URLs stay, so
@@ -106,6 +108,54 @@ def extract_story_ids(*texts):
             if story_id not in ids:
                 ids.append(story_id)
     return ids
+
+
+def normalize_channel_key(value):
+    return re.sub(r"[^a-z0-9]+", "-", (value or "").casefold()).strip("-")
+
+
+def courses_for_contributor_channel(channel_name, courses):
+    key = normalize_channel_key(channel_name)
+    for suffix in ("-contrib", "-contributors"):
+        if key.endswith(suffix):
+            key = key[: -len(suffix)]
+            break
+    return [
+        course
+        for course in courses
+        if key
+        in {
+            normalize_channel_key(course.get("learningLanguage")),
+            normalize_channel_key(course.get("learningLanguageShort")),
+        }
+    ]
+
+
+class CourseSelect(discord.ui.Select):
+    def __init__(self, client, courses, sets):
+        self.review_client = client
+        self.courses = {course["short"]: course for course in courses[:25]}
+        self.sets = sets
+        super().__init__(
+            placeholder="Choose a course",
+            options=[
+                discord.SelectOption(label=course["name"][:100], value=course["short"])
+                for course in courses[:25]
+            ],
+        )
+
+    async def callback(self, interaction):
+        course = self.courses[self.values[0]]
+        await self.review_client.start_slash_review(
+            interaction, course, self.sets
+        )
+        self.view.stop()
+
+
+class CourseSelectView(discord.ui.View):
+    def __init__(self, client, courses, sets):
+        super().__init__(timeout=180)
+        self.add_item(CourseSelect(client, courses, sets))
 
 
 def call_endpoint(payload):
@@ -308,10 +358,18 @@ async def run_codex(prompt, timeout, schema=None):
 class ReviewClient(discord.Client):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.tree = app_commands.CommandTree(self)
+        self.tree.command(
+            name="review",
+            description="Review stories for the course in this contributor channel",
+        )(self.review_command)
         self.active_threads = set()
         self.last_trigger_by_user = {}
         self.course_list = None
         self.course_list_fetched_at = 0.0
+
+    async def setup_hook(self):
+        await self.tree.sync()
 
     async def on_ready(self):
         print(f"Logged on as {self.user}!")
@@ -346,6 +404,82 @@ class ReviewClient(discord.Client):
             self.course_list = result.get("courses", [])
             self.course_list_fetched_at = now
         return self.course_list
+
+    @app_commands.describe(
+        target="Optional set number or one or more Duostories story links"
+    )
+    async def review_command(
+        self, interaction: discord.Interaction, target: str | None = None
+    ):
+        """Handle the global /review command in a contributor channel."""
+        story_ids = extract_story_ids(target or "")
+        if story_ids:
+            await self.start_slash_payload(
+                interaction,
+                {"storyIds": story_ids},
+                "🤖 Starting the requested story review.",
+            )
+            return
+
+        sets = []
+        if target:
+            match = SET_TARGET_RE.fullmatch(target.strip())
+            if not match:
+                await interaction.response.send_message(
+                    "Please provide a set number (for example `7`) or Duostories story links.",
+                    ephemeral=True,
+                )
+                return
+            sets = [int(match.group(1))]
+
+        courses = courses_for_contributor_channel(
+            getattr(interaction.channel, "name", ""), await self.get_course_list()
+        )
+        if not courses:
+            await interaction.response.send_message(
+                "🤖 I could not match this channel to a course. Please include story links, or use `/review` in a language contributor channel.",
+                ephemeral=True,
+            )
+            return
+        if len(courses) > 1:
+            await interaction.response.send_message(
+                "🤖 Which course should I review?",
+                view=CourseSelectView(self, courses, sets),
+                ephemeral=True,
+            )
+            return
+        await self.start_slash_review(interaction, courses[0], sets)
+
+    async def start_slash_review(self, interaction, course, sets):
+        payload = (
+            {"courseShort": course["short"], "sets": sets}
+            if sets
+            else {"courseShort": course["short"], "nextUnpublished": True}
+        )
+        await self.start_slash_payload(
+            interaction,
+            payload,
+            f"🤖 Finding stories to review for **{escape_discord(course['name'])}**.",
+        )
+
+    async def start_slash_payload(self, interaction, payload, announcement):
+        channel = interaction.channel
+        if channel.id in self.active_threads or self._on_cooldown(
+            interaction.user.id
+        ):
+            await interaction.response.send_message(
+                "🤖 A review is already running here, or you just started one. Please try again shortly.",
+                ephemeral=True,
+            )
+            return
+
+        self.active_threads.add(channel.id)
+        try:
+            await interaction.response.defer(thinking=True)
+            await interaction.followup.send(announcement)
+            await self.run_review(channel, payload)
+        finally:
+            self.active_threads.discard(channel.id)
 
     async def on_message(self, message):
         if message.author.bot:
@@ -454,10 +588,21 @@ class ReviewClient(discord.Client):
         if result.get("unknownCourse"):
             await channel.send(HELP_MESSAGE)
             return
+        if result.get("noUnpublished"):
+            await channel.send(
+                "✅ This course has no unpublished stories waiting for review."
+            )
+            return
         stories = result.get("stories", [])
         if not stories:
             await channel.send(HELP_MESSAGE)
             return
+
+        if result.get("selectedSetId") is not None:
+            await self.safe_send(
+                channel,
+                f"🤖 Reviewing set {result['selectedSetId']}, the next unpublished set.",
+            )
 
         if result.get("truncated"):
             total = result.get("totalResolved")

--- a/discord_roles/test_discord_review_bot.py
+++ b/discord_roles/test_discord_review_bot.py
@@ -1,0 +1,156 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import discord
+
+with patch("pathlib.Path.read_text", return_value=""):
+    from discord_review_bot import ReviewClient
+
+
+class FakeResponse:
+    def __init__(self):
+        self.defer = AsyncMock()
+        self.send_message = AsyncMock()
+
+
+class FakeFollowup:
+    def __init__(self):
+        self.send = AsyncMock()
+
+
+class FakeChannel:
+    def __init__(self, name="nahuatl-contrib", channel_id=10):
+        self.name = name
+        self.id = channel_id
+
+
+class FakeUser:
+    id = 20
+
+
+class FakeInteraction:
+    def __init__(self, channel=None):
+        self.channel = channel or FakeChannel()
+        self.user = FakeUser()
+        self.response = FakeResponse()
+        self.followup = FakeFollowup()
+
+
+class ReviewCommandTest(unittest.IsolatedAsyncioTestCase):
+    async def test_unique_contributor_channel_reviews_next_unpublished_set(self):
+        client = ReviewClient(intents=discord.Intents.none())
+        client.get_course_list = AsyncMock(
+            return_value=[
+                {
+                    "short": "nhe-en",
+                    "name": "Nahuatl from English",
+                    "learningLanguage": "Nahuatl",
+                    "learningLanguageShort": "nhe",
+                },
+                {
+                    "short": "mr-en",
+                    "name": "Marathi from English",
+                    "learningLanguage": "Marathi",
+                    "learningLanguageShort": "mr",
+                },
+            ]
+        )
+        client.run_review = AsyncMock()
+        interaction = FakeInteraction()
+
+        await client.review_command(interaction)
+
+        interaction.response.defer.assert_awaited_once_with(thinking=True)
+        client.run_review.assert_awaited_once_with(
+            interaction.channel,
+            {"courseShort": "nhe-en", "nextUnpublished": True},
+        )
+
+    async def test_ambiguous_channel_offers_course_choices(self):
+        client = ReviewClient(intents=discord.Intents.none())
+        client.get_course_list = AsyncMock(
+            return_value=[
+                {
+                    "short": "nhe-en",
+                    "name": "Nahuatl from English",
+                    "learningLanguage": "Nahuatl",
+                    "learningLanguageShort": "nhe",
+                },
+                {
+                    "short": "nhe-es",
+                    "name": "Nahuatl from Spanish",
+                    "learningLanguage": "Nahuatl",
+                    "learningLanguageShort": "nhe",
+                },
+            ]
+        )
+        client.run_review = AsyncMock()
+        interaction = FakeInteraction()
+
+        await client.review_command(interaction)
+
+        client.run_review.assert_not_awaited()
+        interaction.response.send_message.assert_awaited_once()
+        args, kwargs = interaction.response.send_message.await_args
+        self.assertIn("Which course", args[0])
+        self.assertTrue(kwargs["ephemeral"])
+        options = kwargs["view"].children[0].options
+        self.assertEqual(
+            [option.label for option in options],
+            ["Nahuatl from English", "Nahuatl from Spanish"],
+        )
+
+    async def test_explicit_story_links_override_channel_inference(self):
+        client = ReviewClient(intents=discord.Intents.none())
+        client.get_course_list = AsyncMock()
+        client.run_review = AsyncMock()
+        interaction = FakeInteraction(channel=FakeChannel("general-contributors"))
+
+        await client.review_command(
+            interaction,
+            "https://duostories.org/editor/story/123 and "
+            "https://duostories.org/story/456",
+        )
+
+        client.get_course_list.assert_not_awaited()
+        client.run_review.assert_awaited_once_with(
+            interaction.channel, {"storyIds": [123, 456]}
+        )
+
+    async def test_story_link_review_respects_an_active_channel_review(self):
+        client = ReviewClient(intents=discord.Intents.none())
+        client.run_review = AsyncMock()
+        interaction = FakeInteraction()
+        client.active_threads.add(interaction.channel.id)
+
+        await client.review_command(
+            interaction, "https://duostories.org/editor/story/123"
+        )
+
+        client.run_review.assert_not_awaited()
+        interaction.response.send_message.assert_awaited_once()
+
+    async def test_explicit_set_overrides_next_unpublished_default(self):
+        client = ReviewClient(intents=discord.Intents.none())
+        client.get_course_list = AsyncMock(
+            return_value=[
+                {
+                    "short": "nhe-en",
+                    "name": "Nahuatl from English",
+                    "learningLanguage": "Nahuatl",
+                    "learningLanguageShort": "nhe",
+                }
+            ]
+        )
+        client.run_review = AsyncMock()
+        interaction = FakeInteraction()
+
+        await client.review_command(interaction, "set 7")
+
+        client.run_review.assert_awaited_once_with(
+            interaction.channel, {"courseShort": "nhe-en", "sets": [7]}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- register a global `/review` command for language contributor channels
- infer the course from the channel and review its next unpublished set
- offer a Discord course picker when multiple base-language courses match
- allow explicit set numbers and story links to override inference
- preserve cooldown and per-channel concurrency protections

## Why

The review bot previously only ran from the review-request forum. Contributors often announce that another set is ready in their language-specific contributor channel, where the channel and publication state already provide enough context to select the course and next set.

## Validation

- `pnpm run format`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm test` (200 tests)
- `pnpm run test:convex` (98 tests)
- `PYTHONPATH=discord_roles python3 -m unittest discord_roles/test_discord_review_bot.py -v` (5 tests)
- deployed successfully to the configured Convex development deployment