### PR TITLE
Fix Azure marks before ellipses

### DIFF
--- a/src/lib/editor/audio/audio_edit_tools.test.ts
+++ b/src/lib/editor/audio/audio_edit_tools.test.ts
@@ -200,6 +200,22 @@ test("generate_ssml_line sends Azure inline aliases as mapped literal text", () 
   assert.equal(ssml.mapping[ssml.text.indexOf("liili") + 5], 27);
 });
 
+test("generate_ssml_line hides Azure ellipses without sub SSML", () => {
+  const source = "Nikmati mijtootilistli keemaantika ohui…";
+  const ssml = generate_ssml_line(
+    { speaker: "es-ES-ElviraNeural", text: source },
+    undefined as never,
+    [],
+    [],
+  );
+
+  assert.equal(
+    ssml.text,
+    '<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="es-ES"><voice name="es-ES-ElviraNeural">Nikmati mijtootilistli keemaantika ohui<break/></voice></speak>',
+  );
+  assert.equal(ssml.mapping[ssml.text.indexOf("<break/>")], 39);
+});
+
 test("generate_audio_line maps Polly UTF-8 byte speech marks to source text", async () => {
   const originalRequest = globalThis.Request;
   const originalFetch = globalThis.fetch;

--- a/src/lib/editor/audio/audio_timing.ts
+++ b/src/lib/editor/audio/audio_timing.ts
@@ -94,11 +94,13 @@ export function generate_ssml_line(
   if (transcribe_data)
     speak_text = transcribe_text(speak_text, transcribe_data);
 
-  speak_text = find_replace_with_mapping(
-    speak_text,
-    /(\.\.\.|…)/,
-    '<sub alias=" ">$1</sub><break/>',
-  );
+  speak_text = useLiteralAliases
+    ? find_replace_with_mapping(speak_text, /(?:\.\.\.|…)/, "<break/>")
+    : find_replace_with_mapping(
+        speak_text,
+        /(\.\.\.|…)/,
+        '<sub alias=" ">$1</sub><break/>',
+      );
 
   if (speak_text.text.startsWith("<speak>"))
     speak_text = replace_with_mapping(speak_text, "", 0, "<speak>".length);


### PR DESCRIPTION
## Summary

- hide Azure ellipses with `<break/>` alone instead of `<sub alias=" ">…</sub><break/>`
- preserve the existing ellipsis SSML for non-Azure engines
- add regression coverage for the affected Nahuatl audio line and its source mapping

## Root cause

Azure merged the final spoken word and the hidden ellipsis into one boundary with `textOffset: -1`. The backend correctly rejected that invalid boundary, leaving the last word without a speech mark.

A controlled Azure comparison returned:

- hidden `<sub>`: `text: "ohui…"`, `textOffset: -1`
- `<break/>` only: `text: "ohui"`, `textOffset: 150`

Both variants used the identical 2150 ms audio offset, so the break-only form preserves the generated timing while restoring a valid word boundary.

## User impact

Azure-generated lines ending in an ellipsis now retain the final word's speech mark, preventing incomplete highlighting and story-check warnings.

## Validation

- `pnpm test` (207 tests passed)
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- controlled Azure synthesis comparison of both ellipsis variants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ellipsis handling in audio timing generation.
  * Literal aliases now produce direct pauses, while other voices preserve pronunciation mappings before adding the pause.
  * Added coverage to ensure trailing ellipses convert correctly without affecting source mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->