### PR TITLE
Make AI review checklist audio-aware

### DIFF
--- a/discord_roles/discord_review_bot.py
+++ b/discord_roles/discord_review_bot.py
@@ -215,7 +215,7 @@ def group_by_set(stories):
     return sorted(groups.items())
 
 
-def load_checklists(language_short):
+def load_checklists(language_short, no_audio=False):
     parts = []
     global_file = CHECKLIST_DIR / "global.md"
     if global_file.exists():
@@ -223,6 +223,9 @@ def load_checklists(language_short):
     language_file = CHECKLIST_DIR / "languages" / f"{language_short}.md"
     if language_short and language_file.exists():
         parts.append(language_file.read_text(encoding="utf-8"))
+    no_audio_file = CHECKLIST_DIR / "no-audio.md"
+    if no_audio and no_audio_file.exists():
+        parts.append(no_audio_file.read_text(encoding="utf-8"))
     return "\n\n".join(parts)
 
 
@@ -281,9 +284,15 @@ def format_story_for_ai_review(text):
 
 
 def build_ai_prompt(story):
-    checklists = load_checklists(story.get("learningLanguage") or "")
-    no_audio_note = (
-        "This course is a no-audio course.\n" if story.get("noAudio") else ""
+    no_audio = bool(story.get("noAudio"))
+    checklists = load_checklists(
+        story.get("learningLanguage") or "", no_audio=no_audio
+    )
+    audio_capability_note = (
+        "This course is a no-audio course. Apply the no-audio checklist below."
+        if no_audio
+        else "This course has audio. Do not flag listening challenges such as "
+        "[ARRANGE] or infer that the course is no-audio."
     )
     return f"""You are the automatic reviewer for Duostories, a community project translating Duolingo stories.
 Review ONE story written in the Duostories story DSL (blocks like [LINE], [MULTIPLE_CHOICE]; '$' lines are audio timings; 'SpeakerN:' marks who talks).
@@ -291,7 +300,7 @@ Review ONE story written in the Duostories story DSL (blocks like [LINE], [MULTI
 Translation-hint lines have been expanded from the compact DSL into one `learning-language token = base-language hint` line per hoverable token. These hints are deliberately literal, sentence-specific glosses that show learners what each word or joined phrase does. They are NOT prose translations and do not need to sound natural or follow natural base-language word order. Joined hints retain `~` (for example, `kimaka = le~da~a`). Judge whether each gloss conveys the token's meaning or grammatical function in context; only expect natural base-language phrasing in question text and other prose shown as prose.
 
 Story: #{story["storyId"]} "{story.get("name", "")}" — course {story.get("courseShort", "")}, learning language: {story.get("learningLanguage", "")}.
-{no_audio_note}
+{audio_capability_note}
 Follow this review checklist. A separate mechanical check already covers hint counts, missing audio, and question structure — do NOT repeat those.
 
 {checklists}

--- a/discord_roles/test_discord_review_bot.py
+++ b/discord_roles/test_discord_review_bot.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, patch
 import discord
 
 with patch("pathlib.Path.read_text", return_value=""):
-    from discord_review_bot import ReviewClient, build_ai_prompt, format_story_for_ai_review
+    from discord_review_bot import (
+        ReviewClient,
+        build_ai_prompt,
+        format_story_for_ai_review,
+    )
 
 
 class AiReviewPromptTest(unittest.TestCase):
@@ -42,6 +46,38 @@ Līlih. = Lily""",
         story = "> two words\n~ one"
 
         self.assertEqual(format_story_for_ai_review(story), story)
+
+    def test_audio_course_omits_no_audio_checklist(self):
+        prompt = build_ai_prompt(
+            {
+                "storyId": 9730,
+                "name": "¿Gracias?",
+                "courseShort": "nah-es",
+                "learningLanguage": "nah",
+                "noAudio": False,
+                "text": "[ARRANGE]\n> Escucha y selecciona las palabras",
+            }
+        )
+
+        self.assertIn("This course has audio", prompt)
+        self.assertIn("Do not flag listening challenges", prompt)
+        self.assertNotIn("# No-audio course review checklist", prompt)
+
+    def test_no_audio_course_includes_no_audio_checklist(self):
+        prompt = build_ai_prompt(
+            {
+                "storyId": 1,
+                "name": "Test",
+                "courseShort": "nah-es",
+                "learningLanguage": "nah",
+                "noAudio": True,
+                "text": "[LINE]\n> Test",
+            }
+        )
+
+        self.assertIn("This course is a no-audio course", prompt)
+        self.assertIn("# No-audio course review checklist", prompt)
+        self.assertIn("meaning-based", prompt)
 
 
 class FakeResponse:

--- a/docs/review-checklists/global.md
+++ b/docs/review-checklists/global.md
@@ -71,10 +71,6 @@ say so briefly — do not invent findings to fill categories.
       pair is also a valid match.
 - [ ] Questions appear at reasonable intervals and test comprehension of what
       was just read.
-- [ ] In no-audio courses: questions converted from listening exercises use
-      meaning-based distractors, not the sound-alikes of the original (the
-      lint already flags remaining `[ARRANGE]`/`[SELECT_PHRASE]` blocks; see
-      docs/story-publishing/without_tts).
 
 ## 4. Story text quality
 

--- a/docs/review-checklists/no-audio.md
+++ b/docs/review-checklists/no-audio.md
@@ -1,0 +1,9 @@
+# No-audio course review checklist
+
+Apply this addendum only when the course is explicitly identified as a
+no-audio course.
+
+- [ ] Questions converted from listening challenges use meaning-based
+      distractors, not sound-alikes from the original audio course. Mechanical
+      lint separately flags remaining `[ARRANGE]` and `[SELECT_PHRASE]`
+      challenges; do not repeat those lint findings.


### PR DESCRIPTION
## What changed

- Split no-audio review guidance into a dedicated conditional checklist.
- Load that checklist only when backend course metadata reports noAudio: true.
- Explicitly tell the AI reviewer that audio courses support listening challenges and must not infer no-audio status.
- Add regression tests covering prompts for both audio and no-audio courses.

## Why

The AI reviewer falsely reported an ARRANGE challenge in audio-enabled story #9730 as incompatible with the course. Production data correctly reported noAudio: false; the model inferred the opposite after seeing conditional no-audio guidance in the global checklist.

## Impact

Audio courses no longer receive irrelevant no-audio rules, while no-audio courses retain their specialized review guidance.

## Validation

- python3 -m unittest test_discord_review_bot.py from discord_roles/
- pnpm typecheck
- pnpm run lint
- pnpm run format:check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review guidance now distinguishes courses with audio from explicitly no-audio courses.
  * No-audio courses receive an additional checklist for evaluating questions adapted from listening exercises.
  * Audio courses receive audio-specific review guidance without the no-audio checklist.

* **Documentation**
  * Updated review checklists to clarify meaning-based distractors and avoid duplicate findings for specified challenge types.

* **Bug Fixes**
  * Review prompts now apply the appropriate checklist based on each course’s audio availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->