### PR TITLE
Fix Google terminal audio marks

### DIFF
--- a/src/lib/editor/audio/audio_edit_tools.test.ts
+++ b/src/lib/editor/audio/audio_edit_tools.test.ts
@@ -216,6 +216,21 @@ test("generate_ssml_line hides Azure ellipses without sub SSML", () => {
   assert.equal(ssml.mapping[ssml.text.indexOf("<break/>")], 39);
 });
 
+test("generate_ssml_line gives Google final-word marks a numeric source offset", () => {
+  const ssml = generate_ssml_line(
+    { speaker: "lt-LT-Wavenet-A", text: "Labai didelė šeima" },
+    undefined as never,
+    [],
+    [],
+  );
+
+  assert.equal(
+    ssml.text,
+    '<speak><mark name="5"/>Labai <mark name="12"/>didelė <mark name="18"/>šeima</speak>',
+  );
+  assert.doesNotMatch(ssml.text, /undefined/);
+});
+
 test("generate_audio_line maps Polly UTF-8 byte speech marks to source text", async () => {
   const originalRequest = globalThis.Request;
   const originalFetch = globalThis.fetch;

--- a/src/lib/editor/audio/text_with_mapping.ts
+++ b/src/lib/editor/audio/text_with_mapping.ts
@@ -242,7 +242,9 @@ export function add_word_marks_replacements(mapped_text: {
   mapped_text = iter_word_replacements(
     mapped_text,
     (mapped_text, word, word_start, i, bracket_start) => {
-      let insert = `<mark name="${mapped_text.mapping[i]}"/>`;
+      const rangeEnd =
+        mapped_text.mapping[i] ?? (mapped_text.mapping[i - 1] ?? -1) + 1;
+      let insert = `<mark name="${rangeEnd}"/>`;
       mapped_text = replace_with_mapping(mapped_text, insert, word_start);
       i += insert.length;
       return [mapped_text, i];


### PR DESCRIPTION
## Summary

- derive a numeric exclusive source offset for Google marks on a terminal word
- preserve the existing mapped offset behavior for words followed by text
- add regression coverage for the Lithuanian header from story 1869

## Root cause

Google SSML marks are inserted at the beginning of each word but named with that word's exclusive source end. For a final word, the iterator index equals `mapping.length`, so `mapping[i]` returned JavaScript `undefined` and generated `<mark name="undefined"/>`. Google then echoed that literal value in its timepoints response.

The terminal fallback now derives the exclusive end from the last mapped character. For `Labai didelė šeima`, the generated mark names are `5`, `12`, and `18`.

## User impact

Google-generated audio for headers and other text ending directly in a word now receives a valid final timepoint instead of an `undefined` mark, allowing complete audio timing serialization and highlighting.

## Validation

- `pnpm test` (208 tests passed)
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm run format:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing or invalid source offsets for final-word marks in Google SSML output.
  * Improved offset handling when word mappings are incomplete.

* **Tests**
  * Added regression coverage to verify numeric offsets and prevent `undefined` values in generated SSML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->